### PR TITLE
MB-65473: [BP] Refactor and Optimize Pre-Filtered Vector Search (#317)

### DIFF
--- a/faiss_vector_cache.go
+++ b/faiss_vector_cache.go
@@ -105,7 +105,7 @@ func (vc *vectorIndexCache) addDocVecIDMapToCacheLOCKED(ce *cacheEntry) map[uint
 		return ce.docVecIDMap
 	}
 
-	docVecIDMap := make(map[uint32][]int64)
+	docVecIDMap := make(map[uint32][]int64, len(ce.vecDocIDMap))
 	for vecID, docID := range ce.vecDocIDMap {
 		docVecIDMap[docID] = append(docVecIDMap[docID], vecID)
 	}

--- a/faiss_vector_posting.go
+++ b/faiss_vector_posting.go
@@ -25,6 +25,7 @@ import (
 
 	"github.com/RoaringBitmap/roaring"
 	"github.com/RoaringBitmap/roaring/roaring64"
+	"github.com/bits-and-blooms/bitset"
 	faiss "github.com/blevesearch/go-faiss"
 	segment "github.com/blevesearch/scorch_segment_api/v2"
 )
@@ -374,185 +375,139 @@ func (sb *SegmentBase) InterpretVectorIndex(field string, requiresFiltering bool
 					except:   nil, // todo: handle the except bitmap within postings iterator.
 					postings: roaring64.New(),
 				}
-
 				if vecIndex == nil || vecIndex.D() != len(qVector) {
 					// vector index not found or dimensionality mismatched
 					return rv, nil
 				}
-
-				if len(eligibleDocIDs) > 0 {
-					// Non-zero documents eligible per the filter query.
-
-					// If every element in the index is eligible(eg. high selectivity
-					// cases), then this can basically be considered unfiltered kNN.
-					if len(eligibleDocIDs) == int(sb.numDocs) {
-						scores, ids, err := vecIndex.SearchWithoutIDs(qVector, k,
-							vectorIDsToExclude, params)
-						if err != nil {
-							return nil, err
-						}
-
-						addIDsToPostingsList(rv, ids, scores)
-						return rv, nil
-					}
-
-					// vector IDs corresponding to the local doc numbers to be
-					// considered for the search
-					vectorIDsToInclude := make([]int64, 0, len(eligibleDocIDs))
-					for _, id := range eligibleDocIDs {
-						vectorIDsToInclude = append(vectorIDsToInclude, docVecIDMap[uint32(id)]...)
-					}
-
-					if len(vectorIDsToInclude) == 0 {
-						return rv, nil
-					}
-
-					// Retrieve the mapping of centroid IDs to vectors within
-					// the cluster.
-					clusterAssignment, _ := vecIndex.ObtainClusterToVecIDsFromIVFIndex()
-					// Accounting for a flat index
-					if len(clusterAssignment) == 0 {
-						scores, ids, err := vecIndex.SearchWithIDs(qVector, k,
-							vectorIDsToInclude, params)
-						if err != nil {
-							return nil, err
-						}
-
-						addIDsToPostingsList(rv, ids, scores)
-						return rv, nil
-					}
-
-					// Converting to roaring bitmap for ease of intersect ops with
-					// the set of eligible doc IDs.
-					centroidVecIDMap := make(map[int64]*roaring.Bitmap)
-					for centroidID, vecIDs := range clusterAssignment {
-						if _, exists := centroidVecIDMap[centroidID]; !exists {
-							centroidVecIDMap[centroidID] = roaring.NewBitmap()
-						}
-						vecIDsUint32 := make([]uint32, 0, len(vecIDs))
-						for _, vecID := range vecIDs {
-							vecIDsUint32 = append(vecIDsUint32, uint32(vecID))
-						}
-						centroidVecIDMap[centroidID].AddMany(vecIDsUint32)
-					}
-
-					// Determining which clusters, identified by centroid ID,
-					// have at least one eligible vector and hence, ought to be
-					// probed.
-					eligibleCentroidIDs := make([]int64, 0)
-
-					var selector faiss.Selector
-					var err error
-					// If there are more elements to be included than excluded, it
-					// might be quicker to use an exclusion selector as a filter
-					// instead of an inclusion selector.
-					if float32(len(eligibleDocIDs))/float32(len(docVecIDMap)) > 0.5 {
-						ineligibleVecIDsBitmap := roaring.NewBitmap()
-						eligibleDocIDsMap := make(map[uint64]struct{})
-						for _, eligibleDocID := range eligibleDocIDs {
-							eligibleDocIDsMap[(eligibleDocID)] = struct{}{}
-						}
-
-						ineligibleVectorIDs := make([]int64, 0, len(vecDocIDMap)-
-							len(vectorIDsToInclude))
-
-						for docID, vecIDs := range docVecIDMap {
-							if _, exists := eligibleDocIDsMap[uint64(docID)]; !exists {
-								for _, vecID := range vecIDs {
-									ineligibleVecIDsBitmap.Add(uint32(vecID))
-									ineligibleVectorIDs = append(ineligibleVectorIDs, vecID)
-								}
-							}
-						}
-
-						for centroidID, vecIDs := range centroidVecIDMap {
-							vecIDs.AndNot(ineligibleVecIDsBitmap)
-							// At least one eligible vec in cluster.
-							if !vecIDs.IsEmpty() {
-								// The mapping is now reduced to those vectors which
-								// are also eligible docs for the filter query.
-								centroidVecIDMap[centroidID] = vecIDs
-								eligibleCentroidIDs = append(eligibleCentroidIDs, centroidID)
-							} else {
-								// don't consider clusters with no eligible IDs.
-								delete(centroidVecIDMap, centroidID)
-							}
-						}
-
-						selector, err = faiss.NewIDSelectorNot(ineligibleVectorIDs)
-					} else {
-						// Getting the vector IDs corresponding to the eligible
-						// doc IDs.
-						// The docVecIDMap maps each docID to vectorIDs corresponding
-						// to it.
-						// Usually, each docID has one vecID mapped to it unless
-						// the vector is nested, in which case there can be multiple
-						// vectorIDs mapped to the same docID.
-						// Eg. docID d1 -> vecID v1, for the first case
-						// d1 -> {v1,v2}, for the second case.
-						eligibleVecIDsBitmap := roaring.NewBitmap()
-						vecIDsUint32 := make([]uint32, 0)
-						for _, eligibleDocID := range eligibleDocIDs {
-							vecIDs := docVecIDMap[uint32(eligibleDocID)]
-							for _, vecID := range vecIDs {
-								vecIDsUint32 = append(vecIDsUint32, uint32(vecID))
-							}
-						}
-						eligibleVecIDsBitmap.AddMany(vecIDsUint32)
-						for centroidID, vecIDs := range centroidVecIDMap {
-							vecIDs.And(eligibleVecIDsBitmap)
-							if !vecIDs.IsEmpty() {
-								// The mapping is now reduced to those vectors which
-								// are also eligible docs for the filter query.
-								centroidVecIDMap[centroidID] = vecIDs
-								eligibleCentroidIDs = append(eligibleCentroidIDs, centroidID)
-							} else {
-								// don't consider clusters with no eligible IDs.
-								delete(centroidVecIDMap, centroidID)
-							}
-						}
-
-						selector, err = faiss.NewIDSelectorBatch(vectorIDsToInclude)
-					}
+				// Check and proceed only if non-zero documents eligible per the filter query.
+				if len(eligibleDocIDs) == 0 {
+					return rv, nil
+				}
+				// If every element in the index is eligible (full selectivity),
+				// then this can basically be considered unfiltered kNN.
+				if len(eligibleDocIDs) == int(sb.numDocs) {
+					scores, ids, err := vecIndex.SearchWithoutIDs(qVector, k,
+						vectorIDsToExclude, params)
 					if err != nil {
 						return nil, err
 					}
-
-					// Ordering the retrieved centroid IDs by increasing order
-					// of distance i.e. decreasing order of proximity to query vector.
-					closestCentroidIDs, centroidDistances, _ :=
-						vecIndex.ObtainClustersWithDistancesFromIVFIndex(qVector,
-							eligibleCentroidIDs)
-
-					// Getting the nprobe value set at index time.
-					nprobe := vecIndex.GetNProbe()
-
-					eligibleDocsTillNow := int64(0)
-					minEligibleCentroids := 0
-					for i, centroidID := range closestCentroidIDs {
-						eligibleDocsTillNow += int64(centroidVecIDMap[centroidID].GetCardinality())
-						if eligibleDocsTillNow >= k && i >= int(nprobe-1) {
-							// Continue till at least 'K' cumulative vectors are
-							// collected or 'nprobe' clusters are examined, whichever
-							// comes later.
-							minEligibleCentroids = i + 1
-							break
-						}
-						minEligibleCentroids = i + 1
-					}
-
-					// Search the clusters specified by 'closestCentroidIDs' for
-					// vectors whose IDs are present in 'vectorIDsToInclude'
-					scores, ids, err := vecIndex.SearchClustersFromIVFIndex(
-						selector, len(vectorIDsToInclude), closestCentroidIDs,
-						minEligibleCentroids, k, qVector, centroidDistances, params)
-					if err != nil {
-						return nil, err
-					}
-
 					addIDsToPostingsList(rv, ids, scores)
 					return rv, nil
 				}
+				// vector IDs corresponding to the local doc numbers to be
+				// considered for the search
+				vectorIDsToInclude := make([]int64, 0, len(eligibleDocIDs))
+				for _, id := range eligibleDocIDs {
+					vecIDs := docVecIDMap[uint32(id)]
+					// In the common case where vecIDs has only one element, which occurs
+					// when a document has only one vector field, we can
+					// avoid the unnecessary overhead of slice unpacking (append(vecIDs...)).
+					// Directly append the single element for efficiency.
+					if len(vecIDs) == 1 {
+						vectorIDsToInclude = append(vectorIDsToInclude, vecIDs[0])
+					} else {
+						vectorIDsToInclude = append(vectorIDsToInclude, vecIDs...)
+					}
+				}
+				// In case a doc has invalid vector fields but valid non-vector fields,
+				// filter hit IDs may be ineligible for the kNN since the document does
+				// not have any/valid vectors.
+				if len(vectorIDsToInclude) == 0 {
+					return rv, nil
+				}
+				// If the index is not an IVF index, then the search can be
+				// performed directly, using the Flat index.
+				if !vecIndex.IsIVFIndex() {
+					// vector IDs corresponding to the local doc numbers to be
+					// considered for the search
+					scores, ids, err := vecIndex.SearchWithIDs(qVector, k,
+						vectorIDsToInclude, params)
+					if err != nil {
+						return nil, err
+					}
+					addIDsToPostingsList(rv, ids, scores)
+					return rv, nil
+				}
+				// Determining which clusters, identified by centroid ID,
+				// have at least one eligible vector and hence, ought to be
+				// probed.
+				clusterVectorCounts, err := vecIndex.ObtainClusterVectorCountsFromIVFIndex(vectorIDsToInclude)
+				if err != nil {
+					return nil, err
+				}
+				var selector faiss.Selector
+				// If there are more elements to be included than excluded, it
+				// might be quicker to use an exclusion selector as a filter
+				// instead of an inclusion selector.
+				if float32(len(eligibleDocIDs))/float32(len(docVecIDMap)) > 0.5 {
+					// Use a bitset to efficiently track eligible document IDs.
+					// This reduces the lookup cost when checking if a document ID is eligible,
+					// compared to using a map or slice.
+					bs := bitset.New(uint(len(eligibleDocIDs)))
+					for _, docID := range eligibleDocIDs {
+						bs.Set(uint(docID))
+					}
+					ineligibleVectorIDs := make([]int64, 0, len(vecDocIDMap)-len(vectorIDsToInclude))
+					for docID, vecIDs := range docVecIDMap {
+						// Check if the document ID is NOT in the eligible set, marking it as ineligible.
+						if !bs.Test(uint(docID)) {
+							// In the common case where vecIDs has only one element, which occurs
+							// when a document has only one vector field, we can
+							// avoid the unnecessary overhead of slice unpacking (append(vecIDs...)).
+							// Directly append the single element for efficiency.
+							if len(vecIDs) == 1 {
+								ineligibleVectorIDs = append(ineligibleVectorIDs, vecIDs[0])
+							} else {
+								ineligibleVectorIDs = append(ineligibleVectorIDs, vecIDs...)
+							}
+						}
+					}
+					selector, err = faiss.NewIDSelectorNot(ineligibleVectorIDs)
+				} else {
+					selector, err = faiss.NewIDSelectorBatch(vectorIDsToInclude)
+				}
+				if err != nil {
+					return nil, err
+				}
+				// If no error occured during the creation of the selector, then
+				// it should be deleted once the search is complete.
+				defer selector.Delete()
+				// Ordering the retrieved centroid IDs by increasing order
+				// of distance i.e. decreasing order of proximity to query vector.
+				centroidIDs := make([]int64, 0, len(clusterVectorCounts))
+				for centroidID := range clusterVectorCounts {
+					centroidIDs = append(centroidIDs, centroidID)
+				}
+				closestCentroidIDs, centroidDistances, err :=
+					vecIndex.ObtainClustersWithDistancesFromIVFIndex(qVector, centroidIDs)
+				if err != nil {
+					return nil, err
+				}
+				// Getting the nprobe value set at index time.
+				nprobe := int(vecIndex.GetNProbe())
+				// Determining the minimum number of centroids to be probed
+				// to ensure that at least 'k' vectors are collected while
+				// examining at least 'nprobe' centroids.
+				var eligibleDocsTillNow int64
+				minEligibleCentroids := len(closestCentroidIDs)
+				for i, centroidID := range closestCentroidIDs {
+					eligibleDocsTillNow += clusterVectorCounts[centroidID]
+					// Stop once we've examined at least 'nprobe' centroids and
+					// collected at least 'k' vectors.
+					if eligibleDocsTillNow >= k && i+1 >= nprobe {
+						minEligibleCentroids = i + 1
+						break
+					}
+				}
+				// Search the clusters specified by 'closestCentroidIDs' for
+				// vectors whose IDs are present in 'vectorIDsToInclude'
+				scores, ids, err := vecIndex.SearchClustersFromIVFIndex(
+					selector, closestCentroidIDs, minEligibleCentroids,
+					k, qVector, centroidDistances, params)
+				if err != nil {
+					return nil, err
+				}
+				addIDsToPostingsList(rv, ids, scores)
 				return rv, nil
 			},
 			close: func() {

--- a/go.mod
+++ b/go.mod
@@ -4,8 +4,9 @@ go 1.21
 
 require (
 	github.com/RoaringBitmap/roaring v1.9.3
+	github.com/bits-and-blooms/bitset v1.22.0
 	github.com/blevesearch/bleve_index_api v1.1.12
-	github.com/blevesearch/go-faiss v1.0.24
+	github.com/blevesearch/go-faiss v1.0.25
 	github.com/blevesearch/mmap-go v1.0.4
 	github.com/blevesearch/scorch_segment_api/v2 v2.2.16
 	github.com/blevesearch/vellum v1.0.10
@@ -14,7 +15,6 @@ require (
 )
 
 require (
-	github.com/bits-and-blooms/bitset v1.12.0 // indirect
 	github.com/inconshreveable/mousetrap v1.1.0 // indirect
 	github.com/mschoch/smat v0.2.0 // indirect
 	github.com/spf13/pflag v1.0.5 // indirect

--- a/go.sum
+++ b/go.sum
@@ -1,11 +1,12 @@
 github.com/RoaringBitmap/roaring v1.9.3 h1:t4EbC5qQwnisr5PrP9nt0IRhRTb9gMUgQF4t4S2OByM=
 github.com/RoaringBitmap/roaring v1.9.3/go.mod h1:6AXUsoIEzDTFFQCe1RbGA6uFONMhvejWj5rqITANK90=
-github.com/bits-and-blooms/bitset v1.12.0 h1:U/q1fAF7xXRhFCrhROzIfffYnu+dlS38vCZtmFVPHmA=
 github.com/bits-and-blooms/bitset v1.12.0/go.mod h1:7hO7Gc7Pp1vODcmWvKMRA9BNmbv6a/7QIWpPxHddWR8=
+github.com/bits-and-blooms/bitset v1.22.0 h1:Tquv9S8+SGaS3EhyA+up3FXzmkhxPGjQQCkcs2uw7w4=
+github.com/bits-and-blooms/bitset v1.22.0/go.mod h1:7hO7Gc7Pp1vODcmWvKMRA9BNmbv6a/7QIWpPxHddWR8=
 github.com/blevesearch/bleve_index_api v1.1.12 h1:P4bw9/G/5rulOF7SJ9l4FsDoo7UFJ+5kexNy1RXfegY=
 github.com/blevesearch/bleve_index_api v1.1.12/go.mod h1:PbcwjIcRmjhGbkS/lJCpfgVSMROV6TRubGGAODaK1W8=
-github.com/blevesearch/go-faiss v1.0.24 h1:K79IvKjoKHdi7FdiXEsAhxpMuns0x4fM0BO93bW5jLI=
-github.com/blevesearch/go-faiss v1.0.24/go.mod h1:OMGQwOaRRYxrmeNdMrXJPvVx8gBnvE5RYrr0BahNnkk=
+github.com/blevesearch/go-faiss v1.0.25 h1:lel1rkOUGbT1CJ0YgzKwC7k+XH0XVBHnCVWahdCXk4U=
+github.com/blevesearch/go-faiss v1.0.25/go.mod h1:OMGQwOaRRYxrmeNdMrXJPvVx8gBnvE5RYrr0BahNnkk=
 github.com/blevesearch/mmap-go v1.0.4 h1:OVhDhT5B/M1HNPpYPBKIEJaD0F3Si+CrEKULGCDPWmc=
 github.com/blevesearch/mmap-go v1.0.4/go.mod h1:EWmEAOmdAS9z/pi/+Toxu99DnsbhG1TIxUoRmJw/pSs=
 github.com/blevesearch/scorch_segment_api/v2 v2.2.16 h1:uGvKVvG7zvSxCwcm4/ehBa9cCEuZVE+/zvrSl57QUVY=


### PR DESCRIPTION
- Refactor pre-filtered vector search to enhance performance and reduce memory footprint.
- Replace the current bitmap-based cluster selection mechanism with a simpler approach that uses the DirectMap in the IVF index. The IVF index's DirectMap directly maps the vector ID to the cluster it belongs to.
- Make `github.com/bits-and-blooms/bitset` a direct dependency of `zapx` and upgrade it to
  the latest version
- Requires https://github.com/blevesearch/go-faiss/pull/41

---------