### PR TITLE
[v14] Move all iterator forward until a match, only if possible

### DIFF
--- a/posting.go
+++ b/posting.go
@@ -555,7 +555,7 @@ func (i *PostingsIterator) nextDocNumAtOrAfter(atOrAfter uint64) (uint64, bool, 
 
 	i.Actual.AdvanceIfNeeded(uint32(atOrAfter))
 
-	if !i.Actual.HasNext() {
+	if !i.Actual.HasNext() || !i.all.HasNext() {
 		// couldn't find anything
 		return 0, false, nil
 	}
@@ -577,6 +577,10 @@ func (i *PostingsIterator) nextDocNumAtOrAfter(atOrAfter uint64) (uint64, bool, 
 			if err != nil {
 				return 0, false, err
 			}
+		}
+
+		if !i.all.HasNext() {
+			return 0, false, nil
 		}
 
 		allN = i.all.Next()


### PR DESCRIPTION
Intend to address this panic ..

runtime.errorString: runtime error: invalid memory address or nil pointer dereference
  File "github.com/blevesearch/zapx/v15@v15.3.1/posting.go", line 595, in (*PostingsIterator).nextDocNumAtOrAfter
  File "github.com/blevesearch/zapx/v15@v15.3.1/posting.go", line 476, in (*PostingsIterator).nextAtOrAfter
  File "github.com/blevesearch/zapx/v15@v15.3.1/posting.go", line 471, in (*PostingsIterator).Advance
  File "github.com/blevesearch/bleve/v2@v2.2.1/index/scorch/snapshot_index_tfr.go", line 152, in (*IndexSnapshotTermFieldReader).Advance
  File "github.com/blevesearch/bleve/v2@v2.2.1/search/searcher/search_term.go", line 105, in (*TermSearcher).Advance
  ...

.. highlighted here: https://github.com/blevesearch/bleve/issues/1606#issuecomment-993150219