### PR TITLE
Fix unit test breakage from previous commit (API change)

### DIFF
--- a/faiss_vector_test.go
+++ b/faiss_vector_test.go
@@ -486,7 +486,7 @@ func TestVectorSegment(t *testing.T) {
 	hitDocIDs := []uint64{2, 9, 9}
 	hitVecs := [][]float32{data[0], data[7][0:3], data[7][3:6]}
 	if vecSeg, ok := segOnDisk.(segment.VectorSegment); ok {
-		vecIndex, err := vecSeg.InterpretVectorIndex("stubVec", nil)
+		vecIndex, err := vecSeg.InterpretVectorIndex("stubVec", false, nil)
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -580,7 +580,7 @@ func TestPersistedVectorSegment(t *testing.T) {
 	hitDocIDs := []uint64{2, 9, 9}
 	hitVecs := [][]float32{data[0], data[7][0:3], data[7][3:6]}
 	if vecSeg, ok := segOnDisk.(segment.VectorSegment); ok {
-		vecIndex, err := vecSeg.InterpretVectorIndex("stubVec", nil)
+		vecIndex, err := vecSeg.InterpretVectorIndex("stubVec", false, nil)
 		if err != nil {
 			t.Fatal(err)
 		}


### PR DESCRIPTION
```
./faiss_vector_test.go:489:59: not enough arguments in call to vecSeg.InterpretVectorIndex
	have (string, nil)
	want (string, bool, *roaring.Bitmap)
./faiss_vector_test.go:583:59: not enough arguments in call to vecSeg.InterpretVectorIndex
	have (string, nil)
	want (string, bool, *roaring.Bitmap)
```