### PR TITLE
MB-59632 - Persist index type

### DIFF
--- a/cmd/zap/cmd/vector.go
+++ b/cmd/zap/cmd/vector.go
@@ -128,6 +128,9 @@ func decodeSection(data []byte, start uint64) (int, int, map[int64][]uint32, *fa
 	_, n = binary.Uvarint(data[pos : pos+binary.MaxVarintLen64])
 	pos += n
 
+	_, n = binary.Uvarint(data[pos : pos+binary.MaxVarintLen64])
+	pos += n
+
 	// todo: not a good idea to cache the vector index perhaps, since it could be quite huge.
 	indexSize, n := binary.Uvarint(data[pos : pos+binary.MaxVarintLen64])
 	pos += n

--- a/faiss_vector_posting.go
+++ b/faiss_vector_posting.go
@@ -347,6 +347,10 @@ func (sb *SegmentBase) InterpretVectorIndex(field string) (
 	_, n = binary.Uvarint(sb.mem[pos : pos+binary.MaxVarintLen64])
 	pos += n
 
+	// reading index type.
+	_, n = binary.Uvarint(sb.mem[pos : pos+binary.MaxVarintLen64])
+	pos += n
+
 	// todo: not a good idea to cache the vector index perhaps, since it could be quite huge.
 	indexSize, n := binary.Uvarint(sb.mem[pos : pos+binary.MaxVarintLen64])
 	pos += n

--- a/faiss_vector_test.go
+++ b/faiss_vector_test.go
@@ -309,6 +309,10 @@ func getSectionContentOffsets(sb *SegmentBase, offset uint64) (
 	docValueEnd, n = binary.Uvarint(sb.mem[pos : pos+binary.MaxVarintLen64])
 	pos += uint64(n)
 
+	// index type
+	_, n = binary.Uvarint(sb.mem[pos : pos+binary.MaxVarintLen64])
+	pos += uint64(n)
+
 	indexBytesLen, n = binary.Uvarint(sb.mem[pos : pos+binary.MaxVarintLen64])
 	pos += uint64(n)
 


### PR DESCRIPTION
The FAISS index type to be used when creating a new segment/merging segments is decided based on some thresholds.
Persisting index type to disk ensures that determining the index type during the merge process is forward compatible with any changes in these thresholds(eg. after an offline upgrade).

This PR - 
1. Persists the index type as an integer.
2. Reads the type from file when required.
3. Updates the zapx CLI to adhere to the new format.
4. Fixes the UT to pass with the change.