### PR TITLE
MB-60367 Restructuring the code for better memory cleanup

### DIFF
--- a/cmd/zap/cmd/vector.go
+++ b/cmd/zap/cmd/vector.go
@@ -128,14 +128,7 @@ func decodeSection(data []byte, start uint64) (int, int, map[int64]uint64, *fais
 		pos += n
 	}
 
-	// todo: not a good idea to cache the vector index perhaps, since it could be quite huge.
-	indexSize, n := binary.Uvarint(data[pos : pos+binary.MaxVarintLen64])
-	pos += n
-	indexBytes := data[pos : pos+int(indexSize)]
-	pos += int(indexSize)
-
 	// read the number vectors indexed for this field and load the vector to docID mapping.
-	// todo: cache the vecID to docIDs mapping for a fieldID
 	numVecs, n := binary.Uvarint(data[pos : pos+binary.MaxVarintLen64])
 	pos += n
 	for i := 0; i < int(numVecs); i++ {
@@ -146,6 +139,12 @@ func decodeSection(data []byte, start uint64) (int, int, map[int64]uint64, *fais
 		pos += n
 		vecDocIDMap[vecID] = docID
 	}
+
+	// read the index bytes
+	indexSize, n := binary.Uvarint(data[pos : pos+binary.MaxVarintLen64])
+	pos += n
+	indexBytes := data[pos : pos+int(indexSize)]
+	pos += int(indexSize)
 
 	vecIndex, err := faiss.ReadIndexFromBuffer(indexBytes, faiss.IOFlagReadOnly)
 	if err != nil {

--- a/faiss_vector_posting.go
+++ b/faiss_vector_posting.go
@@ -382,12 +382,6 @@ func (sb *SegmentBase) InterpretVectorIndex(field string) (segment.VectorIndex, 
 		pos += n
 	}
 
-	// todo: not a good idea to cache the vector index perhaps, since it could be quite huge.
-	indexSize, n := binary.Uvarint(sb.mem[pos : pos+binary.MaxVarintLen64])
-	pos += n
-	indexBytes := sb.mem[pos : pos+int(indexSize)]
-	pos += int(indexSize)
-
 	// read the number vectors indexed for this field and load the vector to docID mapping.
 	// todo: cache the vecID to docIDs mapping for a fieldID
 	numVecs, n := binary.Uvarint(sb.mem[pos : pos+binary.MaxVarintLen64])
@@ -399,6 +393,12 @@ func (sb *SegmentBase) InterpretVectorIndex(field string) (segment.VectorIndex, 
 		pos += n
 		vecDocIDMap[vecID] = uint32(docID)
 	}
+
+	// todo: not a good idea to cache the vector index perhaps, since it could be quite huge.
+	indexSize, n := binary.Uvarint(sb.mem[pos : pos+binary.MaxVarintLen64])
+	pos += n
+	indexBytes := sb.mem[pos : pos+int(indexSize)]
+	pos += int(indexSize)
 
 	vecIndex, err = faiss.ReadIndexFromBuffer(indexBytes, faiss.IOFlagReadOnly)
 	return wrapVecIndex, err

--- a/faiss_vector_test.go
+++ b/faiss_vector_test.go
@@ -318,16 +318,22 @@ func getSectionContentOffsets(sb *SegmentBase, offset uint64) (
 	_, n = binary.Uvarint(sb.mem[pos : pos+binary.MaxVarintLen64])
 	pos += uint64(n)
 
+	numVecs, n = binary.Uvarint(sb.mem[pos : pos+binary.MaxVarintLen64])
+	pos += uint64(n)
+
+	vecDocIDsMappingOffset = pos
+	for i := 0; i < int(numVecs); i++ {
+		_, n := binary.Varint(sb.mem[pos : pos+binary.MaxVarintLen64])
+		pos += uint64(n)
+		_, n = binary.Uvarint(sb.mem[pos : pos+binary.MaxVarintLen64])
+		pos += uint64(n)
+	}
+
 	indexBytesLen, n = binary.Uvarint(sb.mem[pos : pos+binary.MaxVarintLen64])
 	pos += uint64(n)
 
 	indexBytesOffset = pos
 	pos += indexBytesLen
-
-	numVecs, n = binary.Uvarint(sb.mem[pos : pos+binary.MaxVarintLen64])
-	pos += uint64(n)
-
-	vecDocIDsMappingOffset = pos
 
 	return docValueStart, docValueEnd, indexBytesLen, indexBytesOffset, numVecs, vecDocIDsMappingOffset
 }

--- a/section_faiss_vector_index.go
+++ b/section_faiss_vector_index.go
@@ -182,7 +182,6 @@ func (v *vectorIndexOpaque) flushSectionMetadata(fieldID int, w *CountHashWriter
 	vecToDocID map[int64]uint64, indexes []*vecIndexMeta) error {
 	tempBuf := v.grabBuf(binary.MaxVarintLen64)
 	if len(indexes) == 0 {
-		fmt.Println("its nil")
 		return nil
 	}
 	fieldStart := w.Count()


### PR DESCRIPTION
- Restructuring the code around merge path to help free the memory occupied by the vecToDocID better. 
- Using pointers to struct to avoid copying of values while ranging over the map during the introduction phase of code
- Tests performed on these were: 
    - Indexing 1M sift dataset vector content - merge paths are getting hit - no crashes etc. 
    - Querying on the built index - no crashes/faults observed over there 
    - Point mutations leading to merge segments without vector content with a vector content along with querying on this index to see the results - showing results as per expectations 
    - cmd tool parses the index file find 
    - force one last time to perform the same query - results as per expectation