### PR TITLE
Making IO Stats Optional

### DIFF
--- a/contentcoder.go
+++ b/contentcoder.go
@@ -111,7 +111,9 @@ func (c *chunkedContentCoder) Close() error {
 }
 
 func (c *chunkedContentCoder) incrementBytesWritten(val uint64) {
-	atomic.AddUint64(&c.bytesWritten, val)
+	if AccountIOStats {
+		atomic.AddUint64(&c.bytesWritten, val)
+	}
 }
 
 func (c *chunkedContentCoder) getBytesWritten() uint64 {

--- a/docvalues.go
+++ b/docvalues.go
@@ -139,15 +139,22 @@ func (s *SegmentBase) loadFieldDocValueReader(field string,
 // and the bytes retrieved off the disk pertaining to that
 // is accounted as well.
 func (di *docValueReader) BytesRead() uint64 {
-	return atomic.LoadUint64(&di.bytesRead)
+	if AccountIOStats {
+		return atomic.LoadUint64(&di.bytesRead)
+	}
+	return 0
 }
 
 func (di *docValueReader) ResetBytesRead(val uint64) {
-	atomic.StoreUint64(&di.bytesRead, val)
+	if AccountIOStats {
+		atomic.StoreUint64(&di.bytesRead, val)
+	}
 }
 
 func (di *docValueReader) incrementBytesRead(val uint64) {
-	atomic.AddUint64(&di.bytesRead, val)
+	if AccountIOStats {
+		atomic.AddUint64(&di.bytesRead, val)
+	}
 }
 
 func (di *docValueReader) BytesWritten() uint64 {

--- a/intDecoder.go
+++ b/intDecoder.go
@@ -59,7 +59,9 @@ func newChunkedIntDecoder(buf []byte, offset uint64, rv *chunkedIntDecoder) *chu
 		rv.chunkOffsets[i], read = binary.Uvarint(buf[offset+n : offset+n+binary.MaxVarintLen64])
 		n += uint64(read)
 	}
-	atomic.AddUint64(&rv.bytesRead, n)
+	if AccountIOStats {
+		atomic.AddUint64(&rv.bytesRead, n)
+	}
 	rv.dataStartOffset = offset + n
 	return rv
 }
@@ -89,7 +91,9 @@ func (d *chunkedIntDecoder) loadChunk(chunk int) error {
 	start += s
 	end += e
 	d.curChunkBytes = d.data[start:end]
-	atomic.AddUint64(&d.bytesRead, uint64(len(d.curChunkBytes)))
+	if AccountIOStats {
+		atomic.AddUint64(&d.bytesRead, uint64(len(d.curChunkBytes)))
+	}
 	if d.r == nil {
 		d.r = newMemUvarintReader(d.curChunkBytes)
 	} else {

--- a/intcoder.go
+++ b/intcoder.go
@@ -79,7 +79,9 @@ func (c *chunkedIntCoder) SetChunkSize(chunkSize uint64, maxDocNum uint64) {
 }
 
 func (c *chunkedIntCoder) incrementBytesWritten(val uint64) {
-	atomic.AddUint64(&c.bytesWritten, val)
+	if AccountIOStats {
+		atomic.AddUint64(&c.bytesWritten, val)
+	}
 }
 
 func (c *chunkedIntCoder) getBytesWritten() uint64 {

--- a/posting.go
+++ b/posting.go
@@ -255,15 +255,22 @@ func (p *PostingsList) Count() uint64 {
 // the bytes read from the postings lists stored
 // on disk, while querying
 func (p *PostingsList) ResetBytesRead(val uint64) {
-	atomic.StoreUint64(&p.bytesRead, val)
+	if AccountIOStats {
+		atomic.StoreUint64(&p.bytesRead, val)
+	}
 }
 
 func (p *PostingsList) BytesRead() uint64 {
-	return atomic.LoadUint64(&p.bytesRead)
+	if AccountIOStats {
+		return atomic.LoadUint64(&p.bytesRead)
+	}
+	return 0
 }
 
 func (p *PostingsList) incrementBytesRead(val uint64) {
-	atomic.AddUint64(&p.bytesRead, val)
+	if AccountIOStats {
+		atomic.AddUint64(&p.bytesRead, val)
+	}
 }
 
 func (p *PostingsList) BytesWritten() uint64 {
@@ -368,15 +375,22 @@ func (i *PostingsIterator) Size() int {
 // the freqNorm and location specific information
 // of a hit
 func (i *PostingsIterator) ResetBytesRead(val uint64) {
-	atomic.StoreUint64(&i.bytesRead, val)
+	if AccountIOStats {
+		atomic.StoreUint64(&i.bytesRead, val)
+	}
 }
 
 func (i *PostingsIterator) BytesRead() uint64 {
-	return atomic.LoadUint64(&i.bytesRead)
+	if AccountIOStats {
+		return atomic.LoadUint64(&i.bytesRead)
+	}
+	return 0
 }
 
 func (i *PostingsIterator) incrementBytesRead(val uint64) {
-	atomic.AddUint64(&i.bytesRead, val)
+	if AccountIOStats {
+		atomic.AddUint64(&i.bytesRead, val)
+	}
 }
 
 func (i *PostingsIterator) BytesWritten() uint64 {

--- a/segment.go
+++ b/segment.go
@@ -228,7 +228,9 @@ func (s *Segment) loadConfig() error {
 // read from the on-disk segment as part of the current
 // query.
 func (s *Segment) ResetBytesRead(val uint64) {
-	atomic.StoreUint64(&s.SegmentBase.bytesRead, val)
+	if AccountIOStats {
+		atomic.StoreUint64(&s.SegmentBase.bytesRead, val)
+	}
 }
 
 func (s *Segment) BytesRead() uint64 {
@@ -241,15 +243,22 @@ func (s *Segment) BytesWritten() uint64 {
 }
 
 func (s *Segment) incrementBytesRead(val uint64) {
-	atomic.AddUint64(&s.bytesRead, val)
+	if AccountIOStats {
+		atomic.AddUint64(&s.bytesRead, val)
+	}
 }
 
 func (s *SegmentBase) BytesWritten() uint64 {
-	return atomic.LoadUint64(&s.bytesWritten)
+	if AccountIOStats {
+		return atomic.LoadUint64(&s.bytesWritten)
+	}
+	return 0
 }
 
 func (s *SegmentBase) setBytesWritten(val uint64) {
-	atomic.AddUint64(&s.bytesWritten, val)
+	if AccountIOStats {
+		atomic.AddUint64(&s.bytesWritten, val)
+	}
 }
 
 func (s *SegmentBase) BytesRead() uint64 {
@@ -259,7 +268,9 @@ func (s *SegmentBase) BytesRead() uint64 {
 func (s *SegmentBase) ResetBytesRead(val uint64) {}
 
 func (s *SegmentBase) incrementBytesRead(val uint64) {
-	atomic.AddUint64(&s.bytesRead, val)
+	if AccountIOStats {
+		atomic.AddUint64(&s.bytesRead, val)
+	}
 }
 
 func (s *SegmentBase) loadFields() error {


### PR DESCRIPTION
It looks like the IO stats computation is causing too much of a performance overhead in terms of query throughput and latency. Making the stats computation optional until further optimisations are pushed in.