### PR TITLE
MB-60202 - Filtering deleted documents during FAISS vector index search

### DIFF
--- a/cmd/zap/cmd/vector.go
+++ b/cmd/zap/cmd/vector.go
@@ -115,9 +115,9 @@ var vectorCmd = &cobra.Command{
 	},
 }
 
-func decodeSection(data []byte, start uint64) (int, int, map[uint64]uint64, *faiss.IndexImpl, error) {
+func decodeSection(data []byte, start uint64) (int, int, map[int64]uint64, *faiss.IndexImpl, error) {
 	pos := int(start)
-	vecDocIDMap := make(map[uint64]uint64)
+	vecDocIDMap := make(map[int64]uint64)
 
 	// loading doc values - adhering to the sections format. never
 	// valid values for vector section
@@ -138,7 +138,7 @@ func decodeSection(data []byte, start uint64) (int, int, map[uint64]uint64, *fai
 	numVecs, n := binary.Uvarint(data[pos : pos+binary.MaxVarintLen64])
 	pos += n
 	for i := 0; i < int(numVecs); i++ {
-		vecID, n := binary.Uvarint(data[pos : pos+binary.MaxVarintLen64])
+		vecID, n := binary.Varint(data[pos : pos+binary.MaxVarintLen64])
 		pos += n
 
 		docID, n := binary.Uvarint(data[pos : pos+binary.MaxVarintLen64])

--- a/faiss_vector_posting.go
+++ b/faiss_vector_posting.go
@@ -304,14 +304,7 @@ func (sb *SegmentBase) InterpretVectorIndex(field string) (
 			}
 		}
 
-		var scores []float32
-		var ids []int64
-		var err error
-		if len(vectorIDsToExclude) > 0 {
-			scores, ids, err = vecIndex.SearchWithoutIDs(qVector, k, vectorIDsToExclude)
-		} else {
-			scores, ids, err = vecIndex.Search(qVector, k)
-		}
+		scores, ids, err := vecIndex.SearchWithoutIDs(qVector, k, vectorIDsToExclude)
 
 		if err != nil {
 			return nil, err

--- a/faiss_vector_test.go
+++ b/faiss_vector_test.go
@@ -6,6 +6,7 @@ package zap
 import (
 	"encoding/binary"
 	"math"
+	"math/rand"
 	"os"
 	"testing"
 
@@ -492,6 +493,23 @@ func TestVectorSegment(t *testing.T) {
 			hitCounter++
 		}
 		closeVectorIndex()
+	}
+}
+
+// Test to check if 2 identical vectors return unique hashes.
+func TestHashCode(t *testing.T) {
+	var v1 []float32
+	for i := 0; i < 10; i++ {
+		v1 = append(v1, rand.Float32())
+	}
+
+	h1 := hashCode(v1)
+
+	h2 := hashCode(v1)
+
+	if h1 == h2 {
+		t.Fatal("expected unique hashes for the same vector each time the " +
+			"hash is computed")
 	}
 }
 

--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,7 @@ go 1.20
 require (
 	github.com/RoaringBitmap/roaring v1.2.3
 	github.com/blevesearch/bleve_index_api v1.1.4
-	github.com/blevesearch/go-faiss v1.0.4
+	github.com/blevesearch/go-faiss v1.0.5
 	github.com/blevesearch/mmap-go v1.0.4
 	github.com/blevesearch/scorch_segment_api/v2 v2.2.5
 	github.com/blevesearch/vellum v1.0.10

--- a/go.sum
+++ b/go.sum
@@ -4,8 +4,8 @@ github.com/bits-and-blooms/bitset v1.2.0 h1:Kn4yilvwNtMACtf1eYDlG8H77R07mZSPbMjL
 github.com/bits-and-blooms/bitset v1.2.0/go.mod h1:gIdJ4wp64HaoK2YrL1Q5/N7Y16edYb8uY+O0FJTyyDA=
 github.com/blevesearch/bleve_index_api v1.1.4 h1:n9Ilxlb80g9DAhchR95IcVrzohamDSri0wPnkKnva50=
 github.com/blevesearch/bleve_index_api v1.1.4/go.mod h1:PbcwjIcRmjhGbkS/lJCpfgVSMROV6TRubGGAODaK1W8=
-github.com/blevesearch/go-faiss v1.0.4 h1:SfTVaqGF116umb1Kw90EWdO2FJhQZVYRNTlPH0J/TOg=
-github.com/blevesearch/go-faiss v1.0.4/go.mod h1:jrxHrbl42X/RnDPI+wBoZU8joxxuRwedrxqswQ3xfU8=
+github.com/blevesearch/go-faiss v1.0.5 h1:IWlOZGF3GXFOUdLVW9JkqgWPQ3gEIYqqdp88rbrAcc4=
+github.com/blevesearch/go-faiss v1.0.5/go.mod h1:jrxHrbl42X/RnDPI+wBoZU8joxxuRwedrxqswQ3xfU8=
 github.com/blevesearch/mmap-go v1.0.4 h1:OVhDhT5B/M1HNPpYPBKIEJaD0F3Si+CrEKULGCDPWmc=
 github.com/blevesearch/mmap-go v1.0.4/go.mod h1:EWmEAOmdAS9z/pi/+Toxu99DnsbhG1TIxUoRmJw/pSs=
 github.com/blevesearch/scorch_segment_api/v2 v2.2.5 h1:5SsNQmR8v1bojtGQ1zFhZravcMg5rdiX8AVu6LwlVtc=

--- a/section_faiss_vector_index.go
+++ b/section_faiss_vector_index.go
@@ -206,7 +206,7 @@ func (v *vectorIndexOpaque) flushVectorSection(vecToDocID map[int64]uint64,
 		}
 
 		// write the docID
-		n = binary.PutUvarint(tempBuf, uint64(docID))
+		n = binary.PutUvarint(tempBuf, docID)
 		_, err = w.Write(tempBuf[:n])
 		if err != nil {
 			return 0, err

--- a/section_faiss_vector_index.go
+++ b/section_faiss_vector_index.go
@@ -557,9 +557,9 @@ func (vo *vectorIndexOpaque) process(field index.VectorField, fieldID uint16, do
 
 // todo: better hash function?
 // keep the perf aspects in mind with respect to the hash function.
-// Uses a time based seed to avoid 2 identical vectors in different
-// segments having the same hash -> could be an issue when merging those
-// segments
+// Uses a time based seed to prevent 2 identical vectors in different
+// segments from having the same hash (which otherwise could cause an
+// issue when merging those segments)
 func hashCode(a []float32) int64 {
 	var rv, sum int64
 	for _, v := range a {


### PR DESCRIPTION
This PR addresses filtering of deleted documents by moving from post-filtering to search time filtering. 

- Passes doc IDs to exclude for each search.
- To account for duplicate vectors: saves every vector with a unique hash so that the selector only excludes the specific vector ID. The current approach of identical vectors having identical hashes would lead to (unnecessarily) excluding vectors if other (identical) vectors in the segment were deleted.