### PR TITLE
Handle zero chunk size

### DIFF
--- a/chunk.go
+++ b/chunk.go
@@ -15,6 +15,7 @@
 package zap
 
 import (
+	"errors"
 	"fmt"
 )
 
@@ -26,6 +27,13 @@ var LegacyChunkMode uint32 = 1024
 // be used by default.
 var DefaultChunkMode uint32 = 1026
 
+var ErrChunkSizeZero = errors.New("chunk size is zero")
+
+// getChunkSize returns the chunk size for the given chunkMode, cardinality, and
+// maxDocs.
+//
+// In error cases, the returned chunk size will be 0. Caller can differentiate
+// between a valid chunk size of 0 and an error by checking for ErrChunkSizeZero.
 func getChunkSize(chunkMode uint32, cardinality uint64, maxDocs uint64) (uint64, error) {
 	switch {
 	// any chunkMode <= 1024 will always chunk with chunkSize=chunkMode
@@ -46,6 +54,9 @@ func getChunkSize(chunkMode uint32, cardinality uint64, maxDocs uint64) (uint64,
 		// chunk-size items.
 		// no attempt is made to tweak any other case
 		if cardinality <= 1024 {
+			if maxDocs == 0 {
+				return 0, ErrChunkSizeZero
+			}
 			return maxDocs, nil
 		}
 		return 1024, nil
@@ -61,6 +72,9 @@ func getChunkSize(chunkMode uint32, cardinality uint64, maxDocs uint64) (uint64,
 		// 2.  convert to chunkSize, dividing into maxDocs
 		numChunks := (cardinality / 1024) + 1
 		chunkSize := maxDocs / numChunks
+		if chunkSize == 0 {
+			return 0, ErrChunkSizeZero
+		}
 		return chunkSize, nil
 	}
 	return 0, fmt.Errorf("unknown chunk mode %d", chunkMode)


### PR DESCRIPTION
The existing implementation of the method
getChunkSize(...) (uint64, error), in some cases,
can return chunkSize==0 and err==nil.

The onus is on the caller to check for such possibility and handle it properly.
Callers often use the returned chunkSize as a divisor and a zero chunkSize lead to panic.
see https://github.com/blevesearch/zapx/issues/209

This PR intends to update the method implementation to always return an error in case the returned chunkSize value is 0.
That way caller need to only worry about error being non-nil.

Callers which are ok with 0 chunkSize can check the returned error against ErrChunkSizeZero