### PR TITLE
cache eviction policy for vector indexes 

### DIFF
--- a/build.go
+++ b/build.go
@@ -175,6 +175,9 @@ func InitSegmentBase(mem []byte, memCRC uint32, chunkMode uint32,
 		docValueOffset:      0, // docvalueOffsets identified automicatically by the section
 		dictLocs:            dictLocs,
 		fieldFSTs:           make(map[uint16]*vellum.FST),
+		vectorCache: &vecCache{
+			cache: make(map[uint16]*cacheEntry),
+		},
 	}
 	sb.updateSize()
 

--- a/section_faiss_vector_index.go
+++ b/section_faiss_vector_index.go
@@ -21,6 +21,7 @@ import (
 	"encoding/binary"
 	"fmt"
 	"math"
+	"sync/atomic"
 
 	"github.com/RoaringBitmap/roaring"
 	index "github.com/blevesearch/bleve_index_api"
@@ -669,11 +670,11 @@ func (v *vectorIndexOpaque) realloc() {
 }
 
 func (v *vectorIndexOpaque) incrementBytesWritten(val uint64) {
-	v.bytesWritten += val
+	atomic.AddUint64(&v.bytesWritten, val)
 }
 
 func (v *vectorIndexOpaque) BytesWritten() uint64 {
-	return v.bytesWritten
+	return atomic.LoadUint64(&v.bytesWritten)
 }
 
 func (v *vectorIndexOpaque) BytesRead() uint64 {
@@ -695,6 +696,8 @@ func (v *vectorIndexOpaque) Reset() (err error) {
 	v.vecFieldMap = nil
 	v.vecIDMap = nil
 	v.tmp0 = v.tmp0[:0]
+
+	atomic.StoreUint64(&v.bytesWritten, 0)
 
 	return nil
 }

--- a/section_inverted_text_index.go
+++ b/section_inverted_text_index.go
@@ -19,6 +19,7 @@ import (
 	"encoding/binary"
 	"math"
 	"sort"
+	"sync/atomic"
 
 	"github.com/RoaringBitmap/roaring"
 	index "github.com/blevesearch/bleve_index_api"
@@ -380,11 +381,11 @@ func (i *invertedIndexOpaque) grabBuf(size int) []byte {
 }
 
 func (i *invertedIndexOpaque) incrementBytesWritten(bytes uint64) {
-	i.bytesWritten += bytes
+	atomic.AddUint64(&i.bytesWritten, bytes)
 }
 
 func (i *invertedIndexOpaque) BytesWritten() uint64 {
-	return i.bytesWritten
+	return atomic.LoadUint64(&i.bytesWritten)
 }
 
 func (i *invertedIndexOpaque) BytesRead() uint64 {
@@ -978,6 +979,7 @@ func (io *invertedIndexOpaque) Reset() (err error) {
 	io.reusableFieldTFs = io.reusableFieldTFs[:0]
 
 	io.tmp0 = io.tmp0[:0]
+	atomic.StoreUint64(&io.bytesWritten, 0)
 	io.fieldsSame = false
 	io.numDocs = 0
 


### PR DESCRIPTION
- Uses the exponentially weighted moving average to get the average hits on a particular field (thereby a particular vector index). The index stays in the cache above a certain threshold of the average hits and below which the index is closed and the memory is freed for reuse on C side of things. 
- This ensures that we are not keeping the index in the cache (and holding up memory) even when there is no query workload on the field in a segment so the memory pressure does get reduced on the C side of operations.
- Still a work in progress