### PR TITLE
Fixed 64-bit alignment panic in chunkedContentCoder on 32-bit platforms.

### DIFF
--- a/contentcoder.go
+++ b/contentcoder.go
@@ -37,6 +37,8 @@ var (
 )
 
 type chunkedContentCoder struct {
+	bytesWritten uint64 // atomic access to this variable, moved to top to correct alignment issues on ARM, 386 and 32-bit MIPS.
+
 	final     []byte
 	chunkSize uint64
 	currChunk uint64
@@ -45,7 +47,6 @@ type chunkedContentCoder struct {
 	compressed []byte // temp buf for snappy compression
 
 	w                io.Writer
-	bytesWritten     uint64 // atomic access to this variable
 	progressiveWrite bool
 
 	chunkMeta    []MetaData


### PR DESCRIPTION
Following the fix in #147, a 'panic: unaligned 64-bit atomic operation' is still occurring on some platforms.

As noted in #147, this commit implements the alternative fix by placing the bytesWritten field at the top of the struct. Per the Golang [sync/atomic documentation](https://pkg.go.dev/sync/atomic#pkg-note-BUG), on ARM, 386 and 32-bit MIPS systems, this is the reliable way to prevent these issues.