### PR TITLE
[v12] PostingsIterator: Address nil pointer dereferencing

### DIFF
--- a/posting.go
+++ b/posting.go
@@ -536,7 +536,12 @@ func (i *PostingsIterator) nextDocNumAtOrAfter(atOrAfter uint64) (uint64, bool, 
 		return 0, false, nil
 	}
 
-	if i.postings == nil || i.postings.postings == i.ActualBM {
+	if i.postings == nil || i.postings == emptyPostingsList {
+		// couldn't find anything
+		return 0, false, nil
+	}
+
+	if i.postings.postings == i.ActualBM {
 		return i.nextDocNumAtOrAfterClean(atOrAfter)
 	}
 


### PR DESCRIPTION
+ If the postingsList of the iterator is nil or empty,
  there's nothing to find, so we need not invoke the
  nextDocNumAtOrAfterClean(..) method of PostingsIterator
  when the iterator's postings is nil.

+ Related to: https://github.com/blevesearch/bleve/issues/1606