### PR TITLE
Check if field exists within segment's visitStoredFields callback

### DIFF
--- a/merge.go
+++ b/merge.go
@@ -719,6 +719,10 @@ func mergeStoredAndRemap(segments []*SegmentBase, drops []*roaring.Bitmap,
 			}
 			err := segment.visitStoredFields(vdc, docNum, func(field string, typ byte, value []byte, pos []uint64) bool {
 				fieldID := int(fieldsMap[field]) - 1
+				if fieldID < 0 {
+					// no entry for field in fieldsMap
+					return false
+				}
 				vals[fieldID] = append(vals[fieldID], value)
 				typs[fieldID] = append(typs[fieldID], typ)
 


### PR DESCRIPTION
If there isn't an entry for a field within fieldsMap, fieldID
is set to -1 causing the following array lookup to panic ..

```
panic: runtime error: index out of range [-1]
goroutine 205 [running]:
github.com/blevesearch/zapx/v15.mergeStoredAndRemap.func2(0xc0076e2cf0, 0x27, 0x74, 0xc005d7cd3c, 0x15, 0x336b8, 0x0, 0x0, 0x0, 0x1)
/builds/gopath/pkg/mod/github.com/blevesearch/zapx/v15@v15.2.1/merge.go:722 +0x57b
github.com/blevesearch/zapx/v15.(*SegmentBase).visitStoredFields(0xc000770800, 0xc001c14000, 0x5d7, 0xc002777698, 0x2df, 0x0)
/builds/gopath/pkg/mod/github.com/blevesearch/zapx/v15@v15.2.1/segment.go:382 +0x39c
```

Ref: https://github.com/blevesearch/bleve/issues/1648