### PR TITLE
MB-60914: Zap field specific metrics

### DIFF
--- a/faiss_vector_posting.go
+++ b/faiss_vector_posting.go
@@ -404,7 +404,7 @@ func (sb *SegmentBase) InterpretVectorIndex(field string) (segment.VectorIndex, 
 	return wrapVecIndex, err
 }
 
-func (sb *SegmentBase) UpdateFieldStats(stats map[string]map[string]int) {
+func (sb *SegmentBase) UpdateFieldStats(stats segment.FieldStats) {
 
 	for _, fieldName := range sb.fieldsInv {
 
@@ -413,15 +413,13 @@ func (sb *SegmentBase) UpdateFieldStats(stats map[string]map[string]int) {
 			continue
 		}
 
-		_, n := binary.Uvarint(sb.mem[pos : pos+binary.MaxVarintLen64])
-		pos += n
-		_, n = binary.Uvarint(sb.mem[pos : pos+binary.MaxVarintLen64])
-		pos += n
-		_, n = binary.Uvarint(sb.mem[pos : pos+binary.MaxVarintLen64])
-		pos += n
+		for i := 0; i < 3; i++ {
+			_, n := binary.Uvarint(sb.mem[pos : pos+binary.MaxVarintLen64])
+			pos += n
+		}
 
 		numVecs, _ := binary.Uvarint(sb.mem[pos : pos+binary.MaxVarintLen64])
 
-		stats["num_vectors"][fieldName] = int(numVecs)
+		stats.AddStat("num_vectors", fieldName, numVecs)
 	}
 }

--- a/faiss_vector_posting.go
+++ b/faiss_vector_posting.go
@@ -403,3 +403,25 @@ func (sb *SegmentBase) InterpretVectorIndex(field string) (segment.VectorIndex, 
 	vecIndex, err = faiss.ReadIndexFromBuffer(indexBytes, faiss.IOFlagReadOnly)
 	return wrapVecIndex, err
 }
+
+func (sb *SegmentBase) UpdateFieldStats(stats map[string]map[string]int) {
+
+	for _, fieldName := range sb.fieldsInv {
+
+		pos := int(sb.fieldsSectionsMap[sb.fieldsMap[fieldName]-1][SectionFaissVectorIndex])
+		if pos == 0 {
+			continue
+		}
+
+		_, n := binary.Uvarint(sb.mem[pos : pos+binary.MaxVarintLen64])
+		pos += n
+		_, n = binary.Uvarint(sb.mem[pos : pos+binary.MaxVarintLen64])
+		pos += n
+		_, n = binary.Uvarint(sb.mem[pos : pos+binary.MaxVarintLen64])
+		pos += n
+
+		numVecs, _ := binary.Uvarint(sb.mem[pos : pos+binary.MaxVarintLen64])
+
+		stats["num_vectors"][fieldName] = int(numVecs)
+	}
+}

--- a/faiss_vector_posting.go
+++ b/faiss_vector_posting.go
@@ -417,6 +417,6 @@ func (sb *SegmentBase) UpdateFieldStats(stats segment.FieldStats) {
 		}
 		numVecs, _ := binary.Uvarint(sb.mem[pos : pos+binary.MaxVarintLen64])
 
-		stats.Store(segment.NumVecsStat, fieldName, numVecs)
+		stats.Store("num_vectors", fieldName, numVecs)
 	}
 }

--- a/faiss_vector_posting.go
+++ b/faiss_vector_posting.go
@@ -405,9 +405,7 @@ func (sb *SegmentBase) InterpretVectorIndex(field string) (segment.VectorIndex, 
 }
 
 func (sb *SegmentBase) UpdateFieldStats(stats segment.FieldStats) {
-
 	for _, fieldName := range sb.fieldsInv {
-
 		pos := int(sb.fieldsSectionsMap[sb.fieldsMap[fieldName]-1][SectionFaissVectorIndex])
 		if pos == 0 {
 			continue
@@ -417,9 +415,8 @@ func (sb *SegmentBase) UpdateFieldStats(stats segment.FieldStats) {
 			_, n := binary.Uvarint(sb.mem[pos : pos+binary.MaxVarintLen64])
 			pos += n
 		}
-
 		numVecs, _ := binary.Uvarint(sb.mem[pos : pos+binary.MaxVarintLen64])
 
-		stats.AddStat("num_vectors", fieldName, numVecs)
+		stats.Store(segment.NumVecsStat, fieldName, numVecs)
 	}
 }

--- a/go.mod
+++ b/go.mod
@@ -7,7 +7,7 @@ require (
 	github.com/blevesearch/bleve_index_api v1.1.6
 	github.com/blevesearch/go-faiss v1.0.13
 	github.com/blevesearch/mmap-go v1.0.4
-	github.com/blevesearch/scorch_segment_api/v2 v2.2.8
+	github.com/blevesearch/scorch_segment_api/v2 v2.2.9
 	github.com/blevesearch/vellum v1.0.10
 	github.com/golang/snappy v0.0.1
 	github.com/spf13/cobra v1.7.0

--- a/go.sum
+++ b/go.sum
@@ -8,8 +8,8 @@ github.com/blevesearch/go-faiss v1.0.13 h1:zfFs7ZYD0NqXVSY37j0JZjZT1BhE9AE4peJfc
 github.com/blevesearch/go-faiss v1.0.13/go.mod h1:jrxHrbl42X/RnDPI+wBoZU8joxxuRwedrxqswQ3xfU8=
 github.com/blevesearch/mmap-go v1.0.4 h1:OVhDhT5B/M1HNPpYPBKIEJaD0F3Si+CrEKULGCDPWmc=
 github.com/blevesearch/mmap-go v1.0.4/go.mod h1:EWmEAOmdAS9z/pi/+Toxu99DnsbhG1TIxUoRmJw/pSs=
-github.com/blevesearch/scorch_segment_api/v2 v2.2.8 h1:+OLW38LuRKio6N6V0gIk1srwFz79FJ5v2sNqHz2HVAA=
-github.com/blevesearch/scorch_segment_api/v2 v2.2.8/go.mod h1:ckbeb7knyOOvAdZinn/ASbB7EA3HoagnJkmEV3J7+sg=
+github.com/blevesearch/scorch_segment_api/v2 v2.2.9 h1:3nBaSBRFokjE4FtPW3eUDgcAu3KphBg1GP07zy/6Uyk=
+github.com/blevesearch/scorch_segment_api/v2 v2.2.9/go.mod h1:ckbeb7knyOOvAdZinn/ASbB7EA3HoagnJkmEV3J7+sg=
 github.com/blevesearch/vellum v1.0.10 h1:HGPJDT2bTva12hrHepVT3rOyIKFFF4t7Gf6yMxyMIPI=
 github.com/blevesearch/vellum v1.0.10/go.mod h1:ul1oT0FhSMDIExNjIxHqJoGpVrBpKCdgDQNxfqgJt7k=
 github.com/cpuguy83/go-md2man/v2 v2.0.2/go.mod h1:tgQtvFlXSQOSOSIRvRPT7W67SCa46tRHOmNcaadrF8o=


### PR DESCRIPTION
 - Added an UpdateFieldStats function which will populate the passed map with any field related metrics
 - The map is expected to be already initialized with the appropriate metric names
 - As of now, the only metric added is num_vectors which is obtained by looking at its appropriate field section data
 - This call also is only necessary after a merge because otherwise we can obtain it from the analysis results.
 - With the inclusion of UpdateFieldStats, SegmentBase will now implement the FieldStatsReporter defined in scorch_segment_api