### PR TITLE
Enabling configurable freq/norm

### DIFF
--- a/merge.go
+++ b/merge.go
@@ -491,6 +491,7 @@ func mergeTermFreqNormLocsByCopying(term []byte, postItr *PostingsIterator,
 		}
 
 		newRoaring.Add(uint32(hitNewDocNum))
+
 		err = tfEncoder.AddBytes(hitNewDocNum, nextFreqNormBytes)
 		if err != nil {
 			return 0, 0, 0, err
@@ -537,8 +538,13 @@ func mergeTermFreqNormLocs(fieldsMap map[string]uint16, term []byte, postItr *Po
 
 		locs := next.Locations()
 
-		err = tfEncoder.Add(hitNewDocNum,
-			encodeFreqHasLocs(nextFreq, len(locs) > 0), nextNorm)
+		if nextFreq > 0 {
+			err = tfEncoder.Add(hitNewDocNum,
+				encodeFreqHasLocs(nextFreq, len(locs) > 0), nextNorm)
+		} else {
+			err = tfEncoder.Add(hitNewDocNum,
+				encodeFreqHasLocs(nextFreq, len(locs) > 0))
+		}
 		if err != nil {
 			return 0, 0, 0, nil, err
 		}

--- a/new.go
+++ b/new.go
@@ -657,9 +657,16 @@ func (s *interim) writeDicts() (fdvIndexOffset uint64, dictOffsets []uint64, err
 
 				freqNorm := freqNorms[freqNormOffset]
 
-				err = tfEncoder.Add(docNum,
-					encodeFreqHasLocs(freqNorm.freq, freqNorm.numLocs > 0),
-					uint64(math.Float32bits(freqNorm.norm)))
+				// check if freq/norm is enabled
+				if freqNorm.freq > 0 {
+					err = tfEncoder.Add(docNum,
+						encodeFreqHasLocs(freqNorm.freq, freqNorm.numLocs > 0),
+						uint64(math.Float32bits(freqNorm.norm)))
+				} else {
+					// if disabled, then skip the norm part
+					err = tfEncoder.Add(docNum,
+						encodeFreqHasLocs(freqNorm.freq, freqNorm.numLocs > 0))
+				}
 				if err != nil {
 					return 0, nil, err
 				}


### PR DESCRIPTION
Enabling configurable freq/norm with storage
    
    With freq/norm disabled at the index layer, storage
    layer no longer needs to persist both freq/norm related
    information onto disk.
    A special frequency value of zero/0 is interpreted as
    a configuration for skipping the processing of norm
    value.
    
    So with freq/norm disabled, zap always store the freq
    value of 0 along with an LSB indicating the presence
    of location data.
    
    Savings are mostly of 1 byte per occurrence of the
    token as we always persist a freq value of 0 with
    the location LSB.