### PR TITLE
TestVecPostingsIterator unit test fix

### DIFF
--- a/faiss_vector_posting.go
+++ b/faiss_vector_posting.go
@@ -155,8 +155,6 @@ func (vpl *VecPostingsList) BytesWritten() uint64 {
 
 // =============================================================================
 
-const maskLow32Bits = 0x7fffffff
-
 type VecPostingsIterator struct {
 	postings *VecPostingsList
 	all      roaring64.IntPeekable64
@@ -233,7 +231,7 @@ func (i *VecPostingsIterator) nextAtOrAfter(atOrAfter uint64) (segment.VecPostin
 
 	i.next = VecPosting{} // clear the struct
 	rv := &i.next
-	rv.score = math.Float32frombits(uint32(code & maskLow32Bits))
+	rv.score = math.Float32frombits(uint32(code))
 	rv.docNum = code >> 32
 
 	return rv, nil

--- a/faiss_vector_test.go
+++ b/faiss_vector_test.go
@@ -20,7 +20,9 @@ func getStubDocScores(k int) (ids []uint64, scores []float32, err error) {
 		ids = append(ids, uint64(i))
 		scores = append(scores, float32(2*i+3)/float32(200))
 	}
+	// having some negative scores -> possible due to dot product
 	scores[0] = -scores[0]
+	scores[4] = -scores[4]
 	return ids, scores, nil
 }
 
@@ -37,7 +39,7 @@ func TestVecPostingsIterator(t *testing.T) {
 	docIDs := make(map[uint64]float32)
 
 	for i, id := range ids {
-		code := uint64(id)<<32 | uint64(math.Float32bits(scores[i]))
+		code := getVectorCode(uint32(id), scores[i])
 		vecPL.postings.Add(code)
 		docIDs[id] = scores[i]
 	}
@@ -551,7 +553,6 @@ func TestPersistedVectorSegment(t *testing.T) {
 			if next == nil {
 				break
 			}
-
 
 			expectedDocID := hitDocIDs[hitCounter]
 			if next.Number() != expectedDocID {


### PR DESCRIPTION
- drops the unnecessary masking bits while fetching the score since uint32() type cast does the same thing.
- the zapx and bleve unit tests (with the vectors tag) pass so i don't see any regression from the search result wise for the vector search tests.
```
zapx 
➜ go test ./... --tags=vectors
# github.com/blevesearch/zapx/v16.test
ld: warning: dylib (/usr/local/lib/libfaiss_c.dylib) was built for newer macOS version (11.7) than being linked (11.0)
?   	github.com/blevesearch/zapx/v16/cmd/zap	[no test files]
?   	github.com/blevesearch/zapx/v16/cmd/zap/cmd	[no test files]
ok  	github.com/blevesearch/zapx/v16	4.508s

bleve
➜ go test ./... --tags=vectors
# github.com/blevesearch/bleve/v2.test
ld: warning: dylib (/usr/local/lib/libfaiss_c.dylib) was built for newer macOS version (11.7) than being linked (11.0)
?   	github.com/blevesearch/bleve/v2/analysis/analyzer/custom	[no test files]
....
ok  	github.com/blevesearch/bleve/v2/search/searcher	4.370s
ok  	github.com/blevesearch/bleve/v2/test	34.026s
```