### PR TITLE
MB-62354: Support Cosine Similarity

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.20
 
 require (
 	github.com/RoaringBitmap/roaring v1.9.3
-	github.com/blevesearch/bleve_index_api v1.1.9
+	github.com/blevesearch/bleve_index_api v1.1.11
 	github.com/blevesearch/go-faiss v1.0.19
 	github.com/blevesearch/mmap-go v1.0.4
 	github.com/blevesearch/scorch_segment_api/v2 v2.2.14

--- a/go.sum
+++ b/go.sum
@@ -2,8 +2,8 @@ github.com/RoaringBitmap/roaring v1.9.3 h1:t4EbC5qQwnisr5PrP9nt0IRhRTb9gMUgQF4t4
 github.com/RoaringBitmap/roaring v1.9.3/go.mod h1:6AXUsoIEzDTFFQCe1RbGA6uFONMhvejWj5rqITANK90=
 github.com/bits-and-blooms/bitset v1.12.0 h1:U/q1fAF7xXRhFCrhROzIfffYnu+dlS38vCZtmFVPHmA=
 github.com/bits-and-blooms/bitset v1.12.0/go.mod h1:7hO7Gc7Pp1vODcmWvKMRA9BNmbv6a/7QIWpPxHddWR8=
-github.com/blevesearch/bleve_index_api v1.1.9 h1:Cpq0Lp3As0Gfk3+PmcoNDRKeI50C5yuFNpj0YlN/bOE=
-github.com/blevesearch/bleve_index_api v1.1.9/go.mod h1:PbcwjIcRmjhGbkS/lJCpfgVSMROV6TRubGGAODaK1W8=
+github.com/blevesearch/bleve_index_api v1.1.11 h1:OTNpRnxPWFIhMSgBUBlkD7RVWYrfsojtQeACb8tGGpw=
+github.com/blevesearch/bleve_index_api v1.1.11/go.mod h1:PbcwjIcRmjhGbkS/lJCpfgVSMROV6TRubGGAODaK1W8=
 github.com/blevesearch/go-faiss v1.0.19 h1:UKoP8hS7DVsVSRRloNJb4qPfe2UQ99pP4D3oXd23g2A=
 github.com/blevesearch/go-faiss v1.0.19/go.mod h1:jrxHrbl42X/RnDPI+wBoZU8joxxuRwedrxqswQ3xfU8=
 github.com/blevesearch/mmap-go v1.0.4 h1:OVhDhT5B/M1HNPpYPBKIEJaD0F3Si+CrEKULGCDPWmc=

--- a/section_faiss_vector_index.go
+++ b/section_faiss_vector_index.go
@@ -485,12 +485,6 @@ func (vo *vectorIndexOpaque) writeVectorIndexes(w *CountHashWriter) (offset uint
 	//    2. its constituent vectorID -> {docID} mapping.
 	tempBuf := vo.grabBuf(binary.MaxVarintLen64)
 	for fieldID, content := range vo.vecFieldMap {
-		// Set the faiss metric type (default is Euclidean Distance or l2_norm)
-		var metric = faiss.MetricL2
-		if content.metric == index.InnerProduct || content.metric == index.CosineSimilarity {
-			// use the same FAISS metric for inner product and cosine similarity
-			metric = faiss.MetricInnerProduct
-		}
 		// calculate the capacity of the vecs and ids slices
 		// to avoid multiple allocations.
 		vecs := make([]float32, 0, len(content.vecs)*int(content.dim))
@@ -498,6 +492,13 @@ func (vo *vectorIndexOpaque) writeVectorIndexes(w *CountHashWriter) (offset uint
 		for hash, vecInfo := range content.vecs {
 			vecs = append(vecs, vecInfo.vec...)
 			ids = append(ids, hash)
+		}
+
+		// Set the faiss metric type (default is Euclidean Distance or l2_norm)
+		var metric = faiss.MetricL2
+		if content.metric == index.InnerProduct || content.metric == index.CosineSimilarity {
+			// use the same FAISS metric for inner product and cosine similarity
+			metric = faiss.MetricInnerProduct
 		}
 
 		nvecs := len(ids)

--- a/section_faiss_vector_index.go
+++ b/section_faiss_vector_index.go
@@ -487,23 +487,15 @@ func (vo *vectorIndexOpaque) writeVectorIndexes(w *CountHashWriter) (offset uint
 	for fieldID, content := range vo.vecFieldMap {
 		// Set the faiss metric type (default is Euclidean Distance or l2_norm)
 		var metric = faiss.MetricL2
-		// Flag to indicate if the vectors need to be normalized before indexing.
-		var normalize bool
 		if content.metric == index.InnerProduct || content.metric == index.CosineSimilarity {
 			// use the same FAISS metric for inner product and cosine similarity
 			metric = faiss.MetricInnerProduct
-			// set the normalize flag to true for cosine similarity
-			normalize = content.metric == index.CosineSimilarity
 		}
 		// calculate the capacity of the vecs and ids slices
 		// to avoid multiple allocations.
 		vecs := make([]float32, 0, len(content.vecs)*int(content.dim))
 		ids := make([]int64, 0, len(content.vecs))
 		for hash, vecInfo := range content.vecs {
-			if normalize {
-				// normalize the vector
-				vecInfo.vec = index.NormalizeVector(vecInfo.vec)
-			}
 			vecs = append(vecs, vecInfo.vec...)
 			ids = append(ids, hash)
 		}


### PR DESCRIPTION
- Set FAISS vector metric to be `MetricInnerProduct`, if the distance metric from bleve is either `Cosine` or `InnerProduct`