### PR TITLE
MB-60084: Change index merge procedure to account for existing index type.

### DIFF
--- a/faiss_vector_test.go
+++ b/faiss_vector_test.go
@@ -352,47 +352,6 @@ func letsCreateVectorIndexOfTypeForTesting(dataset [][]float32, dims int,
 	return idx, nil
 }
 
-func TestRemoveVectorIDs(t *testing.T) {
-
-	testCases := []struct {
-		numVecs int
-	}{
-		{
-			// 5 vectors to test for flat indexes.
-			numVecs: 5,
-		},
-		{
-			// 500 vectors to test for IVF indexes
-			numVecs: 500,
-		},
-	}
-
-	for _, testCase := range testCases {
-		data := stubVecDataLengthN(testCase.numVecs)
-		index_key, isIVF := getIndexType(testCase.numVecs)
-		vecIndex, err := letsCreateVectorIndexOfTypeForTesting(data, 3,
-			index_key, isIVF)
-		if err != nil {
-			t.Fatalf("error creating vector index %v", err)
-		}
-
-		currCount := vecIndex.Ntotal()
-		if currCount != int64(testCase.numVecs) {
-			t.Fatalf("all vectors not indexed?")
-		}
-
-		err = removeDeletedVectors(vecIndex, []int64{1, 2})
-		if err != nil {
-			t.Fatalf("err removing deleted vectors: %v\n", err)
-		}
-
-		currCount = vecIndex.Ntotal()
-		if currCount != int64(testCase.numVecs)-2 {
-			t.Fatalf("vectors not deleted correctly?")
-		}
-	}
-}
-
 func TestVectorSegment(t *testing.T) {
 	docs := buildMultiDocDataset()
 

--- a/faiss_vector_test.go
+++ b/faiss_vector_test.go
@@ -316,10 +316,10 @@ func serializeVecs(dataset [][]float32) []float32 {
 }
 
 func letsCreateVectorIndexOfTypeForTesting(dataset [][]float32, dims int,
-	index_key string, isIVF bool) (*faiss.IndexImpl, error) {
+	indexKey string, isIVF bool) (*faiss.IndexImpl, error) {
 	vecs := serializeVecs(dataset)
 
-	idx, err := faiss.IndexFactory(dims, index_key, faiss.MetricL2)
+	idx, err := faiss.IndexFactory(dims, indexKey, faiss.MetricL2)
 	if err != nil {
 		return nil, err
 	}

--- a/faiss_vector_test.go
+++ b/faiss_vector_test.go
@@ -7,7 +7,6 @@ import (
 	"encoding/binary"
 	"fmt"
 	"math"
-	"math/rand"
 	"os"
 	"testing"
 
@@ -135,14 +134,6 @@ func newStubFieldVec(name string, vector []float32, d int, metric string, fieldO
 		encodedType: 'v',
 		options:     fieldOptions,
 	}
-}
-
-func stubVecDataLengthN(n int) [][]float32 {
-	rv := make([][]float32, n)
-	for i := 0; i < n; i++ {
-		rv[i] = []float32{rand.Float32(), rand.Float32(), rand.Float32()}
-	}
-	return rv
 }
 
 func stubVecData() [][]float32 {
@@ -343,9 +334,12 @@ func letsCreateVectorIndexOfTypeForTesting(dataset [][]float32, dims int,
 		if err != nil {
 			return nil, err
 		}
-	}
 
-	idx.Train(vecs)
+		err = idx.Train(vecs)
+		if err != nil {
+			return nil, err
+		}
+	}
 
 	idx.AddWithIDs(vecs, ids)
 

--- a/faiss_vector_test.go
+++ b/faiss_vector_test.go
@@ -324,7 +324,7 @@ func serializeVecs(dataset [][]float32) []float32 {
 	return vecs
 }
 
-func letsCreateVectorIndexOfTypeForTesting(dataset [][]float32, dims int, similarity,
+func letsCreateVectorIndexOfTypeForTesting(dataset [][]float32, dims int,
 	index_key string, isIVF bool) (*faiss.IndexImpl, error) {
 	vecs := serializeVecs(dataset)
 
@@ -370,15 +370,25 @@ func TestRemoveVectorIDs(t *testing.T) {
 	for _, testCase := range testCases {
 		data := stubVecDataLengthN(testCase.numVecs)
 		index_key, isIVF := getIndexType(testCase.numVecs)
-		vecIndex, err := letsCreateVectorIndexOfTypeForTesting(data, 3, "l2",
+		vecIndex, err := letsCreateVectorIndexOfTypeForTesting(data, 3,
 			index_key, isIVF)
 		if err != nil {
 			t.Fatalf("error creating vector index %v", err)
 		}
 
+		currCount := vecIndex.Ntotal()
+		if currCount != int64(testCase.numVecs) {
+			t.Fatalf("all vectors not indexed?")
+		}
+
 		err = removeDeletedVectors(vecIndex, []int64{1, 2})
 		if err != nil {
 			t.Fatalf("err removing deleted vectors: %v\n", err)
+		}
+
+		currCount = vecIndex.Ntotal()
+		if currCount != int64(testCase.numVecs)-2 {
+			t.Fatalf("vectors not deleted correctly?")
 		}
 	}
 }
@@ -421,7 +431,7 @@ func TestVectorSegment(t *testing.T) {
 	}
 
 	data := stubVecData()
-	vecIndex, err := letsCreateVectorIndexOfTypeForTesting(data, 3, "l2", "IDMap2,Flat",
+	vecIndex, err := letsCreateVectorIndexOfTypeForTesting(data, 3, "IDMap2,Flat",
 		false)
 	if err != nil {
 		t.Fatalf("error creating vector index %v", err)

--- a/section_faiss_vector_index.go
+++ b/section_faiss_vector_index.go
@@ -275,11 +275,8 @@ func (v *vectorIndexOpaque) mergeAndWriteVectorIndexes(fieldID int, sbs []*Segme
 	defer freeReconstructedIndexes(vecIndexes)
 
 	var mergedIndexBytes []byte
+	// index type to be created after merge.
 	indexType, isIVF := getIndexType(len(vecToDocID))
-	// could this be possible in a scenario where there are a lot of small segments
-	// i.e. flat indexes but cumulatively their numbers are high enough that they
-	// must now be made into an IVF index.
-
 	// merging of indexes with reconstruction
 	// method. the indexes[i].vecIds is such that it has only the valid vecs
 	// of this vector index present in it, so we'd be reconstructed only the

--- a/section_faiss_vector_index.go
+++ b/section_faiss_vector_index.go
@@ -350,15 +350,15 @@ func (v *vectorIndexOpaque) mergeAndWriteVectorIndexes(fieldID int, sbs []*Segme
 			if err != nil {
 				return err
 			}
-		}
 
-		// train the vector index, essentially performs k-means clustering to partition
-		// the data space of indexData such that during the search time, we probe
-		// only a subset of vectors -> non-exhaustive search. could be a time
-		// consuming step when the indexData is large.
-		err = index.Train(indexData)
-		if err != nil {
-			return err
+			// train the vector index, essentially performs k-means clustering to partition
+			// the data space of indexData such that during the search time, we probe
+			// only a subset of vectors -> non-exhaustive search. could be a time
+			// consuming step when the indexData is large.
+			err = index.Train(indexData)
+			if err != nil {
+				return err
+			}
 		}
 
 		err = index.AddWithIDs(indexData, finalVecIDs)
@@ -470,11 +470,11 @@ func (vo *vectorIndexOpaque) writeVectorIndexes(w *CountHashWriter) (offset uint
 			if err != nil {
 				return 0, err
 			}
-		}
 
-		err = index.Train(vecs)
-		if err != nil {
-			return 0, err
+			err = index.Train(vecs)
+			if err != nil {
+				return 0, err
+			}
 		}
 
 		err = index.AddWithIDs(vecs, ids)

--- a/section_faiss_vector_index.go
+++ b/section_faiss_vector_index.go
@@ -256,7 +256,7 @@ func (v *vectorIndexOpaque) flushVectorSection(vecToDocID map[int64]*roaring.Bit
 }
 
 func removeDeletedVectors(index *faiss.IndexImpl, ids []int64) error {
-	sel, err := faiss.NewIDSelectorBatch(ids)
+	sel, err := faiss.NewIDSelectorArray(ids)
 	if err != nil {
 		return err
 	}

--- a/section_faiss_vector_index.go
+++ b/section_faiss_vector_index.go
@@ -281,12 +281,11 @@ func removeDeletedVectors(index *faiss.IndexImpl, ids []int64) error {
 		return err
 	}
 
+	defer sel.Delete()
 	_, err = index.RemoveIDs(sel)
 	if err != nil {
-		sel.Delete()
 		return err
 	}
-	sel.Delete()
 	return nil
 }
 
@@ -398,7 +397,6 @@ func (v *vectorIndexOpaque) mergeAndWriteVectorIndexes(fieldID int, sbs []*Segme
 			return err
 		}
 	}
-
 	fieldStart, err := v.flushVectorSection(vecToDocID, mergedIndexBytes, w)
 	if err != nil {
 		return err

--- a/section_faiss_vector_index.go
+++ b/section_faiss_vector_index.go
@@ -342,12 +342,14 @@ func (v *vectorIndexOpaque) mergeAndWriteVectorIndexes(fieldID int, sbs []*Segme
 		}
 		defer index.Close()
 
-		// the direct map maintained in the IVF index is essential for the
-		// reconstruction of vectors based on vector IDs in the future merges.
-		// the AddWithIDs API also needs a direct map to be set before using.
-		err = index.SetDirectMap(2)
-		if err != nil {
-			return err
+		if isIVF {
+			// the direct map maintained in the IVF index is essential for the
+			// reconstruction of vectors based on vector IDs in the future merges.
+			// the AddWithIDs API also needs a direct map to be set before using.
+			err = index.SetDirectMap(2)
+			if err != nil {
+				return err
+			}
 		}
 
 		// train the vector index, essentially performs k-means clustering to partition

--- a/section_faiss_vector_index.go
+++ b/section_faiss_vector_index.go
@@ -255,6 +255,41 @@ func (v *vectorIndexOpaque) flushVectorSection(vecToDocID map[int64]*roaring.Bit
 	return fieldStart, nil
 }
 
+// Func which returns if reconstruction is required.
+// Won't be required if multiple flat indexes are being combined into a larger
+// flat index.
+func reconstructionRequired(isNewIndexIVF bool, indexes []vecIndexMeta) bool {
+	// Always required for IVF indexes.
+	if isNewIndexIVF {
+		return true
+	}
+
+	// if any existing index is not flat, all need to be reconstructed.
+	for _, index := range indexes {
+		_, isExistingIndexIVF := getIndexType(len(index.vecIds) + len(index.deleted))
+		if isExistingIndexIVF {
+			return true
+		}
+	}
+
+	return false
+}
+
+func removeDeletedVectors(index *faiss.IndexImpl, ids []int64) error {
+	sel, err := faiss.NewIDSelectorBatch(ids)
+	if err != nil {
+		return err
+	}
+
+	_, err = index.RemoveIDs(sel)
+	if err != nil {
+		sel.Delete()
+		return err
+	}
+	sel.Delete()
+	return nil
+}
+
 // todo: naive implementation. need to keep in mind the perf implications and improve on this.
 // perhaps, parallelized merging can help speed things up over here.
 func (v *vectorIndexOpaque) mergeAndWriteVectorIndexes(fieldID int, sbs []*SegmentBase,
@@ -277,36 +312,37 @@ func (v *vectorIndexOpaque) mergeAndWriteVectorIndexes(fieldID int, sbs []*Segme
 	var mergedIndexBytes []byte
 	// index type to be created after merge.
 	indexType, isIVF := getIndexType(len(vecToDocID))
-	// merging of indexes with reconstruction
-	// method. the indexes[i].vecIds is such that it has only the valid vecs
-	// of this vector index present in it, so we'd be reconstructed only the
-	// valid ones.
-	var indexData []float32
-	for i := 0; i < len(vecIndexes); i++ {
-		if isClosed(closeCh) {
-			return fmt.Errorf("merging of vector sections aborted")
+
+	if reconstructionRequired(isIVF, indexes) {
+		// merging of indexes with reconstruction
+		// method. the indexes[i].vecIds is such that it has only the valid vecs
+		// of this vector index present in it, so we'd be reconstructed only the
+		// valid ones.
+		var indexData []float32
+		for i := 0; i < len(vecIndexes); i++ {
+			if isClosed(closeCh) {
+				return fmt.Errorf("merging of vector sections aborted")
+			}
+			// todo: parallelize reconstruction
+			recons, err := vecIndexes[i].ReconstructBatch(int64(len(indexes[i].vecIds)), indexes[i].vecIds)
+			if err != nil {
+				return err
+			}
+			indexData = append(indexData, recons...)
 		}
-		// todo: parallelize reconstruction
-		recons, err := vecIndexes[i].ReconstructBatch(int64(len(indexes[i].vecIds)), indexes[i].vecIds)
+
+		// safe to assume that all the indexes are of the same config values, given
+		// that they are extracted from the field mapping info.
+		dims := vecIndexes[0].D()
+		metric := vecIndexes[0].MetricType()
+		finalVecIDs := maps.Keys(vecToDocID)
+
+		index, err := faiss.IndexFactory(dims, indexType, metric)
 		if err != nil {
 			return err
 		}
-		indexData = append(indexData, recons...)
-	}
+		defer index.Close()
 
-	// safe to assume that all the indexes are of the same config values, given
-	// that they are extracted from the field mapping info.
-	dims := vecIndexes[0].D()
-	metric := vecIndexes[0].MetricType()
-	finalVecIDs := maps.Keys(vecToDocID)
-
-	index, err := faiss.IndexFactory(dims, indexType, metric)
-	if err != nil {
-		return err
-	}
-	defer index.Close()
-
-	if isIVF {
 		// the direct map maintained in the IVF index is essential for the
 		// reconstruction of vectors based on vector IDs in the future merges.
 		// the AddWithIDs API also needs a direct map to be set before using.
@@ -323,17 +359,44 @@ func (v *vectorIndexOpaque) mergeAndWriteVectorIndexes(fieldID int, sbs []*Segme
 		if err != nil {
 			return err
 		}
-	}
 
-	// applies to both IVF and Flat.
-	err = index.AddWithIDs(indexData, finalVecIDs)
-	if err != nil {
-		return err
-	}
+		err = index.AddWithIDs(indexData, finalVecIDs)
+		if err != nil {
+			return err
+		}
 
-	mergedIndexBytes, err = faiss.WriteIndexIntoBuffer(index)
-	if err != nil {
-		return err
+		mergedIndexBytes, err = faiss.WriteIndexIntoBuffer(index)
+		if err != nil {
+			return err
+		}
+	} else {
+		var err error
+		if len(indexes[0].deleted) > 0 {
+			err = removeDeletedVectors(vecIndexes[0], indexes[0].deleted)
+			if err != nil {
+				return err
+			}
+		}
+		for i := 1; i < len(vecIndexes); i++ {
+			if isClosed(closeCh) {
+				return fmt.Errorf("merging of vector sections aborted")
+			}
+			if len(indexes[i].deleted) > 0 {
+				err = removeDeletedVectors(vecIndexes[i], indexes[i].deleted)
+				if err != nil {
+					return err
+				}
+			}
+			err = vecIndexes[0].MergeFrom(vecIndexes[i], 0)
+			if err != nil {
+				return err
+			}
+		}
+
+		mergedIndexBytes, err = faiss.WriteIndexIntoBuffer(vecIndexes[0])
+		if err != nil {
+			return err
+		}
 	}
 
 	fieldStart, err := v.flushVectorSection(vecToDocID, mergedIndexBytes, w)


### PR DESCRIPTION
Consider the following case:
A segment with an existing IVF index has a large number of deleted vectors due to mutations, etc. Post merge, due to the lesser number of vectors, a flat index will be created. In the current approach, we were attempting to remove vector IDs from an IVF index with a hashtable using a batch ID selector which isn't supported. Hence, the panic seen in the ticket.

This PR adopts an approach where mergeFrom() is applied only if the existing indexes are all flat and the new index to be formed is flat too.

In the process, I've also made some minor changes:
1.  limited training to only IVF indexes - flat indexes don't need to be trained.
2. done a minor refactoring of the utilities used by related UTs.