### PR TITLE
bug fix: fixing the logic of tracking vector ids during a merge

### DIFF
--- a/cmd/zap/cmd/vector.go
+++ b/cmd/zap/cmd/vector.go
@@ -135,8 +135,18 @@ func decodeSection(data []byte, start uint64) (int, int, map[int64][]uint32, *fa
 	numVecs, n := binary.Uvarint(data[pos : pos+binary.MaxVarintLen64])
 	pos += n
 	for i := 0; i < int(numVecs); i++ {
-		vecID, n := binary.Uvarint(data[pos : pos+binary.MaxVarintLen64])
+		vecID, n := binary.Varint(data[pos : pos+binary.MaxVarintLen64])
 		pos += n
+
+		numDocs, n := binary.Uvarint(data[pos : pos+binary.MaxVarintLen64])
+		pos += n
+
+		if numDocs == 1 {
+			docID, n := binary.Uvarint(data[pos : pos+binary.MaxVarintLen64])
+			pos += n
+			vecDocIDMap[int64(vecID)] = []uint32{uint32(docID)}
+			continue
+		}
 
 		bitMapLen, n := binary.Uvarint(data[pos : pos+binary.MaxVarintLen64])
 		pos += n

--- a/faiss_vector_posting.go
+++ b/faiss_vector_posting.go
@@ -216,7 +216,7 @@ func (i *VecPostingsIterator) nextCodeAtOrAfter(atOrAfter uint64) (uint64, bool,
 // a transformation function which stores both the score and the docNum as a single
 // entry which is a uint64 number.
 func getVectorCode(docNum uint32, score float32) uint64 {
-	return uint64(docNum)<<31 | uint64(math.Float32bits(score))
+	return uint64(docNum)<<32 | uint64(math.Float32bits(score))
 }
 
 // Next returns the next posting on the vector postings list, or nil at the end
@@ -234,7 +234,7 @@ func (i *VecPostingsIterator) nextAtOrAfter(atOrAfter uint64) (segment.VecPostin
 	i.next = VecPosting{} // clear the struct
 	rv := &i.next
 	rv.score = math.Float32frombits(uint32(code & maskLow32Bits))
-	rv.docNum = code >> 31
+	rv.docNum = code >> 32
 
 	return rv, nil
 }
@@ -352,6 +352,9 @@ func (sb *SegmentBase) SimilarVectors(field string, qVector []float32, k int64, 
 			// docID and the score to the newly created vecPostingsList
 			for i := 0; i < len(ids); i++ {
 				vecID := ids[i]
+				if vecID == -1 {
+					continue // ignore the invalid entries of ids
+				}
 				docIDs := vecDocIDMap[vecID]
 				var code uint64
 

--- a/faiss_vector_test.go
+++ b/faiss_vector_test.go
@@ -17,10 +17,11 @@ import (
 )
 
 func getStubDocScores(k int) (ids []uint64, scores []float32, err error) {
-	for i := 1; i <= k; i++ {
+	for i := 0; i < k; i++ {
 		ids = append(ids, uint64(i))
 		scores = append(scores, float32((2*i+3)/200))
 	}
+	scores[0] = -scores[0]
 	return ids, scores, nil
 }
 
@@ -37,7 +38,7 @@ func TestVecPostingsIterator(t *testing.T) {
 	docIDs := make(map[uint64]float32)
 
 	for i, id := range ids {
-		code := uint64(id)<<31 | uint64(math.Float32bits(scores[i]))
+		code := uint64(id)<<32 | uint64(math.Float32bits(scores[i]))
 		vecPL.postings.Add(code)
 		docIDs[id] = scores[i]
 	}


### PR DESCRIPTION
- when there is a doc update, there could be a case where the number of valid docs for a vector (after remapping to the new docIDs) is zero. in this case, we shouldn't account the vector to be included in reconstruction and also should be considered as something invalid (deleted) so that we can remove that vector from the index.
- fixing the decoding of segment data in `vector` cmd tool.
- fixing the vector code formation on the postings list. essentially the score can be negative in case of dot product, however due to the right shift being 31 earlier we were reading the sign bit to be the part of docNum as well which caused incorrect doc nums to be returned. the fix for this is to shift the bits by right the number = 32.