### PR TITLE
Update zap v13.x with DiskStatsReporter changes

### DIFF
--- a/posting.go
+++ b/posting.go
@@ -111,6 +111,10 @@ type PostingsList struct {
 // represents an immutable, empty postings list
 var emptyPostingsList = &PostingsList{}
 
+// Following methods are dummy implementations for the interface
+// DiskStatsReporter (for backward compatibility).
+// The working implementations are supported only in zap v15.x
+// and not in the earlier versions of zap.
 func (i *PostingsList) ResetBytesRead(uint64) {}
 
 func (i *PostingsList) BytesRead() uint64 {
@@ -324,6 +328,10 @@ type PostingsIterator struct {
 
 var emptyPostingsIterator = &PostingsIterator{}
 
+// Following methods are dummy implementations for the interface
+// DiskStatsReporter (for backward compatibility).
+// The working implementations are supported only in zap v15.x
+// and not in the earlier versions of zap.
 func (i *PostingsIterator) ResetBytesRead(uint64) {}
 
 func (i *PostingsIterator) BytesRead() uint64 {

--- a/posting.go
+++ b/posting.go
@@ -111,6 +111,18 @@ type PostingsList struct {
 // represents an immutable, empty postings list
 var emptyPostingsList = &PostingsList{}
 
+func (i *PostingsList) ResetBytesRead(uint64) {}
+
+func (i *PostingsList) BytesRead() uint64 {
+	return 0
+}
+
+func (i *PostingsList) incrementBytesRead(uint64) {}
+
+func (i *PostingsList) BytesWritten() uint64 {
+	return 0
+}
+
 func (p *PostingsList) Size() int {
 	sizeInBytes := reflectStaticSizePostingsList + SizeOfPtr
 
@@ -311,6 +323,18 @@ type PostingsIterator struct {
 }
 
 var emptyPostingsIterator = &PostingsIterator{}
+
+func (i *PostingsIterator) ResetBytesRead(uint64) {}
+
+func (i *PostingsIterator) BytesRead() uint64 {
+	return 0
+}
+
+func (i *PostingsIterator) incrementBytesRead(uint64) {}
+
+func (i *PostingsIterator) BytesWritten() uint64 {
+	return 0
+}
 
 func (i *PostingsIterator) Size() int {
 	sizeInBytes := reflectStaticSizePostingsIterator + SizeOfPtr +

--- a/segment.go
+++ b/segment.go
@@ -213,6 +213,10 @@ func (s *Segment) loadConfig() error {
 	return nil
 }
 
+// Following methods are dummy implementations for the interface
+// DiskStatsReporter (for backward compatibility).
+// The working implementations are supported only in zap v15.x
+// and not in the earlier versions of zap.
 func (s *Segment) ResetBytesRead(uint64) {}
 
 func (s *Segment) BytesRead() uint64 {

--- a/segment.go
+++ b/segment.go
@@ -213,6 +213,32 @@ func (s *Segment) loadConfig() error {
 	return nil
 }
 
+func (s *Segment) ResetBytesRead(uint64) {}
+
+func (s *Segment) BytesRead() uint64 {
+	return 0
+}
+
+func (s *Segment) BytesWritten() uint64 {
+	return 0
+}
+
+func (s *Segment) incrementBytesRead(uint64) {}
+
+func (s *SegmentBase) BytesWritten() uint64 {
+	return 0
+}
+
+func (s *SegmentBase) setBytesWritten(uint64) {}
+
+func (s *SegmentBase) BytesRead() uint64 {
+	return 0
+}
+
+func (s *SegmentBase) ResetBytesRead(uint64) {}
+
+func (s *SegmentBase) incrementBytesRead(uint64) {}
+
 func (s *SegmentBase) loadFields() error {
 	// NOTE for now we assume the fields index immediately precedes
 	// the footer, and if this changes, need to adjust accordingly (or


### PR DESCRIPTION
This is a backward compatibility PR in references to changes in https://github.com/blevesearch/scorch_segment_api/pull/20