### PR TITLE
MB-62230 - Pre-filtering performance optimisations

### DIFF
--- a/faiss_vector_posting.go
+++ b/faiss_vector_posting.go
@@ -416,6 +416,13 @@ func (sb *SegmentBase) InterpretVectorIndex(field string, requiresFiltering bool
 
 					// Getting the vector IDs corresponding to the eligible
 					// doc IDs.
+					// The docVecIDMap maps each docID to vectorIDs corresponding
+					// to it.
+					// Usually, each docID has one vecID mapped to it unless
+					// the vector is nested, in which case there can be multiple
+					// vectorIDs mapped to the same docID.
+					// Eg. docID d1 -> vecID v1, for the first case
+					// d1 -> {v1,v2}, for the second case.
 					eligibleVecIDsBitmap := roaring.NewBitmap()
 					vecIDsUint32 := make([]uint32, 0)
 					for _, eligibleDocID := range eligibleDocIDs {

--- a/faiss_vector_posting.go
+++ b/faiss_vector_posting.go
@@ -417,12 +417,14 @@ func (sb *SegmentBase) InterpretVectorIndex(field string, requiresFiltering bool
 					// Getting the vector IDs corresponding to the eligible
 					// doc IDs.
 					eligibleVecIDsBitmap := roaring.NewBitmap()
+					vecIDsUint32 := make([]uint32, 0)
 					for _, eligibleDocID := range eligibleDocIDs {
 						vecIDs := docVecIDMap[uint32(eligibleDocID)]
 						for _, vecID := range vecIDs {
-							eligibleVecIDsBitmap.Add(uint32(vecID))
+							vecIDsUint32 = append(vecIDsUint32, uint32(vecID))
 						}
 					}
+					eligibleVecIDsBitmap.AddMany(vecIDsUint32)
 
 					// Determining which clusters, identified by centroid ID,
 					// have at least one eligible vector and hence, ought to be
@@ -463,6 +465,9 @@ func (sb *SegmentBase) InterpretVectorIndex(field string, requiresFiltering bool
 						}
 						minEligibleCentroids = i + 1
 					}
+
+					// If the fraction of eligible vec IDs is greater than 50%,
+					// use an exclude selector instead for the ineligible IDs.
 
 					// Search the clusters specified by 'closestCentroidIDs' for
 					// vectors whose IDs are present in 'vectorIDsToInclude'

--- a/faiss_vector_posting.go
+++ b/faiss_vector_posting.go
@@ -428,10 +428,13 @@ func (sb *SegmentBase) InterpretVectorIndex(field string, requiresFiltering bool
 
 					var selector faiss.Selector
 					var err error
-					ineligibleVectorIDs := make([]int64, 0, len(vecDocIDMap)-
-						len(vectorIDsToInclude))
+					// If there are more elements to be included than excluded, it
+					// might be quicker to use an exclusion selector as a filter
+					// instead of an inclusion selector.
 					if float32(eligibleVecIDsBitmap.GetCardinality())/
 						float32(len(vecDocIDMap)) > 0.5 {
+						ineligibleVectorIDs := make([]int64, 0, len(vecDocIDMap)-
+							len(vectorIDsToInclude))
 						for docID, vecIDs := range docVecIDMap {
 							for _, vecID := range vecIDs {
 								if !eligibleVecIDsBitmap.Contains(uint32(vecID)) &&

--- a/faiss_vector_posting.go
+++ b/faiss_vector_posting.go
@@ -466,9 +466,6 @@ func (sb *SegmentBase) InterpretVectorIndex(field string, requiresFiltering bool
 						minEligibleCentroids = i + 1
 					}
 
-					// If the fraction of eligible vec IDs is greater than 50%,
-					// use an exclude selector instead for the ineligible IDs.
-
 					// Search the clusters specified by 'closestCentroidIDs' for
 					// vectors whose IDs are present in 'vectorIDsToInclude'
 					scores, ids, err := vecIndex.SearchClustersFromIVFIndex(

--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,7 @@ go 1.21
 require (
 	github.com/RoaringBitmap/roaring v1.9.3
 	github.com/blevesearch/bleve_index_api v1.1.12
-	github.com/blevesearch/go-faiss v1.0.22
+	github.com/blevesearch/go-faiss v1.0.23
 	github.com/blevesearch/mmap-go v1.0.4
 	github.com/blevesearch/scorch_segment_api/v2 v2.2.16
 	github.com/blevesearch/vellum v1.0.10

--- a/go.sum
+++ b/go.sum
@@ -4,8 +4,8 @@ github.com/bits-and-blooms/bitset v1.12.0 h1:U/q1fAF7xXRhFCrhROzIfffYnu+dlS38vCZ
 github.com/bits-and-blooms/bitset v1.12.0/go.mod h1:7hO7Gc7Pp1vODcmWvKMRA9BNmbv6a/7QIWpPxHddWR8=
 github.com/blevesearch/bleve_index_api v1.1.12 h1:P4bw9/G/5rulOF7SJ9l4FsDoo7UFJ+5kexNy1RXfegY=
 github.com/blevesearch/bleve_index_api v1.1.12/go.mod h1:PbcwjIcRmjhGbkS/lJCpfgVSMROV6TRubGGAODaK1W8=
-github.com/blevesearch/go-faiss v1.0.22 h1:j6jwgCOy2a2EQUTOYxjBA59rMn5KPA0jbfYyHNgc2Ls=
-github.com/blevesearch/go-faiss v1.0.22/go.mod h1:OMGQwOaRRYxrmeNdMrXJPvVx8gBnvE5RYrr0BahNnkk=
+github.com/blevesearch/go-faiss v1.0.23 h1:Wmc5AFwDLKGl2L6mjLX1Da3vCL0EKa2uHHSorcIS1Uc=
+github.com/blevesearch/go-faiss v1.0.23/go.mod h1:OMGQwOaRRYxrmeNdMrXJPvVx8gBnvE5RYrr0BahNnkk=
 github.com/blevesearch/mmap-go v1.0.4 h1:OVhDhT5B/M1HNPpYPBKIEJaD0F3Si+CrEKULGCDPWmc=
 github.com/blevesearch/mmap-go v1.0.4/go.mod h1:EWmEAOmdAS9z/pi/+Toxu99DnsbhG1TIxUoRmJw/pSs=
 github.com/blevesearch/scorch_segment_api/v2 v2.2.16 h1:uGvKVvG7zvSxCwcm4/ehBa9cCEuZVE+/zvrSl57QUVY=


### PR DESCRIPTION
1. Add elements to the bitmap in a batch instead of individually to bring down latencies of pre-filtered queries.
2. Vary the selector used and use an exclude selector with high selectivity. 