### PR TITLE
bug fix: accounting the vecIDs approriately while merging

### DIFF
--- a/section_faiss_vector_index.go
+++ b/section_faiss_vector_index.go
@@ -128,7 +128,7 @@ LOOP:
 			indexes[len(indexes)-1].vecIds = make([]int64, 0, numVecs)
 
 			for i := 0; i < int(numVecs); i++ {
-				vecID, n := binary.Uvarint(sb.mem[pos : pos+binary.MaxVarintLen64])
+				vecID, n := binary.Varint(sb.mem[pos : pos+binary.MaxVarintLen64])
 				pos += n
 
 				bitMapLen, n := binary.Uvarint(sb.mem[pos : pos+binary.MaxVarintLen64])
@@ -155,11 +155,10 @@ LOOP:
 					} else {
 						vecToDocID[int64(vecID)] = bitMap
 					}
+					indexes[len(indexes)-1].vecIds = append(indexes[len(indexes)-1].vecIds, int64(vecID))
 				} else {
 					vecToDocID[int64(vecID)].Or(bitMap)
 				}
-
-				indexes[len(indexes)-1].vecIds = append(indexes[len(indexes)-1].vecIds, int64(vecID))
 			}
 		}
 		err := vo.mergeAndWriteVectorIndexes(fieldID, segments, vecToDocID, indexes, w, closeCh)
@@ -210,7 +209,8 @@ func (v *vectorIndexOpaque) flushVectorSection(vecToDocID map[int64]*roaring.Bit
 
 	for vecID, docIDs := range vecToDocID {
 		// write the vecID
-		_, err := writeUvarints(w, uint64(vecID))
+		n = binary.PutVarint(tempBuf, vecID)
+		_, err = w.Write(tempBuf[:n])
 		if err != nil {
 			return 0, err
 		}
@@ -312,7 +312,6 @@ func (v *vectorIndexOpaque) mergeAndWriteVectorIndexes(fieldID int, sbs []*Segme
 	}
 
 	// todo: ivf -> flat index when there were huge number of vector deletes for this field
-
 	for i := 1; i < len(vecIndexes); i++ {
 		if isClosed(closeCh) {
 			return fmt.Errorf("merging of vector sections aborted")
@@ -424,7 +423,7 @@ func (vo *vectorIndexOpaque) writeVectorIndexes(w *CountHashWriter) (offset uint
 		}
 
 		// write the number of unique vectors
-		n = binary.PutUvarint(tempBuf, uint64(len(content.vecs)))
+		n = binary.PutUvarint(tempBuf, uint64(index.Ntotal()))
 		_, err = w.Write(tempBuf[:n])
 		if err != nil {
 			return 0, err
@@ -439,7 +438,8 @@ func (vo *vectorIndexOpaque) writeVectorIndexes(w *CountHashWriter) (offset uint
 		for vecID, _ := range content.vecs {
 			docIDs := vo.vecIDMap[vecID].docIDs
 			// write the vecID
-			_, err := writeUvarints(w, uint64(vecID))
+			n = binary.PutVarint(tempBuf, vecID)
+			_, err = w.Write(tempBuf[:n])
 			if err != nil {
 				return 0, err
 			}


### PR DESCRIPTION
- while merging the vecID->docIDs mapping, only account the unique vecs' IDs.
- use signed int for vecID while storing in index files.