### PR TITLE
MB-61029: Deferring the closing of vector index

### DIFF
--- a/build.go
+++ b/build.go
@@ -175,6 +175,9 @@ func InitSegmentBase(mem []byte, memCRC uint32, chunkMode uint32,
 		docValueOffset:      0, // docValueOffsets identified automatically by the section
 		dictLocs:            dictLocs,
 		fieldFSTs:           make(map[uint16]*vellum.FST),
+		vectorCache: &vecCache{
+			cache: make(map[uint16]*cacheEntry),
+		},
 	}
 	sb.updateSize()
 

--- a/build.go
+++ b/build.go
@@ -175,7 +175,7 @@ func InitSegmentBase(mem []byte, memCRC uint32, chunkMode uint32,
 		docValueOffset:      0, // docValueOffsets identified automatically by the section
 		dictLocs:            dictLocs,
 		fieldFSTs:           make(map[uint16]*vellum.FST),
-		vectorCache:         newVectorCache(),
+		vectorCache:         newVectorIndexCache(),
 	}
 	sb.updateSize()
 

--- a/build.go
+++ b/build.go
@@ -175,7 +175,7 @@ func InitSegmentBase(mem []byte, memCRC uint32, chunkMode uint32,
 		docValueOffset:      0, // docValueOffsets identified automatically by the section
 		dictLocs:            dictLocs,
 		fieldFSTs:           make(map[uint16]*vellum.FST),
-		vectorCache:         newVectorIndexCache(),
+		vecIndexCache:       newVectorIndexCache(),
 	}
 	sb.updateSize()
 

--- a/build.go
+++ b/build.go
@@ -175,9 +175,7 @@ func InitSegmentBase(mem []byte, memCRC uint32, chunkMode uint32,
 		docValueOffset:      0, // docValueOffsets identified automatically by the section
 		dictLocs:            dictLocs,
 		fieldFSTs:           make(map[uint16]*vellum.FST),
-		vectorCache: &vecCache{
-			cache: make(map[uint16]*cacheEntry),
-		},
+		vectorCache:         newVectorCache(),
 	}
 	sb.updateSize()
 

--- a/faiss_vector_cache.go
+++ b/faiss_vector_cache.go
@@ -26,8 +26,9 @@ import (
 )
 
 type vecCache struct {
-	m     sync.RWMutex
-	cache map[uint16]*cacheEntry
+	closeCh chan struct{}
+	m       sync.RWMutex
+	cache   map[uint16]*cacheEntry
 }
 
 type ewma struct {
@@ -37,8 +38,7 @@ type ewma struct {
 }
 
 type cacheEntry struct {
-	cacheMonitor *ewma
-	closeCh      chan struct{}
+	tracker *ewma
 
 	m     sync.RWMutex
 	index *faiss.IndexImpl
@@ -52,13 +52,10 @@ func newVectorCache() *vecCache {
 
 func (vc *vecCache) Clear() {
 	vc.m.Lock()
-	defer vc.m.Unlock()
+	close(vc.closeCh)
+	vc.cache = nil
+	vc.m.Unlock()
 
-	// close every cache monitor in the cache, thereby closing the index
-	// cached as well.
-	for _, c := range vc.cache {
-		close(c.closeCh)
-	}
 }
 
 func (vc *vecCache) checkCacheForVecIndex(fieldID uint16,
@@ -88,15 +85,6 @@ func (vc *vecCache) isVecIndexCached(fieldID uint16) (*faiss.IndexImpl, bool) {
 	rv := entry.index
 	entry.m.RUnlock()
 
-	// the following cleanup is when the index is closed as part of cacheEntry.closeIndex()
-	// but the corresponding field entry in the vecCache is not cleaned up
-	// fixme: this looks ugly must be refactored in a better way.
-	if rv == nil {
-		vc.m.Lock()
-		delete(vc.cache, fieldID)
-		vc.m.Unlock()
-	}
-
 	return rv, present && (rv != nil)
 }
 
@@ -108,15 +96,74 @@ func (vc *vecCache) addRef(fieldIDPlus1 uint16) {
 	entry.addRef()
 }
 
+func (vc *vecCache) clearField(fieldIDPlus1 uint16) {
+	vc.m.Lock()
+	delete(vc.cache, fieldIDPlus1)
+	vc.m.Unlock()
+}
+
+func (vc *vecCache) refreshEntries() (rv int) {
+	vc.m.RLock()
+	cache := vc.cache
+	vc.m.RUnlock()
+
+	defer func() {
+		vc.m.RLock()
+		rv = len(vc.cache)
+		vc.m.RUnlock()
+	}()
+
+	// for every field reconcile the average with the current sample values
+	for fieldIDPlus1, entry := range cache {
+		sample := atomic.LoadUint64(&entry.tracker.sample)
+		entry.tracker.add(sample)
+		// the comparison threshold as of now is (1 - a). mathematically it
+		// means that there is only 1 query per second on average as per history.
+		// and in the current second, there were no queries performed against
+		// this index.
+		if entry.tracker.avg <= (1 - entry.tracker.alpha) {
+			atomic.StoreUint64(&entry.tracker.sample, 0)
+			entry.closeIndex()
+			vc.clearField(fieldIDPlus1)
+			continue
+		}
+		atomic.StoreUint64(&entry.tracker.sample, 0)
+	}
+	return
+}
+
+func (vc *vecCache) monitor() {
+	ticker := time.NewTicker(1 * time.Second)
+	for {
+		select {
+		case <-vc.closeCh:
+			return
+		case <-ticker.C:
+			numEntries := vc.refreshEntries()
+			if numEntries == 0 {
+				// no entries to be monitored, exit
+				return
+			}
+		}
+	}
+}
+
 func (vc *vecCache) update(fieldIDPlus1 uint16, index *faiss.IndexImpl) {
 	vc.m.Lock()
+
+	// the first time we've hit the cache, try to spawn a monitoring routine
+	// which will reconcile the moving averages for all the fields being hit
+	if len(vc.cache) == 0 {
+		go vc.monitor()
+	}
+
 	_, ok := vc.cache[fieldIDPlus1]
 	if !ok {
-		// initializing the alpha with 0.3 essentially means that we are favoring
-		// the history a little bit more relative to the current sample value.
-		// this makes the average to be kept above the threshold value for a
-		// longer time and thereby the index to be resident in the cache
-		// for longer time.
+		//  initializing the alpha with 0.4 essentially means that we are favoring
+		// 	the history a little bit more relative to the current sample value.
+		// 	this makes the average to be kept above the threshold value for a
+		// 	longer time and thereby the index to be resident in the cache
+		// 	for longer time.
 		vc.cache[fieldIDPlus1] = initCacheEntry(index, 0.4)
 	}
 	vc.m.Unlock()
@@ -134,14 +181,12 @@ func (e *ewma) add(val uint64) {
 
 func initCacheEntry(index *faiss.IndexImpl, alpha float64) *cacheEntry {
 	vc := &cacheEntry{
-		index:        index,
-		closeCh:      make(chan struct{}),
-		cacheMonitor: &ewma{},
+		index:   index,
+		tracker: &ewma{},
 	}
-	vc.cacheMonitor.alpha = alpha
-	go vc.monitor()
+	vc.tracker.alpha = alpha
 
-	atomic.StoreUint64(&vc.cacheMonitor.sample, 1)
+	atomic.StoreUint64(&vc.tracker.sample, 1)
 	return vc
 }
 
@@ -149,7 +194,7 @@ func (vc *cacheEntry) addRef() {
 	// every access to the cache entry is accumulated as part of a sample
 	// which will be used to calculate the average in the next cycle of average
 	// computation
-	atomic.AddUint64(&vc.cacheMonitor.sample, 1)
+	atomic.AddUint64(&vc.tracker.sample, 1)
 }
 
 func (vc *cacheEntry) closeIndex() {
@@ -157,33 +202,4 @@ func (vc *cacheEntry) closeIndex() {
 	vc.index.Close()
 	vc.index = nil
 	vc.m.Unlock()
-}
-
-func (vc *cacheEntry) monitor() {
-	// a timer to determing the frequency at which exponentially weighted
-	// moving average is computed
-	ticker := time.NewTicker(1 * time.Second)
-	var sample uint64
-	for {
-		select {
-		case <-vc.closeCh:
-			vc.closeIndex()
-			return
-		case <-ticker.C:
-			sample = atomic.LoadUint64(&vc.cacheMonitor.sample)
-			vc.cacheMonitor.add(sample)
-			// the comparison threshold as of now is (1 - a). mathematically it
-			// means that there is only 1 query per second on average as per history.
-			// and in the current second, there were no queries performed against
-			// this index.
-			// todo: threshold needs better experimentation. affects the time for
-			// which the index is resident in the cache.
-			if vc.cacheMonitor.avg <= (1 - vc.cacheMonitor.alpha) {
-				atomic.StoreUint64(&vc.cacheMonitor.sample, 0)
-				vc.closeIndex()
-				return
-			}
-			atomic.StoreUint64(&vc.cacheMonitor.sample, 0)
-		}
-	}
 }

--- a/faiss_vector_cache.go
+++ b/faiss_vector_cache.go
@@ -1,0 +1,186 @@
+//  Copyright (c) 2024 Couchbase, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// 		http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//go:build vectors
+// +build vectors
+
+package zap
+
+import (
+	"sync"
+	"sync/atomic"
+	"time"
+
+	faiss "github.com/blevesearch/go-faiss"
+)
+
+type vecCache struct {
+	m     sync.RWMutex
+	cache map[uint16]*cacheEntry
+}
+
+type ewma struct {
+	alpha  float64
+	avg    float64
+	sample uint64
+}
+
+type cacheEntry struct {
+	cacheMonitor *ewma
+	closeCh      chan struct{}
+
+	m     sync.RWMutex
+	index *faiss.IndexImpl
+}
+
+func (vc *vecCache) Clear() {
+	vc.m.Lock()
+	defer vc.m.Unlock()
+
+	// close every cache monitor in the cache, thereby closing the index
+	// cached as well.
+	for _, c := range vc.cache {
+		close(c.closeCh)
+	}
+}
+
+func (vc *vecCache) checkCacheForVecIndex(fieldID uint16,
+	indexBytes []byte) (vecIndex *faiss.IndexImpl, err error) {
+	cachedIndex, present := vc.isVecIndexCached(fieldID)
+	if present {
+		vecIndex = cachedIndex
+		vc.addRef(fieldID)
+	} else {
+		// if the cache doesn't have vector index, just construct it out of the
+		// index bytes and update the cache.
+		vecIndex, err = faiss.ReadIndexFromBuffer(indexBytes, faiss.IOFlagReadOnly)
+		vc.update(fieldID, vecIndex)
+	}
+	return vecIndex, err
+}
+
+func (vc *vecCache) isVecIndexCached(fieldID uint16) (*faiss.IndexImpl, bool) {
+	vc.m.RLock()
+	entry, present := vc.cache[fieldID]
+	vc.m.RUnlock()
+	if entry == nil {
+		return nil, false
+	}
+
+	entry.m.RLock()
+	rv := entry.index
+	entry.m.RUnlock()
+
+	// the following cleanup is when the index is closed as part of cacheEntry.closeIndex()
+	// but the corresponding field entry in the vecCache is not cleaned up
+	// fixme: this looks ugly must be refactored in a better way.
+	if rv == nil {
+		vc.m.Lock()
+		delete(vc.cache, fieldID)
+		vc.m.Unlock()
+	}
+
+	return rv, present && (rv != nil)
+}
+
+func (vc *vecCache) addRef(fieldIDPlus1 uint16) {
+	vc.m.RLock()
+	entry := vc.cache[fieldIDPlus1]
+	vc.m.RUnlock()
+
+	entry.addRef()
+}
+
+func (vc *vecCache) update(fieldIDPlus1 uint16, index *faiss.IndexImpl) {
+	vc.m.Lock()
+	_, ok := vc.cache[fieldIDPlus1]
+	if !ok {
+		// initializing the alpha with 0.3 essentially means that we are favoring
+		// the history a little bit more relative to the current sample value.
+		// this makes the average to be kept above the threshold value for a
+		// longer time and thereby the index to be resident in the cache
+		// for longer time.
+		// todo: alpha to be experimented with different values
+		vc.cache[fieldIDPlus1] = initCacheEntry(index, 0.3)
+	}
+	vc.m.Unlock()
+}
+
+func (e *ewma) add(val uint64) {
+	if e.avg == 0.0 {
+		e.avg = float64(val)
+	} else {
+		// the exponentially weighted moving average
+		// X(t) = a.v + (1 - a).X(t-1)
+		e.avg = e.alpha*float64(val) + (1-e.alpha)*e.avg
+	}
+}
+
+func initCacheEntry(index *faiss.IndexImpl, alpha float64) *cacheEntry {
+	vc := &cacheEntry{
+		index:        index,
+		closeCh:      make(chan struct{}),
+		cacheMonitor: &ewma{},
+	}
+	vc.cacheMonitor.alpha = alpha
+	go vc.monitor()
+
+	// initing the sample to be 16 for now. more like a cold start to the monitor
+	// with a large enough value so that we don't immediately evict the index
+	atomic.StoreUint64(&vc.cacheMonitor.sample, 16)
+	return vc
+}
+
+func (vc *cacheEntry) addRef() {
+	// every access to the cache entry is accumulated as part of a sample
+	// which will be used to calculate the average in the next cycle of average
+	// computation
+	atomic.AddUint64(&vc.cacheMonitor.sample, 1)
+}
+
+func (vc *cacheEntry) closeIndex() {
+	vc.m.Lock()
+	vc.index.Close()
+	vc.index = nil
+	vc.m.Unlock()
+}
+
+func (vc *cacheEntry) monitor() {
+	// a timer to determing the frequency at which exponentially weighted
+	// moving average is computed
+	ticker := time.NewTicker(1 * time.Second)
+	var sample uint64
+	for {
+		select {
+		case <-vc.closeCh:
+			vc.closeIndex()
+			return
+		case <-ticker.C:
+			sample = atomic.LoadUint64(&vc.cacheMonitor.sample)
+			vc.cacheMonitor.add(sample)
+			// the comparison threshold as of now is (1 - a). mathematically it
+			// means that there is only 1 query per second on average as per history.
+			// and in the current second, there were no queries performed against
+			// this index.
+			// todo: threshold needs better experimentation. affects the time for
+			// which the index is resident in the cache.
+			if vc.cacheMonitor.avg <= (1 - vc.cacheMonitor.alpha) {
+				atomic.StoreUint64(&vc.cacheMonitor.sample, 0)
+				vc.closeIndex()
+				return
+			}
+			atomic.StoreUint64(&vc.cacheMonitor.sample, 0)
+		}
+	}
+}

--- a/faiss_vector_cache.go
+++ b/faiss_vector_cache.go
@@ -117,8 +117,7 @@ func (vc *vecCache) update(fieldIDPlus1 uint16, index *faiss.IndexImpl) {
 		// this makes the average to be kept above the threshold value for a
 		// longer time and thereby the index to be resident in the cache
 		// for longer time.
-		// todo: alpha to be experimented with different values
-		vc.cache[fieldIDPlus1] = initCacheEntry(index, 0.3)
+		vc.cache[fieldIDPlus1] = initCacheEntry(index, 0.4)
 	}
 	vc.m.Unlock()
 }
@@ -142,9 +141,7 @@ func initCacheEntry(index *faiss.IndexImpl, alpha float64) *cacheEntry {
 	vc.cacheMonitor.alpha = alpha
 	go vc.monitor()
 
-	// initing the sample to be 16 for now. more like a cold start to the monitor
-	// with a large enough value so that we don't immediately evict the index
-	atomic.StoreUint64(&vc.cacheMonitor.sample, 16)
+	atomic.StoreUint64(&vc.cacheMonitor.sample, 1)
 	return vc
 }
 

--- a/faiss_vector_cache.go
+++ b/faiss_vector_cache.go
@@ -44,6 +44,12 @@ type cacheEntry struct {
 	index *faiss.IndexImpl
 }
 
+func newVectorCache() *vecCache {
+	return &vecCache{
+		cache: make(map[uint16]*cacheEntry),
+	}
+}
+
 func (vc *vecCache) Clear() {
 	vc.m.Lock()
 	defer vc.m.Unlock()

--- a/faiss_vector_cache.go
+++ b/faiss_vector_cache.go
@@ -40,9 +40,7 @@ type ewma struct {
 type cacheEntry struct {
 	tracker *ewma
 	refs    int64
-
-	m     sync.RWMutex
-	index *faiss.IndexImpl
+	index   *faiss.IndexImpl
 }
 
 func newVectorIndexCache() *vecIndexCache {
@@ -82,10 +80,8 @@ func (vc *vecIndexCache) createAndCacheVectorIndex(fieldID uint16,
 	// cached.
 	entry, present := vc.cache[fieldID]
 	if present {
-		entry.m.RLock()
 		rv := entry.index
 		entry.incHit()
-		entry.m.RUnlock()
 		return rv, nil
 	}
 
@@ -121,10 +117,7 @@ func (vc *vecIndexCache) isIndexCached(fieldID uint16) (*faiss.IndexImpl, bool) 
 		return nil, false
 	}
 
-	entry.m.RLock()
 	rv := entry.index
-	entry.m.RUnlock()
-
 	return rv, present && (rv != nil)
 }
 
@@ -230,8 +223,6 @@ func (vc *cacheEntry) decRef() {
 }
 
 func (vc *cacheEntry) closeIndex() {
-	vc.m.Lock()
 	vc.index.Close()
 	vc.index = nil
-	vc.m.Unlock()
 }

--- a/faiss_vector_cache.go
+++ b/faiss_vector_cache.go
@@ -149,7 +149,7 @@ func (vc *vecIndexCache) decRef(fieldIDPlus1 uint16) {
 	vc.m.RUnlock()
 }
 
-func (vc *vecIndexCache) refresh() (rv int) {
+func (vc *vecIndexCache) refresh() bool {
 	vc.m.Lock()
 	cache := vc.cache
 
@@ -172,7 +172,7 @@ func (vc *vecIndexCache) refresh() (rv int) {
 		atomic.StoreUint64(&entry.tracker.sample, 0)
 	}
 
-	rv = len(vc.cache)
+	rv := len(vc.cache) == 0
 	vc.m.Unlock()
 	return rv
 }
@@ -184,8 +184,8 @@ func (vc *vecIndexCache) monitor() {
 		case <-vc.closeCh:
 			return
 		case <-ticker.C:
-			numEntries := vc.refresh()
-			if numEntries == 0 {
+			exit := vc.refresh()
+			if exit {
 				// no entries to be monitored, exit
 				return
 			}

--- a/faiss_vector_cache.go
+++ b/faiss_vector_cache.go
@@ -46,7 +46,8 @@ type cacheEntry struct {
 
 func newVectorCache() *vecCache {
 	return &vecCache{
-		cache: make(map[uint16]*cacheEntry),
+		cache:   make(map[uint16]*cacheEntry),
+		closeCh: make(chan struct{}),
 	}
 }
 

--- a/faiss_vector_cache_noop.go
+++ b/faiss_vector_cache_noop.go
@@ -17,15 +17,11 @@
 
 package zap
 
-import (
-	"sync"
-)
-
 type vecCache struct {
-	m     sync.RWMutex
-	cache map[uint16]*cacheEntry
+}
+
+func newVectorCache() *vecCache {
+	return nil
 }
 
 func (v *vecCache) Clear() {}
-
-type cacheEntry struct{}

--- a/faiss_vector_cache_noop.go
+++ b/faiss_vector_cache_noop.go
@@ -1,0 +1,31 @@
+//  Copyright (c) 2024 Couchbase, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// 		http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//go:build !vectors
+// +build !vectors
+
+package zap
+
+import (
+	"sync"
+)
+
+type vecCache struct {
+	m     sync.RWMutex
+	cache map[uint16]*cacheEntry
+}
+
+func (v *vecCache) Clear() {}
+
+type cacheEntry struct{}

--- a/faiss_vector_cache_nosup.go
+++ b/faiss_vector_cache_nosup.go
@@ -17,11 +17,11 @@
 
 package zap
 
-type vecIndexCache struct {
+type vectorIndexCache struct {
 }
 
-func newVectorIndexCache() *vecIndexCache {
+func newVectorIndexCache() *vectorIndexCache {
 	return nil
 }
 
-func (v *vecIndexCache) Clear() {}
+func (v *vectorIndexCache) Clear() {}

--- a/faiss_vector_cache_nosup.go
+++ b/faiss_vector_cache_nosup.go
@@ -17,11 +17,11 @@
 
 package zap
 
-type vecCache struct {
+type vecIndexCache struct {
 }
 
-func newVectorCache() *vecCache {
+func newVectorIndexCache() *vecIndexCache {
 	return nil
 }
 
-func (v *vecCache) Clear() {}
+func (v *vecIndexCache) Clear() {}

--- a/faiss_vector_posting.go
+++ b/faiss_vector_posting.go
@@ -296,6 +296,7 @@ func (sb *SegmentBase) InterpretVectorIndex(field string, except *roaring.Bitmap
 	vecDocIDMap := make(map[int64]uint32)
 	var vectorIDsToExclude []int64
 	var fieldIDPlus1 uint16
+	var vecIndexSize uint64
 
 	var (
 		wrapVecIndex = &vectorIndexWrapper{
@@ -341,10 +342,7 @@ func (sb *SegmentBase) InterpretVectorIndex(field string, except *roaring.Bitmap
 				sb.vectorCache.decRef(fieldIDPlus1)
 			},
 			size: func() uint64 {
-				if vecIndex != nil {
-					return vecIndex.Size()
-				}
-				return 0
+				return vecIndexSize
 			},
 		}
 
@@ -399,6 +397,9 @@ func (sb *SegmentBase) InterpretVectorIndex(field string, except *roaring.Bitmap
 	vecIndex, err = sb.vectorCache.loadVectorIndex(fieldIDPlus1, sb.mem[pos:pos+int(indexSize)])
 	pos += int(indexSize)
 
+	if vecIndex != nil {
+		vecIndexSize = vecIndex.Size()
+	}
 	return wrapVecIndex, err
 }
 

--- a/faiss_vector_posting.go
+++ b/faiss_vector_posting.go
@@ -339,7 +339,7 @@ func (sb *SegmentBase) InterpretVectorIndex(field string, except *roaring.Bitmap
 			close: func() {
 				// skipping the closing because the index is cached and it's being
 				// deferred to a later point of time.
-				sb.vectorCache.decRef(fieldIDPlus1)
+				sb.vecIndexCache.decRef(fieldIDPlus1)
 			},
 			size: func() uint64 {
 				return vecIndexSize
@@ -394,7 +394,7 @@ func (sb *SegmentBase) InterpretVectorIndex(field string, except *roaring.Bitmap
 	indexSize, n := binary.Uvarint(sb.mem[pos : pos+binary.MaxVarintLen64])
 	pos += n
 
-	vecIndex, err = sb.vectorCache.loadVectorIndex(fieldIDPlus1, sb.mem[pos:pos+int(indexSize)])
+	vecIndex, err = sb.vecIndexCache.loadVectorIndex(fieldIDPlus1, sb.mem[pos:pos+int(indexSize)])
 	pos += int(indexSize)
 
 	if vecIndex != nil {

--- a/faiss_vector_posting.go
+++ b/faiss_vector_posting.go
@@ -335,9 +335,8 @@ func (sb *SegmentBase) InterpretVectorIndex(field string, except *roaring.Bitmap
 				return rv, nil
 			},
 			close: func() {
-				if vecIndex != nil {
-					vecIndex.Close()
-				}
+				// skipping the closing for now because the index is cached
+				// todo: subjected to change based on a optimization type flag
 			},
 			size: func() uint64 {
 				if vecIndex != nil {
@@ -392,13 +391,14 @@ func (sb *SegmentBase) InterpretVectorIndex(field string, except *roaring.Bitmap
 		vecDocIDMap[vecID] = docIDUint32
 	}
 
-	// todo: not a good idea to cache the vector index perhaps, since it could be quite huge.
 	indexSize, n := binary.Uvarint(sb.mem[pos : pos+binary.MaxVarintLen64])
 	pos += n
-	indexBytes := sb.mem[pos : pos+int(indexSize)]
+
+	// todo: whether to cache the index or not can be determined by using the
+	// index optimization type flag.
+	vecIndex, err = sb.vectorCache.checkCacheForVecIndex(fieldIDPlus1, sb.mem[pos:pos+int(indexSize)])
 	pos += int(indexSize)
 
-	vecIndex, err = faiss.ReadIndexFromBuffer(indexBytes, faiss.IOFlagReadOnly)
 	return wrapVecIndex, err
 }
 

--- a/faiss_vector_posting.go
+++ b/faiss_vector_posting.go
@@ -335,8 +335,8 @@ func (sb *SegmentBase) InterpretVectorIndex(field string, except *roaring.Bitmap
 				return rv, nil
 			},
 			close: func() {
-				// skipping the closing for now because the index is cached
-				// todo: subjected to change based on a optimization type flag
+				// skipping the closing because the index is cached and it's being
+				// deferred to a later point of time.
 			},
 			size: func() uint64 {
 				if vecIndex != nil {
@@ -394,9 +394,7 @@ func (sb *SegmentBase) InterpretVectorIndex(field string, except *roaring.Bitmap
 	indexSize, n := binary.Uvarint(sb.mem[pos : pos+binary.MaxVarintLen64])
 	pos += n
 
-	// todo: whether to cache the index or not can be determined by using the
-	// index optimization type flag.
-	vecIndex, err = sb.vectorCache.checkCacheForVecIndex(fieldIDPlus1, sb.mem[pos:pos+int(indexSize)])
+	vecIndex, err = sb.vectorCache.loadVectorIndex(fieldIDPlus1, sb.mem[pos:pos+int(indexSize)])
 	pos += int(indexSize)
 
 	return wrapVecIndex, err

--- a/faiss_vector_posting.go
+++ b/faiss_vector_posting.go
@@ -295,6 +295,7 @@ func (sb *SegmentBase) InterpretVectorIndex(field string, except *roaring.Bitmap
 	var vecIndex *faiss.IndexImpl
 	vecDocIDMap := make(map[int64]uint32)
 	var vectorIDsToExclude []int64
+	var fieldIDPlus1 uint16
 
 	var (
 		wrapVecIndex = &vectorIndexWrapper{
@@ -337,6 +338,7 @@ func (sb *SegmentBase) InterpretVectorIndex(field string, except *roaring.Bitmap
 			close: func() {
 				// skipping the closing because the index is cached and it's being
 				// deferred to a later point of time.
+				sb.vectorCache.decRef(fieldIDPlus1)
 			},
 			size: func() uint64 {
 				if vecIndex != nil {
@@ -349,7 +351,7 @@ func (sb *SegmentBase) InterpretVectorIndex(field string, except *roaring.Bitmap
 		err error
 	)
 
-	fieldIDPlus1 := sb.fieldsMap[field]
+	fieldIDPlus1 = sb.fieldsMap[field]
 	if fieldIDPlus1 <= 0 {
 		return wrapVecIndex, nil
 	}

--- a/segment.go
+++ b/segment.go
@@ -55,7 +55,7 @@ func (*ZapPlugin) Open(path string) (segment.Segment, error) {
 		SegmentBase: SegmentBase{
 			fieldsMap:      make(map[string]uint16),
 			fieldFSTs:      make(map[uint16]*vellum.FST),
-			vectorCache:    newVectorIndexCache(),
+			vecIndexCache:  newVectorIndexCache(),
 			fieldDvReaders: make([]map[uint16]*docValueReader, len(segmentSections)),
 		},
 		f:    f,
@@ -111,9 +111,8 @@ type SegmentBase struct {
 	m         sync.Mutex
 	fieldFSTs map[uint16]*vellum.FST
 
-	// fixme: although the operations and APIs of the vecCache is hidden under
-	// the vectors tag, the type should also perhaps be under the vectors tag.
-	vectorCache *vecIndexCache
+	// this cache comes into play when vectors are supported in builds.
+	vecIndexCache *vectorIndexCache
 }
 
 func (sb *SegmentBase) Size() int {
@@ -150,7 +149,7 @@ func (sb *SegmentBase) updateSize() {
 
 func (sb *SegmentBase) AddRef()             {}
 func (sb *SegmentBase) DecRef() (err error) { return nil }
-func (sb *SegmentBase) Close() (err error)  { sb.vectorCache.Clear(); return nil }
+func (sb *SegmentBase) Close() (err error)  { sb.vecIndexCache.Clear(); return nil }
 
 // Segment implements a persisted segment.Segment interface, by
 // embedding an mmap()'ed SegmentBase.
@@ -644,7 +643,7 @@ func (s *Segment) closeActual() (err error) {
 			err = err2
 		}
 	}
-	s.vectorCache.Clear()
+	s.vecIndexCache.Clear()
 	return
 }
 

--- a/segment.go
+++ b/segment.go
@@ -632,6 +632,9 @@ func (s *Segment) Close() (err error) {
 }
 
 func (s *Segment) closeActual() (err error) {
+	// clear contents from the vector index cache before un-mmapping
+	s.vecIndexCache.Clear()
+
 	if s.mm != nil {
 		err = s.mm.Unmap()
 	}
@@ -643,7 +646,7 @@ func (s *Segment) closeActual() (err error) {
 			err = err2
 		}
 	}
-	s.vecIndexCache.Clear()
+
 	return
 }
 

--- a/segment.go
+++ b/segment.go
@@ -53,11 +53,9 @@ func (*ZapPlugin) Open(path string) (segment.Segment, error) {
 
 	rv := &Segment{
 		SegmentBase: SegmentBase{
-			fieldsMap: make(map[string]uint16),
-			fieldFSTs: make(map[uint16]*vellum.FST),
-			vectorCache: &vecCache{
-				cache: make(map[uint16]*cacheEntry),
-			},
+			fieldsMap:      make(map[string]uint16),
+			fieldFSTs:      make(map[uint16]*vellum.FST),
+			vectorCache:    newVectorCache(),
 			fieldDvReaders: make([]map[uint16]*docValueReader, len(segmentSections)),
 		},
 		f:    f,

--- a/segment.go
+++ b/segment.go
@@ -55,7 +55,7 @@ func (*ZapPlugin) Open(path string) (segment.Segment, error) {
 		SegmentBase: SegmentBase{
 			fieldsMap:      make(map[string]uint16),
 			fieldFSTs:      make(map[uint16]*vellum.FST),
-			vectorCache:    newVectorCache(),
+			vectorCache:    newVectorIndexCache(),
 			fieldDvReaders: make([]map[uint16]*docValueReader, len(segmentSections)),
 		},
 		f:    f,
@@ -113,7 +113,7 @@ type SegmentBase struct {
 
 	// fixme: although the operations and APIs of the vecCache is hidden under
 	// the vectors tag, the type should also perhaps be under the vectors tag.
-	vectorCache *vecCache
+	vectorCache *vecIndexCache
 }
 
 func (sb *SegmentBase) Size() int {

--- a/segment.go
+++ b/segment.go
@@ -53,8 +53,11 @@ func (*ZapPlugin) Open(path string) (segment.Segment, error) {
 
 	rv := &Segment{
 		SegmentBase: SegmentBase{
-			fieldsMap:      make(map[string]uint16),
-			fieldFSTs:      make(map[uint16]*vellum.FST),
+			fieldsMap: make(map[string]uint16),
+			fieldFSTs: make(map[uint16]*vellum.FST),
+			vectorCache: &vecCache{
+				cache: make(map[uint16]*cacheEntry),
+			},
 			fieldDvReaders: make([]map[uint16]*docValueReader, len(segmentSections)),
 		},
 		f:    f,
@@ -81,7 +84,6 @@ func (*ZapPlugin) Open(path string) (segment.Segment, error) {
 		_ = rv.Close()
 		return nil, err
 	}
-
 	return rv, nil
 }
 
@@ -110,6 +112,10 @@ type SegmentBase struct {
 
 	m         sync.Mutex
 	fieldFSTs map[uint16]*vellum.FST
+
+	// fixme: although the operations and APIs of the vecCache is hidden under
+	// the vectors tag, the type should also perhaps be under the vectors tag.
+	vectorCache *vecCache
 }
 
 func (sb *SegmentBase) Size() int {
@@ -146,7 +152,7 @@ func (sb *SegmentBase) updateSize() {
 
 func (sb *SegmentBase) AddRef()             {}
 func (sb *SegmentBase) DecRef() (err error) { return nil }
-func (sb *SegmentBase) Close() (err error)  { return nil }
+func (sb *SegmentBase) Close() (err error)  { sb.vectorCache.Clear(); return nil }
 
 // Segment implements a persisted segment.Segment interface, by
 // embedding an mmap()'ed SegmentBase.
@@ -640,6 +646,7 @@ func (s *Segment) closeActual() (err error) {
 			err = err2
 		}
 	}
+	s.vectorCache.Clear()
 	return
 }
 


### PR DESCRIPTION
- Uses the exponentially weighted moving average to get the average hits on a particular field (thereby a particular vector index). The index stays in the memory when the average of the hits is above a certain threshold and below which the index is closed and the memory is freed for reuse on C side of things.
- This ensures that we are not keeping the index in the memory even when there is no query workload on the field in a segment so the memory pressure does get reduced on the C side of operations.
