### PR TITLE
MB-60400: Reduce Garbage generated

### DIFF
--- a/build.go
+++ b/build.go
@@ -172,7 +172,7 @@ func InitSegmentBase(mem []byte, memCRC uint32, chunkMode uint32,
 		fieldsIndexOffset:   sectionsIndexOffset,
 		sectionsIndexOffset: sectionsIndexOffset,
 		fieldDvReaders:      make([]map[uint16]*docValueReader, len(segmentSections)),
-		docValueOffset:      0, // docvalueOffsets identified automicatically by the section
+		docValueOffset:      0, // docValueOffsets identified automatically by the section
 		dictLocs:            dictLocs,
 		fieldFSTs:           make(map[uint16]*vellum.FST),
 	}

--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,7 @@ go 1.20
 require (
 	github.com/RoaringBitmap/roaring v1.2.3
 	github.com/blevesearch/bleve_index_api v1.1.5
-	github.com/blevesearch/go-faiss v1.0.6
+	github.com/blevesearch/go-faiss v1.0.7
 	github.com/blevesearch/mmap-go v1.0.4
 	github.com/blevesearch/scorch_segment_api/v2 v2.2.6
 	github.com/blevesearch/vellum v1.0.10

--- a/go.sum
+++ b/go.sum
@@ -4,8 +4,8 @@ github.com/bits-and-blooms/bitset v1.2.0 h1:Kn4yilvwNtMACtf1eYDlG8H77R07mZSPbMjL
 github.com/bits-and-blooms/bitset v1.2.0/go.mod h1:gIdJ4wp64HaoK2YrL1Q5/N7Y16edYb8uY+O0FJTyyDA=
 github.com/blevesearch/bleve_index_api v1.1.5 h1:0q05mzu6GT/kebzqKywCpou/eUea9wTKa7kfqX7QX+k=
 github.com/blevesearch/bleve_index_api v1.1.5/go.mod h1:PbcwjIcRmjhGbkS/lJCpfgVSMROV6TRubGGAODaK1W8=
-github.com/blevesearch/go-faiss v1.0.6 h1:UqGq55UccPCq2+hgefBHN7/URT+q26DxL1zRgO0DMvo=
-github.com/blevesearch/go-faiss v1.0.6/go.mod h1:jrxHrbl42X/RnDPI+wBoZU8joxxuRwedrxqswQ3xfU8=
+github.com/blevesearch/go-faiss v1.0.7 h1:hMIkk7BBUkTOuR+5Cg1BYuinMHHA5zRdfnQ2c1rLIXw=
+github.com/blevesearch/go-faiss v1.0.7/go.mod h1:jrxHrbl42X/RnDPI+wBoZU8joxxuRwedrxqswQ3xfU8=
 github.com/blevesearch/mmap-go v1.0.4 h1:OVhDhT5B/M1HNPpYPBKIEJaD0F3Si+CrEKULGCDPWmc=
 github.com/blevesearch/mmap-go v1.0.4/go.mod h1:EWmEAOmdAS9z/pi/+Toxu99DnsbhG1TIxUoRmJw/pSs=
 github.com/blevesearch/scorch_segment_api/v2 v2.2.6 h1:rewrzgFaCEjjfWovAB9NubMAd4+aCLxD3RaQcPDaoNo=

--- a/merge.go
+++ b/merge.go
@@ -22,6 +22,7 @@ import (
 	"math"
 	"os"
 	"sort"
+	"sync"
 
 	"github.com/RoaringBitmap/roaring"
 	seg "github.com/blevesearch/scorch_segment_api/v2"
@@ -31,6 +32,12 @@ import (
 var DefaultFileMergerBufferSize = 1024 * 1024
 
 const docDropped = math.MaxUint64 // sentinel docNum to represent a deleted doc
+
+var mergeBufferPool = sync.Pool{
+	New: func() interface{} {
+		return bufio.NewWriterSize(nil, DefaultFileMergerBufferSize)
+	},
+}
 
 // Merge takes a slice of segments and bit masks describing which
 // documents may be dropped, and creates a new segment containing the
@@ -68,7 +75,8 @@ func mergeSegmentBases(segmentBases []*SegmentBase, drops []*roaring.Bitmap, pat
 	}
 
 	// buffer the output
-	br := bufio.NewWriterSize(f, DefaultFileMergerBufferSize)
+	br := mergeBufferPool.Get().(*bufio.Writer)
+	br.Reset(f)
 
 	// wrap it for counting (tracking offsets)
 	cr := NewCountHashWriterWithStatsReporter(br, s)
@@ -106,7 +114,9 @@ func mergeSegmentBases(segmentBases []*SegmentBase, drops []*roaring.Bitmap, pat
 		return nil, 0, err
 	}
 
-	return newDocNums, uint64(cr.Count()), nil
+	numBytesWritten := cr.Count()
+	mergeBufferPool.Put(br)
+	return newDocNums, uint64(numBytesWritten), nil
 }
 
 func MergeToWriter(segments []*SegmentBase, drops []*roaring.Bitmap,

--- a/section_faiss_vector_index.go
+++ b/section_faiss_vector_index.go
@@ -295,7 +295,6 @@ func (v *vectorIndexOpaque) mergeAndWriteVectorIndexes(fieldID int, sbs []*Segme
 	recons := make([]float32, 0, reconsCap)
 	var err error
 	for i := 0; i < len(vecIndexes); i++ {
-		recons = recons[:0]
 		if isClosed(closeCh) {
 			freeReconstructedIndexes(vecIndexes)
 			return seg.ErrClosed

--- a/section_faiss_vector_index.go
+++ b/section_faiss_vector_index.go
@@ -307,8 +307,7 @@ func (v *vectorIndexOpaque) mergeAndWriteVectorIndexes(fieldID int, sbs []*Segme
 			neededReconsLen := len(indexes[i].vecIds) * vecIndexes[i].D()
 			recons = recons[:neededReconsLen]
 			// todo: parallelize reconstruction
-			recons, err = vecIndexes[i].ReconstructBatch(int64(len(indexes[i].vecIds)),
-				indexes[i].vecIds, recons)
+			recons, err = vecIndexes[i].ReconstructBatch(indexes[i].vecIds, recons)
 			if err != nil {
 				freeReconstructedIndexes(vecIndexes)
 				return err

--- a/section_faiss_vector_index.go
+++ b/section_faiss_vector_index.go
@@ -440,14 +440,8 @@ func (vo *vectorIndexOpaque) writeVectorIndexes(w *CountHashWriter) (offset uint
 	for fieldID, content := range vo.vecFieldMap {
 		// calculate the capacity of the vecs and ids slices
 		// to avoid multiple allocations.
-		vecsLen := 0
-		idsLen := 0
-		for _, vecInfo := range content.vecs {
-			vecsLen += len(vecInfo.vec)
-			idsLen++
-		}
-		vecs := make([]float32, 0, vecsLen)
-		ids := make([]int64, 0, idsLen)
+		vecs := make([]float32, 0, uint16(len(content.vecs))*content.dim)
+		ids := make([]int64, 0, len(content.vecs))
 		for hash, vecInfo := range content.vecs {
 			vecs = append(vecs, vecInfo.vec...)
 			ids = append(ids, int64(hash))

--- a/section_faiss_vector_index.go
+++ b/section_faiss_vector_index.go
@@ -438,9 +438,16 @@ func (vo *vectorIndexOpaque) writeVectorIndexes(w *CountHashWriter) (offset uint
 	//    2. its constituent vectorID -> {docID} mapping.
 	tempBuf := vo.grabBuf(binary.MaxVarintLen64)
 	for fieldID, content := range vo.vecFieldMap {
-
-		var vecs []float32
-		var ids []int64
+		// calculate the capacity of the vecs and ids slices
+		// to avoid multiple allocations.
+		vecsLen := 0
+		idsLen := 0
+		for _, vecInfo := range content.vecs {
+			vecsLen += len(vecInfo.vec)
+			idsLen++
+		}
+		vecs := make([]float32, 0, vecsLen)
+		ids := make([]int64, 0, idsLen)
 		for hash, vecInfo := range content.vecs {
 			vecs = append(vecs, vecInfo.vec...)
 			ids = append(ids, int64(hash))

--- a/section_inverted_text_index.go
+++ b/section_inverted_text_index.go
@@ -92,12 +92,11 @@ func mergeAndPersistInvertedSection(segments []*SegmentBase, dropsIn []*roaring.
 	// for each field
 	for fieldID, fieldName := range fieldsInv {
 		// collect FST iterators from all active segments for this field
-		var newDocNums [][]uint64
-		var drops []*roaring.Bitmap
-		var dicts []*Dictionary
-		var itrs []vellum.Iterator
-
-		var segmentsInFocus []*SegmentBase
+		newDocNums := make([][]uint64, 0, len(segments))
+		drops := make([]*roaring.Bitmap, 0, len(segments))
+		dicts := make([]*Dictionary, 0, len(segments))
+		itrs := make([]vellum.Iterator, 0, len(segments))
+		segmentsInFocus := make([]*SegmentBase, 0, len(segments))
 
 		for segmentI, segment := range segments {
 			// check for the closure in meantime

--- a/section_inverted_text_index.go
+++ b/section_inverted_text_index.go
@@ -38,13 +38,13 @@ type invertedTextIndexSection struct {
 // process a particular field or not - since it might be processed by another
 // section this function helps in avoiding unnecessary work.
 // (only used by faiss vector section currently, will need a separate API for every
-//  section we introduce in the future or a better way forward - TODO)
+// section we introduce in the future or a better way forward - TODO)
 var isFieldNotApplicableToInvertedTextSection func(field index.Field) bool
 
 func (i *invertedTextIndexSection) Process(opaque map[int]resetable, docNum uint32, field index.Field, fieldID uint16) {
-	invIndexOpaque := i.getInvertedIndexOpaque(opaque)
 	if isFieldNotApplicableToInvertedTextSection == nil ||
 		!isFieldNotApplicableToInvertedTextSection(field) {
+		invIndexOpaque := i.getInvertedIndexOpaque(opaque)
 		invIndexOpaque.process(field, fieldID, docNum)
 	}
 }
@@ -243,6 +243,11 @@ func mergeAndPersistInvertedSection(segments []*SegmentBase, dropsIn []*roaring.
 			err = enumerator.Next()
 		}
 		if err != vellum.ErrIteratorDone {
+			return nil, 0, err
+		}
+		// close the enumerator to free the underlying iterators
+		err = enumerator.Close()
+		if err != nil {
 			return nil, 0, err
 		}
 

--- a/section_inverted_text_index.go
+++ b/section_inverted_text_index.go
@@ -88,16 +88,19 @@ func mergeAndPersistInvertedSection(segments []*SegmentBase, dropsIn []*roaring.
 	}
 
 	newRoaring := roaring.NewBitmap()
-
+	newDocNums := make([][]uint64, 0, len(segments))
+	drops := make([]*roaring.Bitmap, 0, len(segments))
+	dicts := make([]*Dictionary, 0, len(segments))
+	itrs := make([]vellum.Iterator, 0, len(segments))
+	segmentsInFocus := make([]*SegmentBase, 0, len(segments))
 	// for each field
 	for fieldID, fieldName := range fieldsInv {
 		// collect FST iterators from all active segments for this field
-		newDocNums := make([][]uint64, 0, len(segments))
-		drops := make([]*roaring.Bitmap, 0, len(segments))
-		dicts := make([]*Dictionary, 0, len(segments))
-		itrs := make([]vellum.Iterator, 0, len(segments))
-		segmentsInFocus := make([]*SegmentBase, 0, len(segments))
-
+		newDocNums = newDocNums[:0]
+		drops = drops[:0]
+		dicts = dicts[:0]
+		itrs = itrs[:0]
+		segmentsInFocus = segmentsInFocus[:0]
 		for segmentI, segment := range segments {
 			// check for the closure in meantime
 			if isClosed(closeCh) {

--- a/segment.go
+++ b/segment.go
@@ -592,11 +592,12 @@ func (s *SegmentBase) getDocIDinfo() (*Dictionary, string, error) {
 	s.docIDMutex.RLock()
 	cachedDocID := s.cachedMaxDocID
 	cachedDict := s.idDict
-	s.docIDMutex.RUnlock()
 	if cachedDocID != "" && cachedDict != nil {
+		s.docIDMutex.RUnlock()
 		// max doc ID and the id dict is cached, return it
 		return cachedDict, cachedDocID, nil
 	}
+	s.docIDMutex.RUnlock()
 	// not cached so obtain a write lock
 	// to create the _id dict and read the FST
 	// to get the max doc id and cache them

--- a/write.go
+++ b/write.go
@@ -52,7 +52,7 @@ func writeRoaringWithLen(r *roaring.Bitmap, w io.Writer,
 
 func persistFieldsSection(fieldsInv []string, w *CountHashWriter, dictLocs []uint64, opaque map[int]resetable) (uint64, error) {
 	var rv uint64
-	var fieldsOffsets []uint64
+	fieldsOffsets := make([]uint64, 0, len(fieldsInv))
 
 	for fieldID, fieldName := range fieldsInv {
 		// record start of this field


### PR DESCRIPTION
All the points below remove garbage to some extent

- Implement caching for MaxDocID in a segment, leveraging the immutability of the FST for the segment. This enhancement is particularly beneficial for the Introducer Loop, where the DocNumbers() API is called for each segment in the root. By storing the MaxDocID and avoiding redundant recomputation using fst.GetMaxKey(). We also cache the ID Dict for a segment to avoid generating the same object multiple times, saving on the space alloced to repeated creations of the FST Reader object.
- Optimize the writeVectorIndexes function by preventing repeated append scenarios. This is achieved by preallocating the necessary memory through an additional for loop, enhancing efficiency.
- Close the enumerator, to free the FST iterators
- Add capacities to many slices to avoid repeatedly appending to the same slice, which generates garbage.