### PR TITLE
MB-64883: Adapt interface change for VectorIndex

### DIFF
--- a/faiss_vector_posting.go
+++ b/faiss_vector_posting.go
@@ -423,7 +423,7 @@ func (sb *SegmentBase) InterpretVectorIndex(field string, requiresFiltering bool
 						return rv, nil
 					}
 
-					// CACHE THIS!
+					// TODO: WHY NOT CACHE THIS?
 					// Converting to roaring bitmap for ease of intersect ops with
 					// the set of eligible doc IDs.
 					centroidVecIDMap := make(map[int64]*roaring.Bitmap)


### PR DESCRIPTION
+ Requires: https://github.com/blevesearch/scorch_segment_api/pull/50
+ Change signature of SearchWithFilter to minimize work and take advantage of roaring bitmap operations.
+ Change cached signature of docVecIDMap for easier usability.
+ More TODOs