### PR TITLE
Fix IO Stats computation

### DIFF
--- a/contentcoder.go
+++ b/contentcoder.go
@@ -110,9 +110,7 @@ func (c *chunkedContentCoder) Close() error {
 }
 
 func (c *chunkedContentCoder) incrementBytesWritten(val uint64) {
-	if CollectDiskStats {
-		atomic.AddUint64(&c.bytesWritten, val)
-	}
+	atomic.AddUint64(&c.bytesWritten, val)
 }
 
 func (c *chunkedContentCoder) getBytesWritten() uint64 {

--- a/docvalues.go
+++ b/docvalues.go
@@ -147,7 +147,9 @@ func (di *docValueReader) SetBytesRead(val uint64) {
 }
 
 func (di *docValueReader) incrementBytesRead(val uint64) {
-	atomic.AddUint64(&di.bytesRead, val)
+	if segment.CollectIOStats {
+		atomic.AddUint64(&di.bytesRead, val)
+	}
 }
 
 func (di *docValueReader) loadDvChunk(chunkNumber uint64, s *SegmentBase) error {

--- a/docvalues.go
+++ b/docvalues.go
@@ -147,9 +147,7 @@ func (di *docValueReader) ResetBytesRead(val uint64) {
 }
 
 func (di *docValueReader) incrementBytesRead(val uint64) {
-	if CollectDiskStats {
-		atomic.AddUint64(&di.bytesRead, val)
-	}
+	atomic.AddUint64(&di.bytesRead, val)
 }
 
 func (di *docValueReader) BytesWritten() uint64 {

--- a/docvalues.go
+++ b/docvalues.go
@@ -142,14 +142,18 @@ func (di *docValueReader) BytesRead() uint64 {
 	return atomic.LoadUint64(&di.bytesRead)
 }
 
-func (di *docValueReader) SetBytesRead(val uint64) {
+func (di *docValueReader) ResetBytesRead(val uint64) {
 	atomic.StoreUint64(&di.bytesRead, val)
 }
 
 func (di *docValueReader) incrementBytesRead(val uint64) {
-	if segment.CollectIOStats {
+	if CollectDiskStats {
 		atomic.AddUint64(&di.bytesRead, val)
 	}
+}
+
+func (di *docValueReader) BytesWritten() uint64 {
+	return 0
 }
 
 func (di *docValueReader) loadDvChunk(chunkNumber uint64, s *SegmentBase) error {

--- a/intDecoder.go
+++ b/intDecoder.go
@@ -18,6 +18,8 @@ import (
 	"encoding/binary"
 	"fmt"
 	"sync/atomic"
+
+	segment "github.com/blevesearch/scorch_segment_api/v2"
 )
 
 type chunkedIntDecoder struct {
@@ -59,7 +61,9 @@ func newChunkedIntDecoder(buf []byte, offset uint64, rv *chunkedIntDecoder) *chu
 		rv.chunkOffsets[i], read = binary.Uvarint(buf[offset+n : offset+n+binary.MaxVarintLen64])
 		n += uint64(read)
 	}
-	atomic.AddUint64(&rv.bytesRead, n)
+	if segment.CollectIOStats {
+		atomic.AddUint64(&rv.bytesRead, n)
+	}
 	rv.dataStartOffset = offset + n
 	return rv
 }
@@ -89,7 +93,9 @@ func (d *chunkedIntDecoder) loadChunk(chunk int) error {
 	start += s
 	end += e
 	d.curChunkBytes = d.data[start:end]
-	atomic.AddUint64(&d.bytesRead, uint64(len(d.curChunkBytes)))
+	if segment.CollectIOStats {
+		atomic.AddUint64(&d.bytesRead, uint64(len(d.curChunkBytes)))
+	}
 	if d.r == nil {
 		d.r = newMemUvarintReader(d.curChunkBytes)
 	} else {

--- a/intDecoder.go
+++ b/intDecoder.go
@@ -59,9 +59,7 @@ func newChunkedIntDecoder(buf []byte, offset uint64, rv *chunkedIntDecoder) *chu
 		rv.chunkOffsets[i], read = binary.Uvarint(buf[offset+n : offset+n+binary.MaxVarintLen64])
 		n += uint64(read)
 	}
-
 	atomic.AddUint64(&rv.bytesRead, n)
-
 	rv.dataStartOffset = offset + n
 	return rv
 }
@@ -91,9 +89,7 @@ func (d *chunkedIntDecoder) loadChunk(chunk int) error {
 	start += s
 	end += e
 	d.curChunkBytes = d.data[start:end]
-
 	atomic.AddUint64(&d.bytesRead, uint64(len(d.curChunkBytes)))
-
 	if d.r == nil {
 		d.r = newMemUvarintReader(d.curChunkBytes)
 	} else {

--- a/intDecoder.go
+++ b/intDecoder.go
@@ -59,9 +59,9 @@ func newChunkedIntDecoder(buf []byte, offset uint64, rv *chunkedIntDecoder) *chu
 		rv.chunkOffsets[i], read = binary.Uvarint(buf[offset+n : offset+n+binary.MaxVarintLen64])
 		n += uint64(read)
 	}
-	if CollectDiskStats {
-		atomic.AddUint64(&rv.bytesRead, n)
-	}
+
+	atomic.AddUint64(&rv.bytesRead, n)
+
 	rv.dataStartOffset = offset + n
 	return rv
 }
@@ -91,9 +91,9 @@ func (d *chunkedIntDecoder) loadChunk(chunk int) error {
 	start += s
 	end += e
 	d.curChunkBytes = d.data[start:end]
-	if CollectDiskStats {
-		atomic.AddUint64(&d.bytesRead, uint64(len(d.curChunkBytes)))
-	}
+
+	atomic.AddUint64(&d.bytesRead, uint64(len(d.curChunkBytes)))
+
 	if d.r == nil {
 		d.r = newMemUvarintReader(d.curChunkBytes)
 	} else {

--- a/intDecoder.go
+++ b/intDecoder.go
@@ -18,8 +18,6 @@ import (
 	"encoding/binary"
 	"fmt"
 	"sync/atomic"
-
-	segment "github.com/blevesearch/scorch_segment_api/v2"
 )
 
 type chunkedIntDecoder struct {
@@ -61,7 +59,7 @@ func newChunkedIntDecoder(buf []byte, offset uint64, rv *chunkedIntDecoder) *chu
 		rv.chunkOffsets[i], read = binary.Uvarint(buf[offset+n : offset+n+binary.MaxVarintLen64])
 		n += uint64(read)
 	}
-	if segment.CollectIOStats {
+	if CollectDiskStats {
 		atomic.AddUint64(&rv.bytesRead, n)
 	}
 	rv.dataStartOffset = offset + n
@@ -93,7 +91,7 @@ func (d *chunkedIntDecoder) loadChunk(chunk int) error {
 	start += s
 	end += e
 	d.curChunkBytes = d.data[start:end]
-	if segment.CollectIOStats {
+	if CollectDiskStats {
 		atomic.AddUint64(&d.bytesRead, uint64(len(d.curChunkBytes)))
 	}
 	if d.r == nil {

--- a/intcoder.go
+++ b/intcoder.go
@@ -78,9 +78,7 @@ func (c *chunkedIntCoder) SetChunkSize(chunkSize uint64, maxDocNum uint64) {
 }
 
 func (c *chunkedIntCoder) incrementBytesWritten(val uint64) {
-	if CollectDiskStats {
-		atomic.AddUint64(&c.bytesWritten, val)
-	}
+	atomic.AddUint64(&c.bytesWritten, val)
 }
 
 func (c *chunkedIntCoder) getBytesWritten() uint64 {

--- a/new.go
+++ b/new.go
@@ -33,10 +33,6 @@ var NewSegmentBufferNumResultsBump int = 100
 var NewSegmentBufferNumResultsFactor float64 = 1.0
 var NewSegmentBufferAvgBytesPerDocFactor float64 = 1.0
 
-// This flag controls the disk stats collection from the segment files
-// during indexing and querying
-var CollectDiskStats bool
-
 // ValidateDocFields can be set by applications to perform additional checks
 // on fields in a document being added to a new segment, by default it does
 // nothing.
@@ -498,9 +494,7 @@ func (s *interim) getBytesWritten() uint64 {
 }
 
 func (s *interim) incrementBytesWritten(val uint64) {
-	if CollectDiskStats {
-		atomic.AddUint64(&s.bytesWritten, val)
-	}
+	atomic.AddUint64(&s.bytesWritten, val)
 }
 
 func (s *interim) writeStoredFields() (
@@ -617,9 +611,7 @@ func (s *interim) writeStoredFields() (
 }
 
 func (s *interim) setBytesWritten(val uint64) {
-	if CollectDiskStats {
-		atomic.StoreUint64(&s.bytesWritten, val)
-	}
+	atomic.StoreUint64(&s.bytesWritten, val)
 }
 
 func (s *interim) writeDicts() (fdvIndexOffset uint64, dictOffsets []uint64, err error) {

--- a/posting.go
+++ b/posting.go
@@ -263,7 +263,9 @@ func (p *PostingsList) BytesRead() uint64 {
 }
 
 func (p *PostingsList) incrementBytesRead(val uint64) {
-	atomic.AddUint64(&p.bytesRead, val)
+	if segment.CollectIOStats {
+		atomic.AddUint64(&p.bytesRead, val)
+	}
 }
 
 func (rv *PostingsList) read(postingsOffset uint64, d *Dictionary) error {
@@ -372,7 +374,9 @@ func (i *PostingsIterator) BytesRead() uint64 {
 }
 
 func (i *PostingsIterator) incrementBytesRead(val uint64) {
-	atomic.AddUint64(&i.bytesRead, val)
+	if segment.CollectIOStats {
+		atomic.AddUint64(&i.bytesRead, val)
+	}
 }
 
 func (i *PostingsIterator) loadChunk(chunk int) error {

--- a/posting.go
+++ b/posting.go
@@ -263,9 +263,7 @@ func (p *PostingsList) BytesRead() uint64 {
 }
 
 func (p *PostingsList) incrementBytesRead(val uint64) {
-	if CollectDiskStats {
-		atomic.AddUint64(&p.bytesRead, val)
-	}
+	atomic.AddUint64(&p.bytesRead, val)
 }
 
 func (p *PostingsList) BytesWritten() uint64 {
@@ -378,9 +376,7 @@ func (i *PostingsIterator) BytesRead() uint64 {
 }
 
 func (i *PostingsIterator) incrementBytesRead(val uint64) {
-	if CollectDiskStats {
-		atomic.AddUint64(&i.bytesRead, val)
-	}
+	atomic.AddUint64(&i.bytesRead, val)
 }
 
 func (i *PostingsIterator) BytesWritten() uint64 {

--- a/posting.go
+++ b/posting.go
@@ -254,7 +254,7 @@ func (p *PostingsList) Count() uint64 {
 // The purpose of this implementation is to get
 // the bytes read from the postings lists stored
 // on disk, while querying
-func (p *PostingsList) SetBytesRead(val uint64) {
+func (p *PostingsList) ResetBytesRead(val uint64) {
 	atomic.StoreUint64(&p.bytesRead, val)
 }
 
@@ -263,9 +263,13 @@ func (p *PostingsList) BytesRead() uint64 {
 }
 
 func (p *PostingsList) incrementBytesRead(val uint64) {
-	if segment.CollectIOStats {
+	if CollectDiskStats {
 		atomic.AddUint64(&p.bytesRead, val)
 	}
+}
+
+func (p *PostingsList) BytesWritten() uint64 {
+	return 0
 }
 
 func (rv *PostingsList) read(postingsOffset uint64, d *Dictionary) error {
@@ -365,7 +369,7 @@ func (i *PostingsIterator) Size() int {
 // the bytes read from the disk which includes
 // the freqNorm and location specific information
 // of a hit
-func (i *PostingsIterator) SetBytesRead(val uint64) {
+func (i *PostingsIterator) ResetBytesRead(val uint64) {
 	atomic.StoreUint64(&i.bytesRead, val)
 }
 
@@ -374,9 +378,13 @@ func (i *PostingsIterator) BytesRead() uint64 {
 }
 
 func (i *PostingsIterator) incrementBytesRead(val uint64) {
-	if segment.CollectIOStats {
+	if CollectDiskStats {
 		atomic.AddUint64(&i.bytesRead, val)
 	}
+}
+
+func (i *PostingsIterator) BytesWritten() uint64 {
+	return 0
 }
 
 func (i *PostingsIterator) loadChunk(chunk int) error {
@@ -390,7 +398,7 @@ func (i *PostingsIterator) loadChunk(chunk int) error {
 		// the postingsIterator is tracking only the chunk loaded
 		// and the cumulation is tracked correctly in the downstream
 		// intDecoder
-		i.SetBytesRead(i.freqNormReader.getBytesRead())
+		i.ResetBytesRead(i.freqNormReader.getBytesRead())
 	}
 
 	if i.includeLocs {
@@ -398,7 +406,7 @@ func (i *PostingsIterator) loadChunk(chunk int) error {
 		if err != nil {
 			return err
 		}
-		i.SetBytesRead(i.locReader.getBytesRead())
+		i.ResetBytesRead(i.locReader.getBytesRead())
 	}
 
 	i.currChunk = uint32(chunk)

--- a/segment.go
+++ b/segment.go
@@ -236,11 +236,15 @@ func (s *Segment) BytesRead() uint64 {
 }
 
 func (s *Segment) incrementBytesRead(val uint64) {
-	atomic.AddUint64(&s.bytesRead, val)
+	if segment.CollectIOStats {
+		atomic.AddUint64(&s.bytesRead, val)
+	}
 }
 
 func (s *SegmentBase) incrementBytesRead(val uint64) {
-	atomic.AddUint64(&s.bytesRead, val)
+	if segment.CollectIOStats {
+		atomic.AddUint64(&s.bytesRead, val)
+	}
 }
 
 func (s *SegmentBase) loadFields() error {

--- a/segment.go
+++ b/segment.go
@@ -104,7 +104,8 @@ type SegmentBase struct {
 	size              uint64
 
 	// atomic access to this variable
-	bytesRead uint64
+	bytesRead    uint64
+	bytesWritten uint64
 
 	m         sync.Mutex
 	fieldFSTs map[uint16]*vellum.FST
@@ -226,8 +227,10 @@ func (s *Segment) loadConfig() error {
 // interface, as the intention is to retrieve the bytes
 // read from the on-disk segment as part of the current
 // query.
-func (s *Segment) SetBytesRead(val uint64) {
-	atomic.StoreUint64(&s.SegmentBase.bytesRead, val)
+func (s *Segment) ResetBytesRead(val uint64) {
+	if CollectDiskStats {
+		atomic.StoreUint64(&s.SegmentBase.bytesRead, val)
+	}
 }
 
 func (s *Segment) BytesRead() uint64 {
@@ -235,14 +238,34 @@ func (s *Segment) BytesRead() uint64 {
 		atomic.LoadUint64(&s.SegmentBase.bytesRead)
 }
 
+func (s *Segment) BytesWritten() uint64 {
+	return 0
+}
+
 func (s *Segment) incrementBytesRead(val uint64) {
-	if segment.CollectIOStats {
+	if CollectDiskStats {
 		atomic.AddUint64(&s.bytesRead, val)
 	}
 }
 
+func (s *SegmentBase) BytesWritten() uint64 {
+	return atomic.LoadUint64(&s.bytesWritten)
+}
+
+func (s *SegmentBase) setBytesWritten(val uint64) {
+	if CollectDiskStats {
+		atomic.AddUint64(&s.bytesWritten, val)
+	}
+}
+
+func (s *SegmentBase) BytesRead() uint64 {
+	return 0
+}
+
+func (s *SegmentBase) ResetBytesRead(val uint64) {}
+
 func (s *SegmentBase) incrementBytesRead(val uint64) {
-	if segment.CollectIOStats {
+	if CollectDiskStats {
 		atomic.AddUint64(&s.bytesRead, val)
 	}
 }

--- a/segment.go
+++ b/segment.go
@@ -228,9 +228,7 @@ func (s *Segment) loadConfig() error {
 // read from the on-disk segment as part of the current
 // query.
 func (s *Segment) ResetBytesRead(val uint64) {
-	if CollectDiskStats {
-		atomic.StoreUint64(&s.SegmentBase.bytesRead, val)
-	}
+	atomic.StoreUint64(&s.SegmentBase.bytesRead, val)
 }
 
 func (s *Segment) BytesRead() uint64 {
@@ -243,9 +241,7 @@ func (s *Segment) BytesWritten() uint64 {
 }
 
 func (s *Segment) incrementBytesRead(val uint64) {
-	if CollectDiskStats {
-		atomic.AddUint64(&s.bytesRead, val)
-	}
+	atomic.AddUint64(&s.bytesRead, val)
 }
 
 func (s *SegmentBase) BytesWritten() uint64 {
@@ -253,9 +249,7 @@ func (s *SegmentBase) BytesWritten() uint64 {
 }
 
 func (s *SegmentBase) setBytesWritten(val uint64) {
-	if CollectDiskStats {
-		atomic.AddUint64(&s.bytesWritten, val)
-	}
+	atomic.AddUint64(&s.bytesWritten, val)
 }
 
 func (s *SegmentBase) BytesRead() uint64 {
@@ -265,9 +259,7 @@ func (s *SegmentBase) BytesRead() uint64 {
 func (s *SegmentBase) ResetBytesRead(val uint64) {}
 
 func (s *SegmentBase) incrementBytesRead(val uint64) {
-	if CollectDiskStats {
-		atomic.AddUint64(&s.bytesRead, val)
-	}
+	atomic.AddUint64(&s.bytesRead, val)
 }
 
 func (s *SegmentBase) loadFields() error {


### PR DESCRIPTION
The newly introduced stats in the PR [#1702](https://github.com/blevesearch/bleve/pull/1702) and [#117](https://github.com/blevesearch/zapx/pull/117)
are currently computed all time the irrespective of whether or not its needed. Since it is in a fairly hot code path, it could affect the performance when these stats are not needed. Hence, this PR aims to hide those stats computation behind a flag which controls the same.