### PR TITLE
 Restore the mergeTermFreqNormLocsByCopying optimization (#44)

### DIFF
--- a/intDecoder.go
+++ b/intDecoder.go
@@ -103,6 +103,10 @@ func (d *chunkedIntDecoder) readUvarint() (uint64, error) {
 	return d.r.ReadUvarint()
 }
 
+func (d *chunkedIntDecoder) readBytes(start, end int) []byte {
+	return d.curChunkBytes[start:end]
+}
+
 func (d *chunkedIntDecoder) SkipUvarint() {
 	d.r.SkipUvarint()
 }
@@ -113,4 +117,8 @@ func (d *chunkedIntDecoder) SkipBytes(count int) {
 
 func (d *chunkedIntDecoder) Len() int {
 	return d.r.Len()
+}
+
+func (d *chunkedIntDecoder) remainingLen() int {
+	return len(d.curChunkBytes) - d.r.Len()
 }

--- a/posting.go
+++ b/posting.go
@@ -587,6 +587,58 @@ func (i *PostingsIterator) nextDocNumAtOrAfter(atOrAfter uint64) (uint64, bool, 
 	return uint64(n), true, nil
 }
 
+var freqHasLocs1Hit = encodeFreqHasLocs(1, false)
+
+// nextBytes returns the docNum and the encoded freq & loc bytes for
+// the next posting
+func (i *PostingsIterator) nextBytes() (
+	docNumOut uint64, freq uint64, normBits uint64,
+	bytesFreqNorm []byte, bytesLoc []byte, err error) {
+	docNum, exists, err := i.nextDocNumAtOrAfter(0)
+	if err != nil || !exists {
+		return 0, 0, 0, nil, nil, err
+	}
+
+	if i.normBits1Hit != 0 {
+		if i.buf == nil {
+			i.buf = make([]byte, binary.MaxVarintLen64*2)
+		}
+		n := binary.PutUvarint(i.buf, freqHasLocs1Hit)
+		n += binary.PutUvarint(i.buf[n:], i.normBits1Hit)
+		return docNum, uint64(1), i.normBits1Hit, i.buf[:n], nil, nil
+	}
+
+	startFreqNorm := i.freqNormReader.remainingLen()
+
+	var hasLocs bool
+
+	freq, normBits, hasLocs, err = i.readFreqNormHasLocs()
+	if err != nil {
+		return 0, 0, 0, nil, nil, err
+	}
+
+	endFreqNorm := i.freqNormReader.remainingLen()
+	bytesFreqNorm = i.freqNormReader.readBytes(startFreqNorm, endFreqNorm)
+
+	if hasLocs {
+		startLoc := i.locReader.remainingLen()
+
+		numLocsBytes, err := i.locReader.readUvarint()
+		if err != nil {
+			return 0, 0, 0, nil, nil,
+				fmt.Errorf("error reading location nextBytes numLocs: %v", err)
+		}
+
+		// skip over all the location bytes
+		i.locReader.SkipBytes(int(numLocsBytes))
+
+		endLoc := i.locReader.remainingLen()
+		bytesLoc = i.locReader.readBytes(startLoc, endLoc)
+	}
+
+	return docNum, freq, normBits, bytesFreqNorm, bytesLoc, nil
+}
+
 // optimization when the postings list is "clean" (e.g., no updates &
 // no deletions) where the all bitmap is the same as the actual bitmap
 func (i *PostingsIterator) nextDocNumAtOrAfterClean(


### PR DESCRIPTION
Even with custom or different chunk size/factors, it still
 looks safe and efficient to copy the freq,norm,locs bytes
 for saving the extra encodings of many uvarint's.

 Chunk factor differences across postings per segment
 doesn't look to affect the functionality here.

 By restoring this optimization, the performance of the merge
 paths improved by

    wildcard - 30%
    fuzzy2 - 34%

 for showfast tests.
 ref - https://issues.couchbase.com/browse/MB-41399