### PR TITLE
v14 remove plugin method

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -6,7 +6,7 @@ require (
 	github.com/RoaringBitmap/roaring v0.4.23
 	github.com/blevesearch/bleve_index_api v0.0.2
 	github.com/blevesearch/mmap-go v1.0.2
-	github.com/blevesearch/scorch_segment_api v0.0.3
+	github.com/blevesearch/scorch_segment_api v0.0.4
 	github.com/couchbase/vellum v1.0.2
 	github.com/golang/snappy v0.0.1
 	github.com/spf13/cobra v0.0.5

--- a/go.sum
+++ b/go.sum
@@ -6,8 +6,8 @@ github.com/blevesearch/bleve_index_api v0.0.2 h1:M6EPUf354pMQw0J9NOyJaeIKNAlwpbS
 github.com/blevesearch/bleve_index_api v0.0.2/go.mod h1:yq9YIbuvEQdUB0h+UiLbpDdLLnvcD5ZkqO0LS1wuSvY=
 github.com/blevesearch/mmap-go v1.0.2 h1:JtMHb+FgQCTTYIhtMvimw15dJwu1Y5lrZDMOFXVWPk0=
 github.com/blevesearch/mmap-go v1.0.2/go.mod h1:ol2qBqYaOUsGdm7aRMRrYGgPvnwLe6Y+7LMvAB5IbSA=
-github.com/blevesearch/scorch_segment_api v0.0.3 h1:DJ7aqcIr1JUT77B42uTGtCRw0vz1HxlvUfyv7CefR9I=
-github.com/blevesearch/scorch_segment_api v0.0.3/go.mod h1:WpV76h6YHekU8CzseKfzJRoZfcVu+yWlwcEq+7N+Kp0=
+github.com/blevesearch/scorch_segment_api v0.0.4 h1:0qVqBmW+Zcu4nCRo1eB3x1+WYLUYJ4YX8lDprbX27oY=
+github.com/blevesearch/scorch_segment_api v0.0.4/go.mod h1:WpV76h6YHekU8CzseKfzJRoZfcVu+yWlwcEq+7N+Kp0=
 github.com/coreos/etcd v3.3.10+incompatible/go.mod h1:uF7uidLiAD3TWHmW31ZFd/JWoc32PjwdhPthX9715RE=
 github.com/coreos/go-etcd v2.0.0+incompatible/go.mod h1:Jez6KQU2B/sWsbdaef3ED8NzMklzPG4d5KIOhIy30Tk=
 github.com/coreos/go-semver v0.2.0/go.mod h1:nnelYz7RCh+5ahJtPPxZlU+153eP4D4r3EedlOD2RNk=

--- a/plugin.go
+++ b/plugin.go
@@ -14,10 +14,6 @@
 
 package zap
 
-import (
-	segment "github.com/blevesearch/scorch_segment_api"
-)
-
 // ZapPlugin implements the Plugin interface of
 // the blevesearch/scorch_segment_api pkg
 type ZapPlugin struct{}
@@ -28,10 +24,4 @@ func (*ZapPlugin) Type() string {
 
 func (*ZapPlugin) Version() uint32 {
 	return Version
-}
-
-// Plugin returns an instance segment.Plugin for use
-// by the Scorch indexing scheme
-func Plugin() segment.Plugin {
-	return &ZapPlugin{}
 }


### PR DESCRIPTION
rather than have a method Plugin() which returns a value
implementing the interface (typed as segment.Plugin)

the code (in scorch) registering this version can instead
simply use &zapv15.ZapPlugin{} which satisfies the interface

this more naturally follows the Go convention of consumers
defining the interface they need to work with, and it
further simplifies the segment api package