### PR TITLE
bug fix: reconstruct failing due to key not found

### DIFF
--- a/faiss_vector_posting.go
+++ b/faiss_vector_posting.go
@@ -328,13 +328,12 @@ func (sb *SegmentBase) SimilarVectors(field string, qVector []float32, k int64, 
 			if err != nil {
 				return nil, err
 			}
+			defer vecIndex.Close()
 
 			scores, ids, err := vecIndex.Search(qVector, k)
 			if err != nil {
 				return nil, err
 			}
-
-			vecIndex.Close()
 
 			// for every similar vector returned by the Search() API, add the corresponding
 			// docID and the score to the newly created vecPostingsList


### PR DESCRIPTION
- there are intermittent errors occuring while reading an index/reconstructing the vectors from it using a key. 

`Error in Index *faiss::read_index(IOReader *, int) at /Users/thejasbhat/fts/vector_search/faiss/faiss/impl/index_read.cpp:1028: Index type 0x00000000 ("\x00\x00\x00\x00") not recognized`

`Error in virtual void faiss::Index::reconstruct_batch(idx_t, const idx_t *, float *) const at /Users/thejasbhat/fts/vector_search/faiss/faiss/Index.cpp:70: Error in virtual void faiss::IndexIDMap2Template<faiss::Index>::reconstruct(idx_t, typename IndexT::component_t *) const [IndexT = faiss::Index] at /Users/thejasbhat/fts/vector_search/faiss/faiss/IndexIDMap.cpp:236: key 7274484443284373504 not found`

- refactoring the index.Close() calls so that the memory cleanup is more responsible.
- work in progress