### PR TITLE
MB-68044: Limiting Training Size of Faiss Indexes

### DIFF
--- a/faiss_vector_cache.go
+++ b/faiss_vector_cache.go
@@ -192,7 +192,7 @@ func readVectorSectionFromFile(opts *vectorCacheOptions) (index faissIndex,
 	}
 	pos += int(indexSize)
 
-	params := newFaissIndexParams(opts.optStr, int(numVecs), faissIOFlagsReadOnly)
+	params := newFaissIndexParams(opts.optStr, int(numVecs), 0, faissIOFlagsReadOnly)
 	if faissIndexType(indexType) == faissBIVFIndex {
 		// read the faiss binary index size
 		binSize, n := binary.Uvarint(mem[pos : pos+binary.MaxVarintLen64])

--- a/faiss_vector_index.go
+++ b/faiss_vector_index.go
@@ -55,18 +55,30 @@ type faissIndexParams struct {
 	// some construction-time decisions (e.g. whether to clone to GPU)
 	// depend on the eventual vector count.
 	numVecs int
+	// nlist is the number of centroids the index is being built with.
+	// zero during query time.
+	nlist int
 	// ioFlags used to read the index from bytes
 	ioFlags int
 }
 
 // newFaissIndexParams constructs a faissIndexParams with the given optimization
-// type and expected vector count.
-func newFaissIndexParams(optimization string, numVecs, ioFlags int) *faissIndexParams {
+// type, expected vector count and centroid count.
+func newFaissIndexParams(optimization string, numVecs, nlist, ioFlags int) *faissIndexParams {
 	return &faissIndexParams{
 		optimization: optimization,
 		numVecs:      numVecs,
+		nlist:        nlist,
 		ioFlags:      ioFlags,
 	}
+}
+
+// numTrainingVecs returns how many of the availableVecs vectors to train on.
+func (p *faissIndexParams) numTrainingVecs(availableVecs int) int {
+	if p.nlist <= 0 {
+		return availableVecs
+	}
+	return min(p.nlist*trainingPointsPerCentroid, availableVecs)
 }
 
 func (p *faissIndexParams) size() uint64 {

--- a/faiss_vector_index_bivf.go
+++ b/faiss_vector_index_bivf.go
@@ -287,18 +287,16 @@ func (b *faissBinaryIndex) setNProbe(nprobe int32) {
 }
 
 func (b *faissBinaryIndex) trainAndAdd(trainingData *vectorSet, vecsToAdd *vectorSet) error {
-	nlist := determineCentroids(trainingData.nvecs)
-	nvecsToTrain := nlist * 40 * b.dim()
-	// train the backing index with the floatData
+	nvecsToTrain := b.params.numTrainingVecs(trainingData.nvecs)
 	var err error
 	if b.backing.IsSQIndex() {
-		err = b.backing.Train(trainingData.floatData[:nvecsToTrain])
+		err = b.backing.Train(trainingData.floatData[:nvecsToTrain*b.dim()])
 		if err != nil {
 			return err
 		}
 	}
 
-	err = b.binary.Train(trainingData.binaryData[:(nvecsToTrain / 8)])
+	err = b.binary.Train(trainingData.binaryData[:nvecsToTrain*(b.dim()/8)])
 	if err != nil {
 		return err
 	}

--- a/faiss_vector_index_bivf.go
+++ b/faiss_vector_index_bivf.go
@@ -287,23 +287,17 @@ func (b *faissBinaryIndex) setNProbe(nprobe int32) {
 }
 
 func (b *faissBinaryIndex) trainAndAdd(trainingData *vectorSet, vecsToAdd *vectorSet) error {
-	nvecsToTrain := b.cfg.nlist * 40 * b.cfg.dimension
-
+	nlist := determineCentroids(trainingData.nvecs)
+	nvecsToTrain := nlist * 40 * b.dim()
 	// train the backing index with the floatData
 	var err error
 	if b.backing.IsSQIndex() {
-		if len(trainingData.floatData) < nvecsToTrain {
-			nvecsToTrain = len(trainingData.floatData)
-		}
 		err = b.backing.Train(trainingData.floatData[:nvecsToTrain])
 		if err != nil {
 			return err
 		}
 	}
 
-	if len(trainingData.binaryData) < nvecsToTrain/8 {
-		nvecsToTrain = len(trainingData.binaryData) * 8
-	}
 	err = b.binary.Train(trainingData.binaryData[:(nvecsToTrain / 8)])
 	if err != nil {
 		return err

--- a/faiss_vector_index_bivf.go
+++ b/faiss_vector_index_bivf.go
@@ -287,16 +287,24 @@ func (b *faissBinaryIndex) setNProbe(nprobe int32) {
 }
 
 func (b *faissBinaryIndex) trainAndAdd(trainingData *vectorSet, vecsToAdd *vectorSet) error {
+	nvecsToTrain := b.cfg.nlist * 40 * b.cfg.dimension
+
 	// train the backing index with the floatData
 	var err error
 	if b.backing.IsSQIndex() {
-		err = b.backing.Train(trainingData.floatData)
+		if len(trainingData.floatData) < nvecsToTrain {
+			nvecsToTrain = len(trainingData.floatData)
+		}
+		err = b.backing.Train(trainingData.floatData[:nvecsToTrain])
 		if err != nil {
 			return err
 		}
 	}
 
-	err = b.binary.Train(trainingData.binaryData)
+	if len(trainingData.binaryData) < nvecsToTrain/8 {
+		nvecsToTrain = len(trainingData.binaryData) * 8
+	}
+	err = b.binary.Train(trainingData.binaryData[:(nvecsToTrain / 8)])
 	if err != nil {
 		return err
 	}

--- a/faiss_vector_index_float32.go
+++ b/faiss_vector_index_float32.go
@@ -179,9 +179,8 @@ func (f *faissFloat32Index) setNProbe(nprobe int32) {
 }
 
 func (f *faissFloat32Index) trainAndAdd(trainingData *vectorSet, vecsToAdd *vectorSet) error {
-	nlist := determineCentroids(trainingData.nvecs)
-	nvecsToTrain := nlist * 40 * f.dim()
-	err := f.idx.Train(trainingData.floatData[:nvecsToTrain])
+	nvecsToTrain := f.params.numTrainingVecs(trainingData.nvecs)
+	err := f.idx.Train(trainingData.floatData[:nvecsToTrain*f.dim()])
 	if err != nil {
 		return err
 	}

--- a/faiss_vector_index_float32.go
+++ b/faiss_vector_index_float32.go
@@ -179,10 +179,8 @@ func (f *faissFloat32Index) setNProbe(nprobe int32) {
 }
 
 func (f *faissFloat32Index) trainAndAdd(trainingData *vectorSet, vecsToAdd *vectorSet) error {
-	nvecsToTrain := f.cfg.nlist * 40 * f.cfg.dimension
-	if len(trainingData.floatData) < nvecsToTrain {
-		nvecsToTrain = len(trainingData.floatData)
-	}
+	nlist := determineCentroids(trainingData.nvecs)
+	nvecsToTrain := nlist * 40 * f.dim()
 	err := f.idx.Train(trainingData.floatData[:nvecsToTrain])
 	if err != nil {
 		return err

--- a/faiss_vector_index_float32.go
+++ b/faiss_vector_index_float32.go
@@ -179,7 +179,11 @@ func (f *faissFloat32Index) setNProbe(nprobe int32) {
 }
 
 func (f *faissFloat32Index) trainAndAdd(trainingData *vectorSet, vecsToAdd *vectorSet) error {
-	err := f.idx.Train(trainingData.floatData)
+	nvecsToTrain := f.cfg.nlist * 40 * f.cfg.dimension
+	if len(trainingData.floatData) < nvecsToTrain {
+		nvecsToTrain = len(trainingData.floatData)
+	}
+	err := f.idx.Train(trainingData.floatData[:nvecsToTrain])
 	if err != nil {
 		return err
 	}

--- a/faiss_vector_index_gpu_float32.go
+++ b/faiss_vector_index_gpu_float32.go
@@ -317,7 +317,8 @@ func (f *faissGPUFloat32Index) trainAndAdd(trainingData *vectorSet, vecsToAdd *v
 		return f.trainAndAddCPU(trainingData, vecsToAdd)
 	}
 
-	err := gpuState.idx.Train(trainingData.floatData)
+	nvecsToTrain := f.params.numTrainingVecs(trainingData.nvecs)
+	err := gpuState.idx.Train(trainingData.floatData[:nvecsToTrain*f.dim()])
 	if err != nil {
 		f.teardownGPU()
 		return f.trainAndAddCPU(trainingData, vecsToAdd)
@@ -352,7 +353,8 @@ func (f *faissGPUFloat32Index) trainAndAdd(trainingData *vectorSet, vecsToAdd *v
 }
 
 func (f *faissGPUFloat32Index) trainAndAddCPU(trainingData *vectorSet, vecsToAdd *vectorSet) error {
-	err := f.cpuIdx.Train(trainingData.floatData)
+	nvecsToTrain := f.params.numTrainingVecs(trainingData.nvecs)
+	err := f.cpuIdx.Train(trainingData.floatData[:nvecsToTrain*f.dim()])
 	if err != nil {
 		return err
 	}

--- a/section_faiss_vector_index.go
+++ b/section_faiss_vector_index.go
@@ -52,6 +52,11 @@ const (
 	// The threshold for number of vectors at or beyond which we start building
 	// the IVF class of indexes with SQ8 quantization for memory efficiency.
 	ivfSq8Threshold = 10000
+	// Number of training vectors per centroid used while training an IVF index.
+	// faiss warns below 39 points per centroid, so this is the smallest value
+	// that keeps every cluster well fed while training on as little data as
+	// possible.
+	trainingPointsPerCentroid = 40
 )
 
 // Vector index types supported.
@@ -491,7 +496,7 @@ func (v *vectorIndexOpaque) mergeAndWriteVectorIndexes(trainedIndex faissIndexIV
 		if trainedIndex == nil {
 			ioFlags = faissIOFlagsReadOnly
 		}
-		reconsParams := newFaissIndexParams(currVecIndex.indexOptimizedFor, currVecIndex.nvecs, ioFlags)
+		reconsParams := newFaissIndexParams(currVecIndex.indexOptimizedFor, currVecIndex.nvecs, 0, ioFlags)
 
 		// load binary index from disk if present
 		if currVecIndex.indexType == faissBIVFIndex {
@@ -1003,7 +1008,7 @@ func newFaissIndexConfig(idxType faissIndexType, optimizationType string, dimens
 
 // Factory function to create a faissIndex for the given index config.
 func faissIndexFactory(cfg *faissIndexConfig) (faissIndex, error) {
-	params := newFaissIndexParams(cfg.optimizationType, cfg.numVecs, faissIOFlags)
+	params := newFaissIndexParams(cfg.optimizationType, cfg.numVecs, cfg.nlist, faissIOFlags)
 	switch cfg.indexType {
 	case faissFP32Index:
 		description := determineFloat32IndexToUse(cfg.numVecs, cfg.nlist, cfg.optimizationType)


### PR DESCRIPTION
- Added nlist to params. This is only populated during index time
- Set the number of training vectors to number of centroids * 40