### PR TITLE
Revert "Making IO Stats Optional"

### DIFF
--- a/contentcoder.go
+++ b/contentcoder.go
@@ -111,9 +111,7 @@ func (c *chunkedContentCoder) Close() error {
 }
 
 func (c *chunkedContentCoder) incrementBytesWritten(val uint64) {
-	if AccountIOStats {
-		atomic.AddUint64(&c.bytesWritten, val)
-	}
+	atomic.AddUint64(&c.bytesWritten, val)
 }
 
 func (c *chunkedContentCoder) getBytesWritten() uint64 {

--- a/docvalues.go
+++ b/docvalues.go
@@ -139,22 +139,15 @@ func (s *SegmentBase) loadFieldDocValueReader(field string,
 // and the bytes retrieved off the disk pertaining to that
 // is accounted as well.
 func (di *docValueReader) BytesRead() uint64 {
-	if AccountIOStats {
-		return atomic.LoadUint64(&di.bytesRead)
-	}
-	return 0
+	return atomic.LoadUint64(&di.bytesRead)
 }
 
 func (di *docValueReader) ResetBytesRead(val uint64) {
-	if AccountIOStats {
-		atomic.StoreUint64(&di.bytesRead, val)
-	}
+	atomic.StoreUint64(&di.bytesRead, val)
 }
 
 func (di *docValueReader) incrementBytesRead(val uint64) {
-	if AccountIOStats {
-		atomic.AddUint64(&di.bytesRead, val)
-	}
+	atomic.AddUint64(&di.bytesRead, val)
 }
 
 func (di *docValueReader) BytesWritten() uint64 {

--- a/intDecoder.go
+++ b/intDecoder.go
@@ -59,9 +59,7 @@ func newChunkedIntDecoder(buf []byte, offset uint64, rv *chunkedIntDecoder) *chu
 		rv.chunkOffsets[i], read = binary.Uvarint(buf[offset+n : offset+n+binary.MaxVarintLen64])
 		n += uint64(read)
 	}
-	if AccountIOStats {
-		atomic.AddUint64(&rv.bytesRead, n)
-	}
+	atomic.AddUint64(&rv.bytesRead, n)
 	rv.dataStartOffset = offset + n
 	return rv
 }
@@ -91,9 +89,7 @@ func (d *chunkedIntDecoder) loadChunk(chunk int) error {
 	start += s
 	end += e
 	d.curChunkBytes = d.data[start:end]
-	if AccountIOStats {
-		atomic.AddUint64(&d.bytesRead, uint64(len(d.curChunkBytes)))
-	}
+	atomic.AddUint64(&d.bytesRead, uint64(len(d.curChunkBytes)))
 	if d.r == nil {
 		d.r = newMemUvarintReader(d.curChunkBytes)
 	} else {

--- a/intcoder.go
+++ b/intcoder.go
@@ -79,9 +79,7 @@ func (c *chunkedIntCoder) SetChunkSize(chunkSize uint64, maxDocNum uint64) {
 }
 
 func (c *chunkedIntCoder) incrementBytesWritten(val uint64) {
-	if AccountIOStats {
-		atomic.AddUint64(&c.bytesWritten, val)
-	}
+	atomic.AddUint64(&c.bytesWritten, val)
 }
 
 func (c *chunkedIntCoder) getBytesWritten() uint64 {

--- a/new.go
+++ b/new.go
@@ -41,11 +41,6 @@ var ValidateDocFields = func(field index.Field) error {
 	return nil
 }
 
-// This flag controls the IO stats computation for segments
-// during indexing and querying.
-// Note: To be set at init ONLY.
-var AccountIOStats bool
-
 // New creates an in-memory zap-encoded SegmentBase from a set of Documents
 func (z *ZapPlugin) New(results []index.Document) (
 	segment.Segment, uint64, error) {
@@ -502,16 +497,11 @@ func (s *interim) processDocument(docNum uint64,
 }
 
 func (s *interim) getBytesWritten() uint64 {
-	if AccountIOStats {
-		return atomic.LoadUint64(&s.bytesWritten)
-	}
-	return 0
+	return atomic.LoadUint64(&s.bytesWritten)
 }
 
 func (s *interim) incrementBytesWritten(val uint64) {
-	if AccountIOStats {
-		atomic.AddUint64(&s.bytesWritten, val)
-	}
+	atomic.AddUint64(&s.bytesWritten, val)
 }
 
 func (s *interim) writeStoredFields() (
@@ -628,9 +618,7 @@ func (s *interim) writeStoredFields() (
 }
 
 func (s *interim) setBytesWritten(val uint64) {
-	if AccountIOStats {
-		atomic.StoreUint64(&s.bytesWritten, val)
-	}
+	atomic.StoreUint64(&s.bytesWritten, val)
 }
 
 func (s *interim) writeDicts() (fdvIndexOffset uint64, dictOffsets []uint64, err error) {

--- a/posting.go
+++ b/posting.go
@@ -255,22 +255,15 @@ func (p *PostingsList) Count() uint64 {
 // the bytes read from the postings lists stored
 // on disk, while querying
 func (p *PostingsList) ResetBytesRead(val uint64) {
-	if AccountIOStats {
-		atomic.StoreUint64(&p.bytesRead, val)
-	}
+	atomic.StoreUint64(&p.bytesRead, val)
 }
 
 func (p *PostingsList) BytesRead() uint64 {
-	if AccountIOStats {
-		return atomic.LoadUint64(&p.bytesRead)
-	}
-	return 0
+	return atomic.LoadUint64(&p.bytesRead)
 }
 
 func (p *PostingsList) incrementBytesRead(val uint64) {
-	if AccountIOStats {
-		atomic.AddUint64(&p.bytesRead, val)
-	}
+	atomic.AddUint64(&p.bytesRead, val)
 }
 
 func (p *PostingsList) BytesWritten() uint64 {
@@ -375,22 +368,15 @@ func (i *PostingsIterator) Size() int {
 // the freqNorm and location specific information
 // of a hit
 func (i *PostingsIterator) ResetBytesRead(val uint64) {
-	if AccountIOStats {
-		atomic.StoreUint64(&i.bytesRead, val)
-	}
+	atomic.StoreUint64(&i.bytesRead, val)
 }
 
 func (i *PostingsIterator) BytesRead() uint64 {
-	if AccountIOStats {
-		return atomic.LoadUint64(&i.bytesRead)
-	}
-	return 0
+	return atomic.LoadUint64(&i.bytesRead)
 }
 
 func (i *PostingsIterator) incrementBytesRead(val uint64) {
-	if AccountIOStats {
-		atomic.AddUint64(&i.bytesRead, val)
-	}
+	atomic.AddUint64(&i.bytesRead, val)
 }
 
 func (i *PostingsIterator) BytesWritten() uint64 {

--- a/segment.go
+++ b/segment.go
@@ -228,9 +228,7 @@ func (s *Segment) loadConfig() error {
 // read from the on-disk segment as part of the current
 // query.
 func (s *Segment) ResetBytesRead(val uint64) {
-	if AccountIOStats {
-		atomic.StoreUint64(&s.SegmentBase.bytesRead, val)
-	}
+	atomic.StoreUint64(&s.SegmentBase.bytesRead, val)
 }
 
 func (s *Segment) BytesRead() uint64 {
@@ -243,22 +241,15 @@ func (s *Segment) BytesWritten() uint64 {
 }
 
 func (s *Segment) incrementBytesRead(val uint64) {
-	if AccountIOStats {
-		atomic.AddUint64(&s.bytesRead, val)
-	}
+	atomic.AddUint64(&s.bytesRead, val)
 }
 
 func (s *SegmentBase) BytesWritten() uint64 {
-	if AccountIOStats {
-		return atomic.LoadUint64(&s.bytesWritten)
-	}
-	return 0
+	return atomic.LoadUint64(&s.bytesWritten)
 }
 
 func (s *SegmentBase) setBytesWritten(val uint64) {
-	if AccountIOStats {
-		atomic.AddUint64(&s.bytesWritten, val)
-	}
+	atomic.AddUint64(&s.bytesWritten, val)
 }
 
 func (s *SegmentBase) BytesRead() uint64 {
@@ -268,9 +259,7 @@ func (s *SegmentBase) BytesRead() uint64 {
 func (s *SegmentBase) ResetBytesRead(val uint64) {}
 
 func (s *SegmentBase) incrementBytesRead(val uint64) {
-	if AccountIOStats {
-		atomic.AddUint64(&s.bytesRead, val)
-	}
+	atomic.AddUint64(&s.bytesRead, val)
 }
 
 func (s *SegmentBase) loadFields() error {


### PR DESCRIPTION
Reverts blevesearch/zapx#131
 - These changes are not necessary since the optimisation solves the regression issue https://github.com/blevesearch/bleve/issues/1731