### PR TITLE
Fixed 64-bit alignment panic on 32-bit platforms

### DIFF
--- a/section_inverted_text_index.go
+++ b/section_inverted_text_index.go
@@ -915,6 +915,8 @@ func (i *invertedTextIndexSection) InitOpaque(args map[string]interface{}) reset
 }
 
 type invertedIndexOpaque struct {
+	bytesWritten uint64 // atomic access to this variable, moved to top to correct alignment issues on ARM, 386 and 32-bit MIPS.
+
 	results []index.Document
 
 	chunkMode uint32
@@ -967,9 +969,8 @@ type invertedIndexOpaque struct {
 
 	fieldAddrs map[int]int
 
-	bytesWritten uint64
-	fieldsSame   bool
-	numDocs      uint64
+	fieldsSame bool
+	numDocs    uint64
 }
 
 func (io *invertedIndexOpaque) Reset() (err error) {

--- a/segment.go
+++ b/segment.go
@@ -89,6 +89,10 @@ func (*ZapPlugin) Open(path string) (segment.Segment, error) {
 // SegmentBase is a memory only, read-only implementation of the
 // segment.Segment interface, using zap's data representation.
 type SegmentBase struct {
+	// atomic access to these variables, moved to top to correct alignment issues on ARM, 386 and 32-bit MIPS.
+	bytesRead    uint64
+	bytesWritten uint64
+
 	mem                 []byte
 	memCRC              uint32
 	chunkMode           uint32
@@ -104,10 +108,6 @@ type SegmentBase struct {
 	fieldDvReaders      []map[uint16]*docValueReader // naive chunk cache per field; section->field->reader
 	fieldDvNames        []string                     // field names cached in fieldDvReaders
 	size                uint64
-
-	// atomic access to these variables
-	bytesRead    uint64
-	bytesWritten uint64
 
 	m         sync.Mutex
 	fieldFSTs map[uint16]*vellum.FST


### PR DESCRIPTION
It's the same story as per #148, but for v16.

```
panic: unaligned 64-bit atomic operation

goroutine 1 [running]:
internal/runtime/atomic.panicUnaligned()
/root/go/pkg/mod/golang.org/toolchain@v0.0.1-go1.23.0.linux-386/src/internal/runtime/atomic/unaligned.go:8 +0x2d
internal/runtime/atomic.Xadd64(0xa0226e4, 0x0)
/root/go/pkg/mod/golang.org/toolchain@v0.0.1-go1.23.0.linux-386/src/internal/runtime/atomic/atomic_386.s:125 +0x11
github.com/blevesearch/zapx/v16.(*invertedIndexOpaque).incrementBytesWritten(...)
/root/go/pkg/mod/github.com/blevesearch/zapx/v16@v16.1.5/section_inverted_text_index.go:401
github.com/blevesearch/zapx/v16.(*invertedIndexOpaque).writeDicts(0xa022608, 0xfd7efa8)
/root/go/pkg/mod/github.com/blevesearch/zapx/v16@v16.1.5/section_inverted_text_index.go:529 +0xe74
github.com/blevesearch/zapx/v16.(*invertedTextIndexSection).Persist(0x9424880, 0xfe720c0, 0xfd7efa8)
/root/go/pkg/mod/github.com/blevesearch/zapx/v16@v16.1.5/section_inverted_text_index.go:54 +0x3d
github.com/blevesearch/zapx/v16.(*interim).convert(0xfe5fc00)
/root/go/pkg/mod/github.com/blevesearch/zapx/v16@v16.1.5/new.go:220 +0x6d9
github.com/blevesearch/zapx/v16.(*ZapPlugin).newWithChunkMode(0x9424880, {0xf774008, 0x3e9, 0x3e9}, 0x402)
/root/go/pkg/mod/github.com/blevesearch/zapx/v16@v16.1.5/new.go:69 +0x194
github.com/blevesearch/zapx/v16.(*ZapPlugin).New(0x9424880, {0xf774008, 0x3e9, 0x3e9})
/root/go/pkg/mod/github.com/blevesearch/zapx/v16@v16.1.5/new.go:45 +0x43
github.com/blevesearch/bleve/v2/index/scorch.(*Scorch).Batch(0x9fde008, 0xf6ffa90)
/root/go/pkg/mod/github.com/blevesearch/bleve/v2@v2.4.2/index/scorch/scorch.go:445 +0x63a
github.com/blevesearch/bleve/v2.(*indexImpl).Batch(0x9c98500, 0xf6bf680)
/root/go/pkg/mod/github.com/blevesearch/bleve/v2@v2.4.2/index_impl.go:316 +0x90
```