### PR TITLE
Error handling for empty vellum data

### DIFF
--- a/posting.go
+++ b/posting.go
@@ -109,7 +109,6 @@ type PostingsList struct {
 
 	chunkSize uint64
 
-	// atomic access to this variable
 	bytesRead uint64
 }
 
@@ -349,7 +348,6 @@ type PostingsIterator struct {
 	includeFreqNorm bool
 	includeLocs     bool
 
-	// atomic access to this variable
 	bytesRead uint64
 }
 

--- a/segment.go
+++ b/segment.go
@@ -319,6 +319,10 @@ func (sb *SegmentBase) dictionary(field string) (rv *Dictionary, err error) {
 			if rv.fst, ok = sb.fieldFSTs[rv.fieldID]; !ok {
 				// read the length of the vellum data
 				vellumLen, read := binary.Uvarint(sb.mem[dictStart : dictStart+binary.MaxVarintLen64])
+				if vellumLen == 0 {
+					sb.m.Unlock()
+					return nil, fmt.Errorf("empty dictionary for field: %v", field)
+				}
 				fstBytes := sb.mem[dictStart+uint64(read) : dictStart+uint64(read)+vellumLen]
 				rv.incrementBytesRead(uint64(read) + vellumLen)
 				rv.fst, err = vellum.Load(fstBytes)

--- a/segment.go
+++ b/segment.go
@@ -103,7 +103,7 @@ type SegmentBase struct {
 	fieldDvNames      []string                   // field names cached in fieldDvReaders
 	size              uint64
 
-	// atomic access to this variable
+	// atomic access to these variables
 	bytesRead    uint64
 	bytesWritten uint64
 


### PR DESCRIPTION
- Handling this case will help in avoiding any downstream empty slice panics that might occur.
- An example with respect to this panic is as follows:

```
panic: runtime error: index out of range [0] with length 0   
goroutine 1537342 [running]: github.com/blevesearch/vellum.(*fstStateV1).isEncodedSingle(...) 
/home/couchbase/.cbdepscache/gomodcache/pkg/mod/github.com/blevesearch/vellum@v1.0.8/decoder_v1.go:100 github.com/blevesearch/vellum.(*fstStateV1).TransitionFor(0xc014e04de0?, 0x40?) 
/home/couchbase/.cbdepscache/gomodcache/pkg/mod/github.com/blevesearch/vellum@v1.0.8/decoder_v1.go:239 +0x2d2 github.com/blevesearch/vellum.(*FST).get(0xc014e11cc0, {0xc01c7db558, 0x5, 0xc010531a68?}, {0x15cac98, 0xc01cb846e8}) 
/home/couchbase/.cbdepscache/gomodcache/pkg/mod/github.com/blevesearch/vellum@v1.0.8/fst.go:78 +0xd0 github.com/blevesearch/vellum.(*Reader).Get(...) 
/home/couchbase/.cbdepscache/gomodcache/pkg/mod/github.com/blevesearch/vellum@v1.0.8/fst.go:299 github.com/blevesearch/zapx/v15.(*Dictionary).postingsList(0xc01cb7cba0, {0xc01c7db558?, 0x1?, 0xc01358a500?}, 0xc0129bdd70?, 0xc01cb7b7c0) 
/home/couchbase/.cbdepscache/gomodcache/pkg/mod/github.com/blevesearch/zapx/v15@v15.3.4/dict.go:57 +0x88 github.com/blevesearch/zapx/v15.
```

This happens when the backend fst which is the term dictionary is loaded with an empty byte slice of data from the index file, and when we try to do a Get() on the fst, we would end up doing operations on the empty slice that causes a panic. 