### PR TITLE
Use of IVF with HNSW32 coarse quantizer

### DIFF
--- a/section_faiss_vector_index.go
+++ b/section_faiss_vector_index.go
@@ -458,6 +458,8 @@ const (
 // and an index type.
 func determineIndexToUse(nvecs, nlist int) (string, int) {
 	switch {
+	case nvecs >= 100000:
+		return fmt.Sprintf("IVF%d_HNSW32,SQ8", nlist), IndexTypeIVF
 	case nvecs >= 10000:
 		return fmt.Sprintf("IVF%d,SQ8", nlist), IndexTypeIVF
 	case nvecs >= 1000:


### PR DESCRIPTION
Bringing back the coarse quantizer into use per observations Aditi recorded earlier. A slight adjustment now is to deploy it only over a vector count of 100000.