### PR TITLE
MB-62167: Fix windows crash

### DIFF
--- a/faiss_vector_cache.go
+++ b/faiss_vector_cache.go
@@ -118,8 +118,7 @@ func (vc *vectorIndexCache) createAndCache(fieldID uint16, mem []byte, except *r
 	indexSize, n := binary.Uvarint(mem[pos : pos+binary.MaxVarintLen64])
 	pos += n
 
-	index, err = faiss.ReadIndexFromBuffer(mem[pos:pos+int(indexSize)],
-		faiss.IOFlagReadMmap|faiss.IOFlagSkipPrefetch)
+	index, err = faiss.ReadIndexFromBuffer(mem[pos:pos+int(indexSize)], vectorIndexIOFlags)
 	if err != nil {
 		return nil, nil, nil, err
 	}

--- a/faiss_vector_cache.go
+++ b/faiss_vector_cache.go
@@ -118,7 +118,7 @@ func (vc *vectorIndexCache) createAndCache(fieldID uint16, mem []byte, except *r
 	indexSize, n := binary.Uvarint(mem[pos : pos+binary.MaxVarintLen64])
 	pos += n
 
-	index, err = faiss.ReadIndexFromBuffer(mem[pos:pos+int(indexSize)], vectorIndexIOFlags)
+	index, err = faiss.ReadIndexFromBuffer(mem[pos:pos+int(indexSize)], faissIOFlags)
 	if err != nil {
 		return nil, nil, nil, err
 	}

--- a/faiss_vector_io_flags_unix.go
+++ b/faiss_vector_io_flags_unix.go
@@ -1,0 +1,22 @@
+//  Copyright (c) 2024 Couchbase, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// 		http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//go:build vectors && !windows
+// +build vectors,!windows
+
+package zap
+
+import faiss "github.com/blevesearch/go-faiss"
+
+const vectorIndexIOFlags = faiss.IOFlagReadMmap | faiss.IOFlagSkipPrefetch

--- a/faiss_vector_io_flags_unix.go
+++ b/faiss_vector_io_flags_unix.go
@@ -19,4 +19,4 @@ package zap
 
 import faiss "github.com/blevesearch/go-faiss"
 
-const vectorIndexIOFlags = faiss.IOFlagReadMmap | faiss.IOFlagSkipPrefetch
+const faissIOFlags = faiss.IOFlagReadMmap | faiss.IOFlagSkipPrefetch

--- a/faiss_vector_io_flags_win.go
+++ b/faiss_vector_io_flags_win.go
@@ -19,4 +19,4 @@ package zap
 
 import faiss "github.com/blevesearch/go-faiss"
 
-const vectorIndexIOFlags = faiss.IOFlagReadOnly
+const faissIOFlags = faiss.IOFlagReadOnly

--- a/faiss_vector_io_flags_win.go
+++ b/faiss_vector_io_flags_win.go
@@ -1,0 +1,22 @@
+//  Copyright (c) 2024 Couchbase, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// 		http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//go:build vectors && windows
+// +build vectors,windows
+
+package zap
+
+import faiss "github.com/blevesearch/go-faiss"
+
+const vectorIndexIOFlags = faiss.IOFlagReadOnly

--- a/section_faiss_vector_index.go
+++ b/section_faiss_vector_index.go
@@ -286,7 +286,7 @@ func (v *vectorIndexOpaque) mergeAndWriteVectorIndexes(sbs []*SegmentBase,
 		}
 		// read the index bytes. todo: parallelize this
 		indexBytes := segBase.mem[indexes[segI].startOffset : indexes[segI].startOffset+int(indexes[segI].indexSize)]
-		index, err := faiss.ReadIndexFromBuffer(indexBytes, vectorIndexIOFlags)
+		index, err := faiss.ReadIndexFromBuffer(indexBytes, faissIOFlags)
 		if err != nil {
 			freeReconstructedIndexes(vecIndexes)
 			return err

--- a/section_faiss_vector_index.go
+++ b/section_faiss_vector_index.go
@@ -286,8 +286,7 @@ func (v *vectorIndexOpaque) mergeAndWriteVectorIndexes(sbs []*SegmentBase,
 		}
 		// read the index bytes. todo: parallelize this
 		indexBytes := segBase.mem[indexes[segI].startOffset : indexes[segI].startOffset+int(indexes[segI].indexSize)]
-		index, err := faiss.ReadIndexFromBuffer(indexBytes,
-			faiss.IOFlagReadMmap|faiss.IOFlagSkipPrefetch)
+		index, err := faiss.ReadIndexFromBuffer(indexBytes, vectorIndexIOFlags)
 		if err != nil {
 			freeReconstructedIndexes(vecIndexes)
 			return err


### PR DESCRIPTION
- Faiss does not support OnDiskInvertedLists on windows, and hence while using go-faiss's IO flags, we must take into account the build platform.
- This PR enforces the old faiss.IOFlagReadOnly flag for windows and maintains the existing io flags for unix based platforms.