### PR TITLE
Place a ceiling for initial capacity allocated for bytes.Buffer

### DIFF
--- a/new.go
+++ b/new.go
@@ -32,6 +32,7 @@ import (
 var NewSegmentBufferNumResultsBump int = 100
 var NewSegmentBufferNumResultsFactor float64 = 1.0
 var NewSegmentBufferAvgBytesPerDocFactor float64 = 1.0
+var MaxSegmentBufferInitialSize int = 10 * 1024 * 1024 // 10MB
 
 // ValidateDocFields can be set by applications to perform additional checks
 // on fields in a document being added to a new segment, by default it does
@@ -61,7 +62,11 @@ func (*ZapPlugin) newWithChunkMode(results []index.Document,
 			NewSegmentBufferNumResultsFactor)
 		estimateNumResults := int(float64(len(results)+NewSegmentBufferNumResultsBump) *
 			NewSegmentBufferAvgBytesPerDocFactor)
-		br.Grow(estimateAvgBytesPerDoc * estimateNumResults)
+		sizeEstimate := estimateAvgBytesPerDoc * estimateNumResults
+		if sizeEstimate > MaxSegmentBufferInitialSize {
+			sizeEstimate = MaxSegmentBufferInitialSize
+		}
+		br.Grow(sizeEstimate)
 	}
 
 	s.results = results


### PR DESCRIPTION
+ Initializing the ceiling to 10MB. This means that at least
   10 MB of space is guaranteed if the estimate is larger than
    that. Any additional space will be allocated on demand.
+ Intended to address: https://github.com/blevesearch/bleve/issues/1780