### PR TITLE
MB-57871 - [v15] Avoid unnecessary atomic operation on bytesWritten

### DIFF
--- a/contentcoder.go
+++ b/contentcoder.go
@@ -19,7 +19,6 @@ import (
 	"encoding/binary"
 	"io"
 	"reflect"
-	"sync/atomic"
 
 	"github.com/golang/snappy"
 )
@@ -37,7 +36,7 @@ var (
 )
 
 type chunkedContentCoder struct {
-	bytesWritten uint64 // atomic access to this variable, moved to top to correct alignment issues on ARM, 386 and 32-bit MIPS.
+	bytesWritten uint64 // moved to top to correct alignment issues on ARM, 386 and 32-bit MIPS.
 
 	final     []byte
 	chunkSize uint64
@@ -112,11 +111,11 @@ func (c *chunkedContentCoder) Close() error {
 }
 
 func (c *chunkedContentCoder) incrementBytesWritten(val uint64) {
-	atomic.AddUint64(&c.bytesWritten, val)
+	c.bytesWritten += val
 }
 
 func (c *chunkedContentCoder) getBytesWritten() uint64 {
-	return atomic.LoadUint64(&c.bytesWritten)
+	return c.bytesWritten
 }
 
 func (c *chunkedContentCoder) flushContents() error {

--- a/docvalues.go
+++ b/docvalues.go
@@ -75,7 +75,6 @@ type docValueReader struct {
 	curChunkData   []byte // compressed data cache
 	uncompressed   []byte // temp buf for snappy decompression
 
-	// atomic access to this variable
 	bytesRead uint64
 }
 

--- a/intDecoder.go
+++ b/intDecoder.go
@@ -27,7 +27,6 @@ type chunkedIntDecoder struct {
 	data            []byte
 	r               *memUvarintReader
 
-	// atomic access to this variable
 	bytesRead uint64
 }
 

--- a/intcoder.go
+++ b/intcoder.go
@@ -18,7 +18,6 @@ import (
 	"bytes"
 	"encoding/binary"
 	"io"
-	"sync/atomic"
 )
 
 // We can safely use 0 to represent termNotEncoded since 0
@@ -36,7 +35,6 @@ type chunkedIntCoder struct {
 
 	buf []byte
 
-	// atomic access to this variable
 	bytesWritten uint64
 }
 
@@ -79,11 +77,11 @@ func (c *chunkedIntCoder) SetChunkSize(chunkSize uint64, maxDocNum uint64) {
 }
 
 func (c *chunkedIntCoder) incrementBytesWritten(val uint64) {
-	atomic.AddUint64(&c.bytesWritten, val)
+	c.bytesWritten += val
 }
 
 func (c *chunkedIntCoder) getBytesWritten() uint64 {
-	return atomic.LoadUint64(&c.bytesWritten)
+	return c.bytesWritten
 }
 
 // Add encodes the provided integers into the correct chunk for the provided

--- a/new.go
+++ b/new.go
@@ -147,7 +147,6 @@ type interim struct {
 	lastNumDocs int
 	lastOutSize int
 
-	// atomic access to this variable
 	bytesWritten uint64
 }
 
@@ -497,11 +496,11 @@ func (s *interim) processDocument(docNum uint64,
 }
 
 func (s *interim) getBytesWritten() uint64 {
-	return atomic.LoadUint64(&s.bytesWritten)
+	return s.bytesWritten
 }
 
 func (s *interim) incrementBytesWritten(val uint64) {
-	atomic.AddUint64(&s.bytesWritten, val)
+	s.bytesWritten += val
 }
 
 func (s *interim) writeStoredFields() (


### PR DESCRIPTION
- the construct of bytes written while constructing a segment is not a shared resource i.e. a single thread operates on a segment creation. Hence the atomic.Add() operation is not necessary here.
- Tested using bleve unit test with race flace 

```
go test -run=TestBytesWritten --race
PASS
ok  	github.com/blevesearch/bleve/v2	2.294s
```