### PR TITLE
Toy GPU

### DIFF
--- a/faiss_vector_cache.go
+++ b/faiss_vector_cache.go
@@ -65,7 +65,7 @@ func (vc *vectorIndexCache) Clear() {
 
 // loadOrCreate obtains the vector index from the cache or creates it if it's not present.
 func (vc *vectorIndexCache) loadOrCreate(fieldID uint16, mem []byte, numDocs uint32, except *roaring.Bitmap) (
-	index *faissIndex, mapping *idMapping, exclude *bitmap, err error) {
+	index faissIndex, mapping *idMapping, exclude *bitmap, err error) {
 	// first try to read from the cache with a read lock
 	vc.m.RLock()
 	if vc.isClosed {
@@ -97,7 +97,7 @@ func (vc *vectorIndexCache) loadOrCreate(fieldID uint16, mem []byte, numDocs uin
 
 // Rebuilding the cache on a miss.
 func (vc *vectorIndexCache) createAndCacheLOCKED(fieldID uint16, mem []byte,
-	numDocs uint32, except *roaring.Bitmap) (index *faissIndex,
+	numDocs uint32, except *roaring.Bitmap) (index faissIndex,
 	mapping *idMapping, exclude *bitmap, err error) {
 	// if the cache doesn't have the entry, construct the vector to doc id map and
 	// the vector index out of the mem bytes and update the cache under lock.
@@ -139,10 +139,10 @@ func (vc *vectorIndexCache) createAndCacheLOCKED(fieldID uint16, mem []byte,
 		return nil, nil, nil, fmt.Errorf("could not read faiss index size")
 	}
 	pos += n
-	index = &faissIndex{}
 
+	var rv faissIndex
 	// read the serialized vector index
-	index.fIndex, err = faiss.ReadIndexFromBuffer(mem[pos:pos+int(indexSize)], faissIOFlags)
+	fIndex, err := faiss.ReadIndexFromBuffer(mem[pos:pos+int(indexSize)], faissIOFlags)
 	if err != nil {
 		return nil, nil, nil, fmt.Errorf("faiss index load error: %v", err)
 	}
@@ -154,19 +154,28 @@ func (vc *vectorIndexCache) createAndCacheLOCKED(fieldID uint16, mem []byte,
 		pos += n
 
 		// read the serialized binary vector index
-		index.bIndex, err = faiss.ReadBinaryIndexFromBuffer(mem[pos:pos+int(binSize)], faissIOFlags)
+		bIndex, err := faiss.ReadBinaryIndexFromBuffer(mem[pos:pos+int(binSize)], faissIOFlags)
 		if err != nil {
 			return nil, nil, nil, fmt.Errorf("faiss binary index load error: %v", err)
 		}
 		pos += int(binSize)
+		rv, err = newFaissBinaryIndex(bIndex, fIndex)
+		if err != nil {
+			return nil, nil, nil, fmt.Errorf("faiss binary index creation error: %v", err)
+		}
+	} else {
+		rv, err = newFaissFloat32Index(fIndex)
+		if err != nil {
+			return nil, nil, nil, fmt.Errorf("faiss float32 index creation error: %v", err)
+		}
 	}
 	// update the cache
-	vc.insertLOCKED(fieldID, index, mapping)
-	return index, mapping, getExcludedVectors(mapping, except), nil
+	vc.insertLOCKED(fieldID, rv, mapping)
+	return rv, mapping, getExcludedVectors(mapping, except), nil
 }
 
 func (vc *vectorIndexCache) insertLOCKED(fieldID uint16,
-	index *faissIndex, mapping *idMapping) {
+	index faissIndex, mapping *idMapping) {
 	// the first time we've hit the cache, try to spawn a monitoring routine
 	// which will reconcile the moving averages for all the fields being hit
 	if len(vc.cache) == 0 {
@@ -269,7 +278,7 @@ func (e *ewma) add(val uint64) {
 
 // -----------------------------------------------------------------------------
 
-func createCacheEntry(index *faissIndex, mapping *idMapping, alpha float64) *cacheEntry {
+func createCacheEntry(index faissIndex, mapping *idMapping, alpha float64) *cacheEntry {
 	ce := &cacheEntry{
 		index:   index,
 		mapping: mapping,
@@ -290,7 +299,7 @@ type cacheEntry struct {
 	// threshold we close/cleanup only if the live refs to the cache entry is 0.
 	refs int64
 
-	index   *faissIndex
+	index   faissIndex
 	mapping *idMapping
 }
 
@@ -306,7 +315,7 @@ func (ce *cacheEntry) decRef() {
 	atomic.AddInt64(&ce.refs, -1)
 }
 
-func (ce *cacheEntry) load(except *roaring.Bitmap) (*faissIndex, *idMapping, *bitmap, error) {
+func (ce *cacheEntry) load(except *roaring.Bitmap) (faissIndex, *idMapping, *bitmap, error) {
 	ce.incHit()
 	ce.addRef()
 	return ce.index, ce.mapping, getExcludedVectors(ce.mapping, except), nil

--- a/faiss_vector_index.go
+++ b/faiss_vector_index.go
@@ -1,0 +1,78 @@
+//  Copyright (c) 2024 Couchbase, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// 		http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//go:build vectors
+// +build vectors
+
+package zap
+
+import "github.com/blevesearch/go-faiss"
+
+// Abstract interface for Faiss vector indices, which are returned by the go-faiss library.
+type FaissVectorIndex interface {
+	// returns the underlying IVF index if this is an IVF index,
+	// and a boolean indicating whether the cast was successful.
+	castIVF() (index FaissVectorIndexIVF, ok bool)
+}
+
+type FaissVectorIndexIVF interface {
+}
+
+// ---------------------------------
+// CPU Faiss Float32 Index
+// ---------------------------------
+type faissFloat32Index struct {
+	idx *faiss.IndexImpl
+}
+
+func newFaissFloat32Index(idx *faiss.IndexImpl) (index FaissVectorIndex, err error) {
+	return &faissFloat32Index{
+		idx: idx,
+	}, nil
+}
+
+func (f *faissFloat32Index) castIVF() (index FaissVectorIndexIVF, ok bool) {
+	if f.idx.IsIVFIndex() {
+		// return f itself, as the IVF interface is implemented by the same
+		// struct as the non-IVF interface in go-faiss.
+		return f, true
+	}
+	// not an IVF index, return nil and false.
+	return nil, false
+}
+
+// ---------------------------------
+// CPU Faiss Binary Index
+// ---------------------------------
+type faissBinaryIndex struct {
+	backing *faiss.IndexImpl
+	binary  *faiss.BinaryIndexImpl
+}
+
+func newFaissBinaryIndex(backing *faiss.IndexImpl, binary *faiss.BinaryIndexImpl) (index FaissVectorIndex, err error) {
+	return &faissBinaryIndex{
+		backing: backing,
+		binary:  binary,
+	}, nil
+}
+
+func (b *faissBinaryIndex) castIVF() (index FaissVectorIndexIVF, ok bool) {
+	if b.binary.IsIVFIndex() {
+		// return b itself, as the IVF interface is implemented by the same
+		// struct as the non-IVF interface in go-faiss.
+		return b, true
+	}
+	// not an IVF index, return nil and false.
+	return nil, false
+}

--- a/faiss_vector_index.go
+++ b/faiss_vector_index.go
@@ -17,16 +17,60 @@
 
 package zap
 
-import "github.com/blevesearch/go-faiss"
+import (
+	"fmt"
+
+	"github.com/blevesearch/go-faiss"
+)
 
 // Abstract interface for Faiss vector indices, which are returned by the go-faiss library.
-type FaissVectorIndex interface {
+type faissIndex interface {
+	// adds the given vectors to the index.
+	add(vecs *vectorSet) error
+	// searializes the index into a byte slice,
+	// which can be stored or transmitted.
+	serialize() ([]byte, error)
+	// closes the index and releases any associated resources.
+	close()
+	// returns the size of the index in bytes.
+	size() uint64
 	// returns the underlying IVF index if this is an IVF index,
 	// and a boolean indicating whether the cast was successful.
-	castIVF() (index FaissVectorIndexIVF, ok bool)
+	castIVF() (index faissIndexIVF, ok bool)
+	// returns the underlying SQ index if this is an SQ index,
+	// and a boolean indicating whether the cast was successful.
+	castSQ() (index faissIndexSQ, ok bool)
 }
 
-type FaissVectorIndexIVF interface {
+// Interface for Faiss vector indices that support reconstruction of vectors based on their IDs.
+type faissReconstructIndex interface {
+	faissIndex
+	// reconstructs the vectors corresponding to the given vector IDs.
+	// This is essential for merge operations, where we need to reconstruct
+	// vectors from existing indexes to add them to the new merged index.
+	reconstruct(vecIds []int64) ([]float32, error)
+}
+
+// Interface for IVF-specific operations on Faiss vector indices.
+type faissIndexIVF interface {
+	// sets the direct map type for the IVF index. The direct map is essential for
+	// reconstructing vectors based on their sequential vector IDs in future merges.
+	setDirectMap(directMapType int) error
+	// sets the number of probes (nprobe) for the IVF index. nprobe determines how many
+	// inverted lists are probed during search, and is a key parameter that controls the
+	// trade-off between search accuracy and latency.
+	setNProbe(nprobe int32)
+	// trains the IVF index on the provided training data. This step is necessary to
+	// perform k-means clustering to partition the data space of the index, which enables
+	// efficient non-exhaustive search during query time.
+	train(trainingData *vectorSet) error
+}
+
+type faissIndexSQ interface {
+	// trains the SQ index on the provided training data. This step is necessary to
+	// perform quantization of the vector space, which enables efficient storage and
+	// search of high-dimensional vectors.
+	train(trainingData *vectorSet) error
 }
 
 // ---------------------------------
@@ -36,13 +80,13 @@ type faissFloat32Index struct {
 	idx *faiss.IndexImpl
 }
 
-func newFaissFloat32Index(idx *faiss.IndexImpl) (index FaissVectorIndex, err error) {
+func newFaissFloat32Index(idx *faiss.IndexImpl) (index faissIndex, err error) {
 	return &faissFloat32Index{
 		idx: idx,
 	}, nil
 }
 
-func (f *faissFloat32Index) castIVF() (index FaissVectorIndexIVF, ok bool) {
+func (f *faissFloat32Index) castIVF() (index faissIndexIVF, ok bool) {
 	if f.idx.IsIVFIndex() {
 		// return f itself, as the IVF interface is implemented by the same
 		// struct as the non-IVF interface in go-faiss.
@@ -50,6 +94,52 @@ func (f *faissFloat32Index) castIVF() (index FaissVectorIndexIVF, ok bool) {
 	}
 	// not an IVF index, return nil and false.
 	return nil, false
+}
+
+func (f *faissFloat32Index) castSQ() (index faissIndexSQ, ok bool) {
+	if f.idx.IsSQIndex() {
+		// return f itself, as the SQ interface is implemented by the same
+		// struct as the non-SQ interface in go-faiss.
+		return f, true
+	}
+	// not an SQ index, return nil and false.
+	return nil, false
+}
+
+func (f *faissFloat32Index) close() {
+	if f.idx != nil {
+		f.idx.Close()
+	}
+}
+
+func (f *faissFloat32Index) setDirectMap(directMapType int) error {
+	return f.idx.SetDirectMap(directMapType)
+}
+
+func (f *faissFloat32Index) setNProbe(nprobe int32) {
+	f.idx.SetNProbe(nprobe)
+}
+
+func (f *faissFloat32Index) add(vecs *vectorSet) error {
+	// add the floatData from the vectorSet to the index
+	return f.idx.Add(vecs.floatData)
+}
+
+func (f *faissFloat32Index) train(trainingData *vectorSet) error {
+	// train the index using the floatData from the vectorSet
+	return f.idx.Train(trainingData.floatData)
+}
+
+func (f *faissFloat32Index) serialize() ([]byte, error) {
+	// serialize the index into a byte slice using go-faiss's WriteIndexToBuffer method
+	return faiss.WriteIndexIntoBuffer(f.idx)
+}
+
+func (f *faissFloat32Index) size() uint64 {
+	if f.idx == nil {
+		return 0
+	}
+	return f.idx.Size()
 }
 
 // ---------------------------------
@@ -60,14 +150,14 @@ type faissBinaryIndex struct {
 	binary  *faiss.BinaryIndexImpl
 }
 
-func newFaissBinaryIndex(backing *faiss.IndexImpl, binary *faiss.BinaryIndexImpl) (index FaissVectorIndex, err error) {
+func newFaissBinaryIndex(binary *faiss.BinaryIndexImpl, backing *faiss.IndexImpl) (index faissIndex, err error) {
 	return &faissBinaryIndex{
 		backing: backing,
 		binary:  binary,
 	}, nil
 }
 
-func (b *faissBinaryIndex) castIVF() (index FaissVectorIndexIVF, ok bool) {
+func (b *faissBinaryIndex) castIVF() (index faissIndexIVF, ok bool) {
 	if b.binary.IsIVFIndex() {
 		// return b itself, as the IVF interface is implemented by the same
 		// struct as the non-IVF interface in go-faiss.
@@ -75,4 +165,124 @@ func (b *faissBinaryIndex) castIVF() (index FaissVectorIndexIVF, ok bool) {
 	}
 	// not an IVF index, return nil and false.
 	return nil, false
+}
+
+// Binary indexes don't support SQ, so this always returns nil and false.
+func (b *faissBinaryIndex) castSQ() (index faissIndexSQ, ok bool) {
+	return nil, false
+}
+
+func (b *faissBinaryIndex) close() {
+	if b.binary != nil {
+		b.binary.Close()
+	}
+	if b.backing != nil {
+		b.backing.Close()
+	}
+}
+
+func (b *faissBinaryIndex) setDirectMap(directMapType int) error {
+	return b.binary.SetDirectMap(directMapType)
+}
+
+func (b *faissBinaryIndex) setNProbe(nprobe int32) {
+	b.binary.SetNProbe(nprobe)
+}
+
+func (b *faissBinaryIndex) add(vecs *vectorSet) error {
+	// add the binaryData from the vectorSet to the binary index
+	return b.binary.Add(vecs.binaryData)
+}
+
+func (b *faissBinaryIndex) train(trainingData *vectorSet) error {
+	// train the binary index using the binaryData from the vectorSet
+	return b.binary.Train(trainingData.binaryData)
+}
+
+func (b *faissBinaryIndex) serialize() ([]byte, error) {
+	// serialize the binary index into a byte slice using go-faiss's WriteIndexToBuffer method
+	return faiss.WriteBinaryIndexIntoBuffer(b.binary)
+}
+
+func (b *faissBinaryIndex) size() uint64 {
+	var sizeInBytes uint64
+	if b.binary != nil {
+		sizeInBytes += b.binary.Size()
+	}
+	if b.backing != nil {
+		sizeInBytes += b.backing.Size()
+	}
+	return sizeInBytes
+}
+
+// ----------------------------------
+// vectorSet
+// ----------------------------------
+type vectorSet struct {
+	// dimensionality of each vector
+	dim int
+	// number of vectors represented
+	nvecs int
+	// float vectors stored in row-major format,
+	// i.e. for N vectors of D dimensions,
+	// the length of this slice is N*D,
+	floatData []float32
+	// row-major binary representation of the float vectors,
+	// where each bit represents the sign bit
+	// of the corresponding float value.
+	binaryData []uint8
+}
+
+func newVectorSet(dim int, data []float32) (*vectorSet, error) {
+	if len(data) != dim || dim <= 0 {
+		return nil, fmt.Errorf("invalid vector data: dims %d, data length %d", dim, len(data))
+	}
+	nvecs := len(data) / dim
+	return &vectorSet{
+		dim:       dim,
+		nvecs:     nvecs,
+		floatData: data,
+	}, nil
+}
+
+// converts float32 vectors into binary format based on the sign bit
+// of the float32 values.
+func convertToBinary(vecs []float32, dims int) []uint8 {
+	nvecs := len(vecs) / dims
+	packed := make([]uint8, 0, nvecs*(dims+7)/8)
+	var cur uint8
+	var count int
+	for i := 0; i < nvecs; i++ {
+		count = 0
+		for j := 0; j < dims; j++ {
+			value := vecs[i*dims+j]
+			// Apply the threshold: convert the float32 to 1 or 0 based on threshold
+			if value >= 0.0 {
+				// Shift the bit into the correct position in the byte
+				cur |= (1 << (7 - count))
+			}
+			count++
+			// When we have 8 bits, store the byte and reset for the next byte
+			if count == 8 {
+				packed = append(packed, cur)
+				cur = 0
+				count = 0
+			}
+		}
+		// If there are any remaining bits, pack them into a byte and append
+		if count > 0 {
+			cur <<= (8 - count)
+			packed = append(packed, cur)
+		}
+	}
+	return packed
+}
+
+func (v *vectorSet) binarize() {
+	// if binaryData is already populated, no need to convert again
+	if v.binaryData != nil {
+		return
+	}
+	// convert the floatData to binary format and store in binaryData
+	v.binaryData = convertToBinary(v.floatData, v.dim)
 }

--- a/faiss_vector_index.go
+++ b/faiss_vector_index.go
@@ -18,41 +18,66 @@
 package zap
 
 import (
-	"fmt"
+	"encoding/json"
+	"errors"
 
 	"github.com/blevesearch/go-faiss"
+)
+
+var (
+	ErrNilIndex error = errors.New("faiss index cannot be nil")
 )
 
 // Abstract interface for Faiss vector indices, which are returned by the go-faiss library.
 type faissIndex interface {
 	// adds the given vectors to the index.
 	add(vecs *vectorSet) error
-	// searializes the index into a byte slice,
-	// which can be stored or transmitted.
-	serialize() ([]byte, error)
 	// closes the index and releases any associated resources.
 	close()
+	// returns the dimensionality of the vectors in the index.
+	dim() int
+	// returns the metric type used by the index, which determines how distances between vectors are computed during search.
+	metricType() int
+	// performs a search on the index using the provided query vector and parameters, with an optional
+	// exclude selector to indicate a "blocklist" of indexed vectors to ignore during search.
+	// It returns the distances and corresponding vector IDs of the top k results.
+	searchWithoutIDs(qVector *vectorSet, k int64, selector faiss.Selector, params json.RawMessage) ([]float32, []int64, error)
+	// performs a search on the index using the provided query vector and parameters, with a required
+	// include selector to indicate an "allowlist" of indexed vectors to consider during search.
+	// It returns the distances and corresponding vector IDs of the top k results.
+	searchWithIDs(qVector *vectorSet, k int64, selector faiss.Selector, params json.RawMessage) ([]float32, []int64, error)
+	// serializes the index into a byte slice,
+	// which can be stored or transmitted.
+	serialize() ([]byte, error)
 	// returns the size of the index in bytes.
 	size() uint64
+	// -----------------------------------------------------------------
+	// casting methods to access index-specific operations below
+	// -----------------------------------------------------------------
 	// returns the underlying IVF index if this is an IVF index,
 	// and a boolean indicating whether the cast was successful.
-	castIVF() (index faissIndexIVF, ok bool)
+	castIVF() faissIndexIVF
 	// returns the underlying SQ index if this is an SQ index,
 	// and a boolean indicating whether the cast was successful.
-	castSQ() (index faissIndexSQ, ok bool)
-}
-
-// Interface for Faiss vector indices that support reconstruction of vectors based on their IDs.
-type faissReconstructIndex interface {
-	faissIndex
-	// reconstructs the vectors corresponding to the given vector IDs.
-	// This is essential for merge operations, where we need to reconstruct
-	// vectors from existing indexes to add them to the new merged index.
-	reconstruct(vecIds []int64) ([]float32, error)
+	castSQ() faissIndexSQ
 }
 
 // Interface for IVF-specific operations on Faiss vector indices.
 type faissIndexIVF interface {
+	// returns the count of the selected vector IDs in each
+	// cluster of the IVF index, based on the provided selector.
+	clusterVectorCounts(sel faiss.Selector, nlist int) ([]int64, error)
+	// returns the top K cardinalities (number of vectors) of the centroids in the IVF index.
+	centroidCardinalities(limit int, descending bool) ([]uint64, [][]float32, error)
+	// returns the IVF index parameters, nprobe and nlist from the ivf index.
+	ivfParams() (nprobe, nlist int)
+	// performs a search on the flat index quantizer of the IVF index, considering only the
+	// clusters selected by the centroidSelector and returns the search results.
+	searchQuantizer(qVector *vectorSet, centroidSelector faiss.Selector, centroidCount int64) ([]int64, []float32, error)
+	// performs a search on the IVF index by probing the specified clusters and returns the search results.
+	// We restrict the search to a caller-supplied set of pre-assigned clusters rather than probing internally.
+	searchClusters(eligibleCentroidIDs []int64, centroidDis []float32,
+		centroidsToProbe int, qVecSet *vectorSet, k int64, selector faiss.Selector, params json.RawMessage) ([]float32, []int64, error)
 	// sets the direct map type for the IVF index. The direct map is essential for
 	// reconstructing vectors based on their sequential vector IDs in future merges.
 	setDirectMap(directMapType int) error
@@ -71,218 +96,4 @@ type faissIndexSQ interface {
 	// perform quantization of the vector space, which enables efficient storage and
 	// search of high-dimensional vectors.
 	train(trainingData *vectorSet) error
-}
-
-// ---------------------------------
-// CPU Faiss Float32 Index
-// ---------------------------------
-type faissFloat32Index struct {
-	idx *faiss.IndexImpl
-}
-
-func newFaissFloat32Index(idx *faiss.IndexImpl) (index faissIndex, err error) {
-	return &faissFloat32Index{
-		idx: idx,
-	}, nil
-}
-
-func (f *faissFloat32Index) castIVF() (index faissIndexIVF, ok bool) {
-	if f.idx.IsIVFIndex() {
-		// return f itself, as the IVF interface is implemented by the same
-		// struct as the non-IVF interface in go-faiss.
-		return f, true
-	}
-	// not an IVF index, return nil and false.
-	return nil, false
-}
-
-func (f *faissFloat32Index) castSQ() (index faissIndexSQ, ok bool) {
-	if f.idx.IsSQIndex() {
-		// return f itself, as the SQ interface is implemented by the same
-		// struct as the non-SQ interface in go-faiss.
-		return f, true
-	}
-	// not an SQ index, return nil and false.
-	return nil, false
-}
-
-func (f *faissFloat32Index) close() {
-	if f.idx != nil {
-		f.idx.Close()
-	}
-}
-
-func (f *faissFloat32Index) setDirectMap(directMapType int) error {
-	return f.idx.SetDirectMap(directMapType)
-}
-
-func (f *faissFloat32Index) setNProbe(nprobe int32) {
-	f.idx.SetNProbe(nprobe)
-}
-
-func (f *faissFloat32Index) add(vecs *vectorSet) error {
-	// add the floatData from the vectorSet to the index
-	return f.idx.Add(vecs.floatData)
-}
-
-func (f *faissFloat32Index) train(trainingData *vectorSet) error {
-	// train the index using the floatData from the vectorSet
-	return f.idx.Train(trainingData.floatData)
-}
-
-func (f *faissFloat32Index) serialize() ([]byte, error) {
-	// serialize the index into a byte slice using go-faiss's WriteIndexToBuffer method
-	return faiss.WriteIndexIntoBuffer(f.idx)
-}
-
-func (f *faissFloat32Index) size() uint64 {
-	if f.idx == nil {
-		return 0
-	}
-	return f.idx.Size()
-}
-
-// ---------------------------------
-// CPU Faiss Binary Index
-// ---------------------------------
-type faissBinaryIndex struct {
-	backing *faiss.IndexImpl
-	binary  *faiss.BinaryIndexImpl
-}
-
-func newFaissBinaryIndex(binary *faiss.BinaryIndexImpl, backing *faiss.IndexImpl) (index faissIndex, err error) {
-	return &faissBinaryIndex{
-		backing: backing,
-		binary:  binary,
-	}, nil
-}
-
-func (b *faissBinaryIndex) castIVF() (index faissIndexIVF, ok bool) {
-	if b.binary.IsIVFIndex() {
-		// return b itself, as the IVF interface is implemented by the same
-		// struct as the non-IVF interface in go-faiss.
-		return b, true
-	}
-	// not an IVF index, return nil and false.
-	return nil, false
-}
-
-// Binary indexes don't support SQ, so this always returns nil and false.
-func (b *faissBinaryIndex) castSQ() (index faissIndexSQ, ok bool) {
-	return nil, false
-}
-
-func (b *faissBinaryIndex) close() {
-	if b.binary != nil {
-		b.binary.Close()
-	}
-	if b.backing != nil {
-		b.backing.Close()
-	}
-}
-
-func (b *faissBinaryIndex) setDirectMap(directMapType int) error {
-	return b.binary.SetDirectMap(directMapType)
-}
-
-func (b *faissBinaryIndex) setNProbe(nprobe int32) {
-	b.binary.SetNProbe(nprobe)
-}
-
-func (b *faissBinaryIndex) add(vecs *vectorSet) error {
-	// add the binaryData from the vectorSet to the binary index
-	return b.binary.Add(vecs.binaryData)
-}
-
-func (b *faissBinaryIndex) train(trainingData *vectorSet) error {
-	// train the binary index using the binaryData from the vectorSet
-	return b.binary.Train(trainingData.binaryData)
-}
-
-func (b *faissBinaryIndex) serialize() ([]byte, error) {
-	// serialize the binary index into a byte slice using go-faiss's WriteIndexToBuffer method
-	return faiss.WriteBinaryIndexIntoBuffer(b.binary)
-}
-
-func (b *faissBinaryIndex) size() uint64 {
-	var sizeInBytes uint64
-	if b.binary != nil {
-		sizeInBytes += b.binary.Size()
-	}
-	if b.backing != nil {
-		sizeInBytes += b.backing.Size()
-	}
-	return sizeInBytes
-}
-
-// ----------------------------------
-// vectorSet
-// ----------------------------------
-type vectorSet struct {
-	// dimensionality of each vector
-	dim int
-	// number of vectors represented
-	nvecs int
-	// float vectors stored in row-major format,
-	// i.e. for N vectors of D dimensions,
-	// the length of this slice is N*D,
-	floatData []float32
-	// row-major binary representation of the float vectors,
-	// where each bit represents the sign bit
-	// of the corresponding float value.
-	binaryData []uint8
-}
-
-func newVectorSet(dim int, data []float32) (*vectorSet, error) {
-	if len(data) != dim || dim <= 0 {
-		return nil, fmt.Errorf("invalid vector data: dims %d, data length %d", dim, len(data))
-	}
-	nvecs := len(data) / dim
-	return &vectorSet{
-		dim:       dim,
-		nvecs:     nvecs,
-		floatData: data,
-	}, nil
-}
-
-// converts float32 vectors into binary format based on the sign bit
-// of the float32 values.
-func convertToBinary(vecs []float32, dims int) []uint8 {
-	nvecs := len(vecs) / dims
-	packed := make([]uint8, 0, nvecs*(dims+7)/8)
-	var cur uint8
-	var count int
-	for i := 0; i < nvecs; i++ {
-		count = 0
-		for j := 0; j < dims; j++ {
-			value := vecs[i*dims+j]
-			// Apply the threshold: convert the float32 to 1 or 0 based on threshold
-			if value >= 0.0 {
-				// Shift the bit into the correct position in the byte
-				cur |= (1 << (7 - count))
-			}
-			count++
-			// When we have 8 bits, store the byte and reset for the next byte
-			if count == 8 {
-				packed = append(packed, cur)
-				cur = 0
-				count = 0
-			}
-		}
-		// If there are any remaining bits, pack them into a byte and append
-		if count > 0 {
-			cur <<= (8 - count)
-			packed = append(packed, cur)
-		}
-	}
-	return packed
-}
-
-func (v *vectorSet) binarize() {
-	// if binaryData is already populated, no need to convert again
-	if v.binaryData != nil {
-		return
-	}
-	// convert the floatData to binary format and store in binaryData
-	v.binaryData = convertToBinary(v.floatData, v.dim)
 }

--- a/faiss_vector_index.go
+++ b/faiss_vector_index.go
@@ -91,9 +91,18 @@ type faissIndexIVF interface {
 	train(trainingData *vectorSet) error
 }
 
+// Interface for SQ-specific operations on Faiss vector indices.
 type faissIndexSQ interface {
 	// trains the SQ index on the provided training data. This step is necessary to
 	// perform quantization of the vector space, which enables efficient storage and
 	// search of high-dimensional vectors.
 	train(trainingData *vectorSet) error
+}
+
+// Interface for batched search operations on Faiss vector indices.
+type faissIndexBatch interface {
+	// performs a batch search on the index using the provided query vector and parameters,
+	// and returns the distances and corresponding vector IDs of the top k results.
+	// NOTE: only vector search requests with the same `k` are batched together.
+	batchSearch(qVector *vectorSet, k int64) ([]float32, []int64, error)
 }

--- a/faiss_vector_index_bivf.go
+++ b/faiss_vector_index_bivf.go
@@ -1,0 +1,214 @@
+//  Copyright (c) 2026 Couchbase, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// 		http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//go:build vectors
+// +build vectors
+
+package zap
+
+import (
+	"encoding/json"
+
+	faiss "github.com/blevesearch/go-faiss"
+)
+
+// ---------------------------------
+// Faiss Binary IVF Index
+// ---------------------------------
+type faissBinaryIndex struct {
+	backing *faiss.IndexImpl
+	binary  *faiss.BinaryIndexImpl
+}
+
+func newFaissBinaryIndex(binary *faiss.BinaryIndexImpl, backing *faiss.IndexImpl) (index faissIndex, err error) {
+	// the binary index cannot be nil, but the backing index can be nil, depending on the use case.
+	if binary == nil {
+		return nil, ErrNilIndex
+	}
+	return &faissBinaryIndex{
+		backing: backing,
+		binary:  binary,
+	}, nil
+}
+
+func (b *faissBinaryIndex) add(vecs *vectorSet) error {
+	// add the binaryData from the vectorSet to the binary index
+	return b.binary.Add(vecs.binaryData)
+}
+
+func (b *faissBinaryIndex) close() {
+	b.binary.Close()
+	if b.backing != nil {
+		b.backing.Close()
+	}
+}
+
+func (b *faissBinaryIndex) dim() int {
+	return b.binary.D()
+}
+
+func (b *faissBinaryIndex) metricType() int {
+	if b.backing != nil {
+		return b.backing.MetricType()
+	}
+	return b.binary.MetricType()
+}
+
+func (b *faissBinaryIndex) searchWithoutIDs(qVector *vectorSet, k int64, selector faiss.Selector, params json.RawMessage) ([]float32, []int64, error) {
+	// search the binary index with oversampling and then do a re-ranking on the
+	// FAISS index to get the top K results
+	// first binarize the query vector if not already done
+	qVector.binarize()
+	_, binIDs, err := b.binary.SearchWithoutIDs(qVector.binaryData, binaryOversampleValue*k,
+		selector, params)
+	if err != nil {
+		return nil, nil, err
+	}
+	distances, err := b.backing.DistCompute(qVector.floatData, binIDs)
+	if err != nil {
+		return nil, nil, err
+	}
+	// quick select algorithm for inplace partial sorting to get top K results
+	// based on distances/scores
+	scores, labels := topNIDsByDistance(distances, binIDs, int(k))
+	return scores, labels, nil
+}
+
+func (b *faissBinaryIndex) searchWithIDs(qVector *vectorSet, k int64, selector faiss.Selector, params json.RawMessage) ([]float32, []int64, error) {
+	// search the binary index with oversampling and then do a re-ranking on the
+	// FAISS index to get the top K results
+	// first binarize the query vector if not already done
+	qVector.binarize()
+	_, binIDs, err := b.binary.SearchWithIDs(qVector.binaryData, binaryOversampleValue*k,
+		selector, params)
+	if err != nil {
+		return nil, nil, err
+	}
+	distances, err := b.backing.DistCompute(qVector.floatData, binIDs)
+	if err != nil {
+		return nil, nil, err
+	}
+	// quick select algorithm for inplace partial sorting to get top K results
+	// based on distances/scores
+	scores, labels := topNIDsByDistance(distances, binIDs, int(k))
+	return scores, labels, nil
+}
+
+func (b *faissBinaryIndex) serialize() ([]byte, error) {
+	return faiss.WriteBinaryIndexIntoBuffer(b.binary)
+}
+
+func (b *faissBinaryIndex) size() uint64 {
+	sizeInBytes := b.binary.Size()
+	if b.backing != nil {
+		sizeInBytes += b.backing.Size()
+	}
+	return sizeInBytes
+}
+
+// -----------------------------------------------------------------
+// casting methods to access index-specific operations below
+// -----------------------------------------------------------------
+func (b *faissBinaryIndex) castIVF() faissIndexIVF {
+	if b.binary.IsIVFIndex() {
+		// return b itself, as the IVF interface is implemented by the same
+		// struct as the non-IVF interface in go-faiss.
+		return b
+	}
+	// not an IVF index, return nil.
+	return nil
+}
+
+// Binary indexes don't support SQ, so this always returns nil.
+func (b *faissBinaryIndex) castSQ() faissIndexSQ {
+	return nil
+}
+
+// -----------------------------------------------------------------
+// IVF-Index specific operations
+// -----------------------------------------------------------------
+
+func (b *faissBinaryIndex) centroidCardinalities(limit int, descending bool) ([]uint64, [][]float32, error) {
+	cardinalites, bCentroids, err := b.binary.ObtainKCentroidCardinalitiesFromIVFIndex(limit, descending)
+	if err != nil {
+		return nil, nil, err
+	}
+	centroids := make([][]float32, len(bCentroids))
+	for i := range bCentroids {
+		centroids[i] = make([]float32, len(bCentroids[i]))
+		for j := range bCentroids[i] {
+			centroids[i][j] = float32(bCentroids[i][j])
+		}
+	}
+	return cardinalites, centroids, nil
+}
+
+func (b *faissBinaryIndex) clusterVectorCounts(sel faiss.Selector, nlist int) ([]int64, error) {
+	return b.binary.ObtainClusterVectorCountsFromIVFIndex(sel, nlist)
+}
+
+func (b *faissBinaryIndex) ivfParams() (nprobe, nlist int) {
+	return b.binary.IVFParams()
+}
+
+func (b *faissBinaryIndex) searchQuantizer(qVector *vectorSet, centroidSelector faiss.Selector, centroidCount int64) ([]int64, []float32, error) {
+	// binarize the query vector if not already done
+	qVector.binarize()
+	ids, dis, err := b.binary.ObtainClustersWithDistancesFromIVFIndex(qVector.binaryData, centroidSelector, centroidCount)
+	if err != nil {
+		return nil, nil, err
+	}
+	distances := make([]float32, len(dis))
+	for i, d := range dis {
+		distances[i] = float32(d)
+	}
+	return ids, distances, nil
+}
+
+func (b *faissBinaryIndex) searchClusters(eligibleCentroidIDs []int64, centroidDis []float32,
+	centroidsToProbe int, qVecSet *vectorSet, k int64, selector faiss.Selector, params json.RawMessage) ([]float32, []int64, error) {
+	// search the binary index without oversampling, since we are already searching a
+	// limited number of centroids specified by centroidsToProbe
+	// binarize the query vector if not already done
+	qVecSet.binarize()
+	// convert the float distances to binary distances for the binary index search
+	binDis := make([]int32, len(centroidDis))
+	for i, d := range centroidDis {
+		binDis[i] = int32(d)
+	}
+	_, binIds, err := b.binary.SearchClustersFromIVFIndex(eligibleCentroidIDs, binDis,
+		centroidsToProbe, qVecSet.binaryData, k, selector, params)
+	if err != nil {
+		return nil, nil, err
+	}
+	// reranking is still necessary since hamming distance has a lot of collisions
+	distances, err := b.backing.DistCompute(qVecSet.floatData, binIds)
+	if err != nil {
+		return nil, nil, err
+	}
+	return distances, binIds, nil
+}
+
+func (b *faissBinaryIndex) setDirectMap(directMapType int) error {
+	return b.binary.SetDirectMap(directMapType)
+}
+
+func (b *faissBinaryIndex) setNProbe(nprobe int32) {
+	b.binary.SetNProbe(nprobe)
+}
+
+func (b *faissBinaryIndex) train(trainingData *vectorSet) error {
+	// train the binary index using the binaryData from the vectorSet
+	return b.binary.Train(trainingData.binaryData)
+}

--- a/faiss_vector_index_bivf.go
+++ b/faiss_vector_index_bivf.go
@@ -70,18 +70,31 @@ func (b *faissBinaryIndex) searchWithoutIDs(qVector *vectorSet, k int64, selecto
 	// FAISS index to get the top K results
 	// first binarize the query vector if not already done
 	qVector.binarize()
-	_, binIDs, err := b.binary.SearchWithoutIDs(qVector.binaryData, binaryOversampleValue*k,
+	binDis, binIDs, err := b.binary.SearchWithoutIDs(qVector.binaryData, binaryOversampleValue*k,
 		selector, params)
 	if err != nil {
 		return nil, nil, err
 	}
-	distances, err := b.backing.DistCompute(qVector.floatData, binIDs)
-	if err != nil {
-		return nil, nil, err
+	var scores []float32
+	var labels []int64
+	// if we have a backing index for re-ranking, compute the distances/scores for the
+	// retrieved binary IDs and then get the top K results based on those distances/scores.
+	if b.backing != nil {
+		distances, err := b.backing.DistCompute(qVector.floatData, binIDs)
+		if err != nil {
+			return nil, nil, err
+		}
+		// quick select algorithm for inplace partial sorting to get top K results
+		// based on distances/scores
+		scores, labels = topNIDsByDistance(distances, binIDs, int(k))
+	} else {
+		// if we don't have a backing index for re-ranking, we retun the top K results based on the binary distances.
+		scores = make([]float32, k)
+		for i, d := range binDis[:k] {
+			scores[i] = float32(d)
+		}
+		labels = binIDs[:k]
 	}
-	// quick select algorithm for inplace partial sorting to get top K results
-	// based on distances/scores
-	scores, labels := topNIDsByDistance(distances, binIDs, int(k))
 	return scores, labels, nil
 }
 
@@ -90,18 +103,31 @@ func (b *faissBinaryIndex) searchWithIDs(qVector *vectorSet, k int64, selector f
 	// FAISS index to get the top K results
 	// first binarize the query vector if not already done
 	qVector.binarize()
-	_, binIDs, err := b.binary.SearchWithIDs(qVector.binaryData, binaryOversampleValue*k,
+	binDis, binIDs, err := b.binary.SearchWithIDs(qVector.binaryData, binaryOversampleValue*k,
 		selector, params)
 	if err != nil {
 		return nil, nil, err
 	}
-	distances, err := b.backing.DistCompute(qVector.floatData, binIDs)
-	if err != nil {
-		return nil, nil, err
+	var scores []float32
+	var labels []int64
+	// if we have a backing index for re-ranking, compute the distances/scores for the
+	// retrieved binary IDs and then get the top K results based on those distances/scores.
+	if b.backing != nil {
+		distances, err := b.backing.DistCompute(qVector.floatData, binIDs)
+		if err != nil {
+			return nil, nil, err
+		}
+		// quick select algorithm for inplace partial sorting to get top K results
+		// based on distances/scores
+		scores, labels = topNIDsByDistance(distances, binIDs, int(k))
+	} else {
+		// if we don't have a backing index for re-ranking, we retun the top K results based on the binary distances.
+		scores = make([]float32, k)
+		for i, d := range binDis[:k] {
+			scores[i] = float32(d)
+		}
+		labels = binIDs[:k]
 	}
-	// quick select algorithm for inplace partial sorting to get top K results
-	// based on distances/scores
-	scores, labels := topNIDsByDistance(distances, binIDs, int(k))
 	return scores, labels, nil
 }
 
@@ -177,27 +203,44 @@ func (b *faissBinaryIndex) searchQuantizer(qVector *vectorSet, centroidSelector 
 }
 
 func (b *faissBinaryIndex) searchClusters(eligibleCentroidIDs []int64, centroidDis []float32,
-	centroidsToProbe int, qVecSet *vectorSet, k int64, selector faiss.Selector, params json.RawMessage) ([]float32, []int64, error) {
+	centroidsToProbe int, qVector *vectorSet, k int64, selector faiss.Selector, params json.RawMessage) ([]float32, []int64, error) {
+	// binarize the query vector if not already done
+	qVector.binarize()
+	// convert the float distances to binary distances for the binary index search
+	binaryCentroidDis := make([]int32, len(centroidDis))
+	for i, d := range centroidDis {
+		binaryCentroidDis[i] = int32(d)
+	}
 	// search the binary index without oversampling, since we are already searching a
 	// limited number of centroids specified by centroidsToProbe
-	// binarize the query vector if not already done
-	qVecSet.binarize()
-	// convert the float distances to binary distances for the binary index search
-	binDis := make([]int32, len(centroidDis))
-	for i, d := range centroidDis {
-		binDis[i] = int32(d)
-	}
-	_, binIds, err := b.binary.SearchClustersFromIVFIndex(eligibleCentroidIDs, binDis,
-		centroidsToProbe, qVecSet.binaryData, k, selector, params)
+	binDis, binIDs, err := b.binary.SearchClustersFromIVFIndex(eligibleCentroidIDs, binaryCentroidDis,
+		centroidsToProbe, qVector.binaryData, k, selector, params)
 	if err != nil {
 		return nil, nil, err
 	}
-	// reranking is still necessary since hamming distance has a lot of collisions
-	distances, err := b.backing.DistCompute(qVecSet.floatData, binIds)
-	if err != nil {
-		return nil, nil, err
+	var scores []float32
+	var labels []int64
+	// if we have a backing index for re-ranking, compute the distances/scores for the
+	// retrieved binary IDs and then get the top K results based on those distances/scores.
+	if b.backing != nil {
+		// reranking is still necessary since hamming distance has a lot of collisions
+		distances, err := b.backing.DistCompute(qVector.floatData, binIDs)
+		if err != nil {
+			return nil, nil, err
+		}
+		// quick select algorithm for inplace partial sorting to get top K results
+		// based on distances/scores
+		scores, labels = topNIDsByDistance(distances, binIDs, int(k))
+	} else {
+		// if we don't have a backing index for re-ranking, we
+		// return the top K results based on the binary distances.
+		scores = make([]float32, k)
+		for i, d := range binDis[:k] {
+			scores[i] = float32(d)
+		}
+		labels = binIDs[:k]
 	}
-	return distances, binIds, nil
+	return scores, labels, nil
 }
 
 func (b *faissBinaryIndex) setDirectMap(directMapType int) error {

--- a/faiss_vector_index_float32.go
+++ b/faiss_vector_index_float32.go
@@ -1,0 +1,132 @@
+//  Copyright (c) 2026 Couchbase, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// 		http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//go:build vectors
+// +build vectors
+
+package zap
+
+import (
+	"encoding/json"
+
+	faiss "github.com/blevesearch/go-faiss"
+)
+
+// ---------------------------------
+// Faiss Float32 Index
+// ---------------------------------
+type faissFloat32Index struct {
+	idx *faiss.IndexImpl
+}
+
+func newFaissFloat32Index(idx *faiss.IndexImpl) (index faissIndex, err error) {
+	if idx == nil {
+		return nil, ErrNilIndex
+	}
+	return &faissFloat32Index{
+		idx: idx,
+	}, nil
+}
+
+func (f *faissFloat32Index) add(vecs *vectorSet) error {
+	return f.idx.Add(vecs.floatData)
+}
+
+func (f *faissFloat32Index) close() {
+	f.idx.Close()
+}
+
+func (f *faissFloat32Index) dim() int {
+	return f.idx.D()
+}
+
+func (f *faissFloat32Index) metricType() int {
+	return f.idx.MetricType()
+}
+
+func (f *faissFloat32Index) searchWithoutIDs(qVector *vectorSet, k int64, selector faiss.Selector, params json.RawMessage) ([]float32, []int64, error) {
+	return f.idx.SearchWithoutIDs(qVector.floatData, k, selector, params)
+}
+
+func (f *faissFloat32Index) searchWithIDs(qVector *vectorSet, k int64, selector faiss.Selector, params json.RawMessage) ([]float32, []int64, error) {
+	return f.idx.SearchWithIDs(qVector.floatData, k, selector, params)
+}
+
+func (f *faissFloat32Index) serialize() ([]byte, error) {
+	return faiss.WriteIndexIntoBuffer(f.idx)
+}
+
+func (f *faissFloat32Index) size() uint64 {
+	return f.idx.Size()
+}
+
+// -----------------------------------------------------------------
+// casting methods to access index-specific operations below
+// -----------------------------------------------------------------
+func (f *faissFloat32Index) castIVF() faissIndexIVF {
+	if f.idx.IsIVFIndex() {
+		// return f itself, as the IVF interface is implemented by the same
+		// struct as the non-IVF interface in go-faiss.
+		return f
+	}
+	// not an IVF index, return nil.
+	return nil
+}
+
+func (f *faissFloat32Index) castSQ() faissIndexSQ {
+	if f.idx.IsSQIndex() {
+		// return f itself, as the SQ interface is implemented by the same
+		// struct as the non-SQ interface in go-faiss.
+		return f
+	}
+	// not an SQ index, return nil.
+	return nil
+}
+
+// -----------------------------------------------------------------
+// IVF-Index specific operations
+// -----------------------------------------------------------------
+func (f *faissFloat32Index) clusterVectorCounts(sel faiss.Selector, nlist int) ([]int64, error) {
+	return f.idx.ObtainClusterVectorCountsFromIVFIndex(sel, nlist)
+}
+
+func (f *faissFloat32Index) centroidCardinalities(limit int, descending bool) ([]uint64, [][]float32, error) {
+	return f.idx.ObtainKCentroidCardinalitiesFromIVFIndex(limit, descending)
+}
+
+func (f *faissFloat32Index) ivfParams() (nprobe, nlist int) {
+	return f.idx.IVFParams()
+}
+
+func (f *faissFloat32Index) searchQuantizer(qVector *vectorSet, centroidSelector faiss.Selector, centroidCount int64) ([]int64, []float32, error) {
+	return f.idx.ObtainClustersWithDistancesFromIVFIndex(qVector.floatData, centroidSelector, centroidCount)
+}
+
+func (f *faissFloat32Index) searchClusters(eligibleCentroidIDs []int64, centroidDis []float32,
+	centroidsToProbe int, qVecSet *vectorSet, k int64, selector faiss.Selector, params json.RawMessage) ([]float32, []int64, error) {
+	return f.idx.SearchClustersFromIVFIndex(eligibleCentroidIDs, centroidDis, centroidsToProbe, qVecSet.floatData, k, selector, params)
+}
+
+func (f *faissFloat32Index) setDirectMap(directMapType int) error {
+	return f.idx.SetDirectMap(directMapType)
+}
+
+func (f *faissFloat32Index) setNProbe(nprobe int32) {
+	f.idx.SetNProbe(nprobe)
+}
+
+func (f *faissFloat32Index) train(trainingData *vectorSet) error {
+	// train the index using the floatData from the vectorSet
+	return f.idx.Train(trainingData.floatData)
+}

--- a/faiss_vector_request_batcher.go
+++ b/faiss_vector_request_batcher.go
@@ -1,0 +1,266 @@
+//  Copyright (c) 2026 Couchbase, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// 		http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//go:build vectors
+// +build vectors
+
+package zap
+
+import (
+	"errors"
+	"time"
+)
+
+var (
+	// adaptive batching parameters - these can be tuned based on the expected workload and latency requirements.
+
+	// MinLatencyBudget is the minimum amount of time that the batcher will wait before flushing a batch of requests.
+	MinLatencyBudget time.Duration = 10 * time.Millisecond
+	// MaxLatencyBudget is the maximum amount of time that the batcher will wait before flushing a batch of requests.
+	MaxLatencyBudget time.Duration = 250 * time.Millisecond
+)
+
+var (
+	errBatcherStopped error = errors.New("batcher has been stopped")
+)
+
+// The requestBatcher is responsible for batching search requests to a Faiss index.
+// It will accumulate incoming search requests and execute them in batches to improve performance.
+// The batcher will use the provided Faiss index to perform the searches, and it
+// will manage the batching logic, including timing and concurrency control.
+type requestBatcher struct {
+	// the coalesce queue that manages the batching of incoming search requests.
+	cq *coalesceQueue
+}
+
+func newRequestBatcher(idx faissIndexBatch) *requestBatcher {
+	b := &requestBatcher{
+		cq: newCoalesceQueue(idx),
+	}
+	return b
+}
+
+func (b *requestBatcher) search(qVector *vectorSet, k int64) ([]float32, []int64, error) {
+	// create a new batch request for this search query.
+	req, respCh := newBatchRequest(qVector, k)
+	// check if the batcher has been stopped before processing the search request.
+	select {
+	case b.cq.enqueueCh <- req:
+	case <-b.cq.stopCh:
+		return nil, nil, errBatcherStopped
+	}
+	// wait for the search results to be sent back through the response channel,
+	// and return those results to the caller.
+	resp := <-respCh
+	return resp.distances, resp.ids, resp.err
+}
+
+func (b *requestBatcher) stop() {
+	b.cq.stop()
+}
+
+// --------------------------------------------------
+// batch request
+// --------------------------------------------------
+
+type batchRequest struct {
+	qVector *vectorSet
+	k       int64
+	respCh  []chan *batchResponse
+}
+
+func newBatchRequest(qVector *vectorSet, k int64) (*batchRequest, chan *batchResponse) {
+	// response channel for sending the search results back to the requester.
+	respChan := make(chan *batchResponse, 1)
+	return &batchRequest{
+		qVector: qVector,
+		k:       k,
+		respCh:  []chan *batchResponse{respChan},
+	}, respChan
+}
+
+func (r *batchRequest) canMerge(other *batchRequest) bool {
+	// for now, we can only merge requests that have the same k value,
+	// since the Faiss search API requires a single k value for each search.
+	return r.k == other.k
+}
+
+func (r *batchRequest) mergeWith(other *batchRequest) {
+	if !r.canMerge(other) {
+		return
+	}
+	// since we are merging the query vectors of two requests, we need to clone
+	// the original query vector to avoid mutating the original request's query vector when we merge.
+	r.qVector = r.qVector.clone()
+	// merge the query vectors of the two requests by concatenating them together.
+	r.qVector.mergeWith(other.qVector)
+	// append the response channels from the other request to this request, so that when the search results are ready,
+	// we can send the results back to all requesters that were merged into this batch.
+	r.respCh = append(r.respCh, other.respCh...)
+}
+
+func (r *batchRequest) sendResponse(distances []float32, ids []int64, err error) {
+	// we may have multiple batches merged together, so we need segregate the results for each original request
+	// and send them back to the appropriate response channels.
+	if err != nil {
+		// if there was an error during the search, send the error back to all requesters in this batch.
+		for _, respCh := range r.respCh {
+			respCh <- newBatchResponse(nil, nil, err)
+			close(respCh)
+		}
+		return
+	}
+	// if the search was successful, we need to split the combined results back into individual responses for each original request.
+	for i, respCh := range r.respCh {
+		offset := int64(i) * r.k
+		// calculate the start and end indices for the results corresponding to this response channel.
+		curDistances := distances[offset : offset+r.k]
+		curIDs := ids[offset : offset+r.k]
+		// send the results back to the requester through the response channel.
+		respCh <- newBatchResponse(curDistances, curIDs, nil)
+		// close the response channel to signal that the response has been sent and there will be no more data.
+		close(respCh)
+	}
+}
+
+// --------------------------------------------------
+// batch response
+// --------------------------------------------------
+
+type batchResponse struct {
+	distances []float32
+	ids       []int64
+	err       error
+}
+
+func newBatchResponse(distances []float32, ids []int64, err error) *batchResponse {
+	return &batchResponse{
+		distances: distances,
+		ids:       ids,
+		err:       err,
+	}
+}
+
+// --------------------------------------------------
+// coalesceQueue
+// --------------------------------------------------
+
+type coalesceQueue struct {
+	// the Faiss index that this coalesce queue will execute search requests against.
+	idx faissIndexBatch
+	// channel for enqueuing new batch requests into the queue.
+	enqueueCh chan *batchRequest
+	// channel for signaling the batcher to stop processing requests and shut down.
+	stopCh chan struct{}
+	// queue of pending batch requests that are waiting to be processed.
+	queue []*batchRequest
+	// timer for automatically triggering the execution of a batch of requests when the earliest deadline is reached.
+	timer *time.Timer
+	// timestamp of the last time the queue was flushed.
+	lastFlush time.Time
+}
+
+func newCoalesceQueue(idx faissIndexBatch) *coalesceQueue {
+	rv := &coalesceQueue{
+		idx:       idx,
+		queue:     make([]*batchRequest, 0),
+		enqueueCh: make(chan *batchRequest),
+		stopCh:    make(chan struct{}),
+	}
+	go rv.monitor()
+	return rv
+}
+
+func (q *coalesceQueue) stop() {
+	if isClosed(q.stopCh) {
+		return
+	}
+	close(q.stopCh)
+}
+
+func (q *coalesceQueue) monitor() {
+	var dequeueTimer <-chan time.Time
+	for {
+		select {
+		case req := <-q.enqueueCh:
+			if len(q.queue) == 0 {
+				dequeueTimer = q.startTimer()
+			}
+			q.enqueue(req)
+		case <-dequeueTimer:
+			// when the timer fires, it means that at least one batch request in the queue has
+			// reached its deadline and needs to be executed.
+			q.flush()
+			// the queue is flushed after processing, so set the dequeue timer to nil until we have
+			// new requests in the queue that can trigger a new timer.
+			dequeueTimer = nil
+		case <-q.stopCh:
+			// flush the queue one last time before stopping, to ensure that any pending requests are processed.
+			q.flush()
+			dequeueTimer = nil
+			return
+		}
+	}
+}
+
+func (q *coalesceQueue) startTimer() <-chan time.Time {
+	// Calculate adaptive budget when this is the first request after a flush
+	var budget time.Duration
+	// empty queue.
+	if !q.lastFlush.IsZero() {
+		// Calculate time elapsed since last flush
+		timeSinceLastFlush := time.Since(q.lastFlush)
+		// Adaptive strategy:
+		// - If requests arrive quickly (small timeSinceLastFlush), use higher budget to batch more
+		// - If requests arrive slowly (large timeSinceLastFlush), use lower budget to reduce latency
+		budget = max(MaxLatencyBudget-timeSinceLastFlush, MinLatencyBudget)
+	} else {
+		// First request ever, use maximum budget
+		budget = MaxLatencyBudget
+	}
+	if q.timer != nil {
+		q.timer.Reset(budget)
+	} else {
+		q.timer = time.NewTimer(budget)
+	}
+	return q.timer.C
+}
+
+func (q *coalesceQueue) enqueue(req *batchRequest) {
+	// Try to find an existing batch request in the queue that can be merged with this new request.
+	for _, pendingReq := range q.queue {
+		if pendingReq.canMerge(req) {
+			// if we find a compatible request, merge this new request into the existing batch request and return.
+			pendingReq.mergeWith(req)
+			return
+		}
+	}
+	// if we didn't find any compatible request to merge with, add this new request to the end of the queue.
+	q.queue = append(q.queue, req)
+}
+
+func (q *coalesceQueue) flush() {
+	// execute all the requests in the queue, and empty the queue afterwards.
+	for _, req := range q.queue {
+		distances, ids, err := q.idx.batchSearch(req.qVector, req.k)
+		req.sendResponse(distances, ids, err)
+	}
+	// update the last flush time to now, since we just processed a batch of requests.
+	q.lastFlush = time.Now()
+	if q.timer != nil {
+		q.timer.Stop()
+	}
+	// clear the queue after processing all the requests.
+	q.queue = q.queue[:0]
+}

--- a/faiss_vector_request_batcher_test.go
+++ b/faiss_vector_request_batcher_test.go
@@ -1,0 +1,132 @@
+//  Copyright (c) 2026 Couchbase, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// 		http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//go:build vectors
+// +build vectors
+
+package zap
+
+import (
+	"encoding/json"
+	"testing"
+	"time"
+
+	faiss "github.com/blevesearch/go-faiss"
+)
+
+// --------------------------
+// fake Faiss index
+// --------------------------
+// placeholder faiss index implementation for testing the request batcher.
+// It allows us to simulate search latency and return predefined distances and IDs for
+// search requests, without needing a real Faiss index or vector data.
+type fakeFaissIndex struct {
+	searchDelay time.Duration
+}
+
+func (f *fakeFaissIndex) search(vecs *vectorSet, k int64) ([]float32, []int64, error) {
+	if f.searchDelay > 0 {
+		time.Sleep(f.searchDelay)
+	}
+	// generate K random distances and IDs for testing purposes, for each vector in the input vector set.
+	resultSize := vecs.nvecs * int(k)
+	d := make([]float32, resultSize)
+	i := make([]int64, resultSize)
+	for j := 0; j < resultSize; j++ {
+		d[j] = float32(j)
+		i[j] = int64(j)
+	}
+	return d, i, nil
+}
+
+func (f *fakeFaissIndex) batchSearch(vecs *vectorSet, k int64) ([]float32, []int64, error) {
+	return f.search(vecs, k)
+}
+
+func (f *fakeFaissIndex) searchWithoutIDs(vecs *vectorSet, k int64, _ faiss.Selector, _ json.RawMessage) ([]float32, []int64, error) {
+	return f.search(vecs, k)
+}
+
+func (f *fakeFaissIndex) searchWithIDs(vecs *vectorSet, k int64, _ faiss.Selector, _ json.RawMessage) ([]float32, []int64, error) {
+	return f.search(vecs, k)
+}
+
+func (f *fakeFaissIndex) add(vecs *vectorSet) error {
+	return nil
+}
+
+func (f *fakeFaissIndex) close() {}
+
+func (f *fakeFaissIndex) dim() int {
+	return 0
+}
+
+func (f *fakeFaissIndex) metricType() int {
+	return 0
+}
+
+func (f *fakeFaissIndex) serialize() ([]byte, error) {
+	return nil, nil
+}
+
+func (f *fakeFaissIndex) size() uint64 {
+	return 0
+}
+
+func (f *fakeFaissIndex) castIVF() faissIndexIVF {
+	return nil
+}
+
+func (f *fakeFaissIndex) castSQ() faissIndexSQ {
+	return nil
+}
+
+func newFakeFaissIndex(searchDelay time.Duration) *fakeFaissIndex {
+	return &fakeFaissIndex{
+		searchDelay: searchDelay,
+	}
+}
+
+// --------------------------------------------------
+
+func dummyVectorSet(dim int) (*vectorSet, error) {
+	vec := make([]float32, dim)
+	for i := 0; i < dim; i++ {
+		vec[i] = float32(i)
+	}
+	return newVectorSet(dim, vec)
+}
+
+func BenchmarkBatchedSearch(b *testing.B) {
+	// config
+	dims := 512
+	k := 10
+	delay := 50 * time.Millisecond
+	// impl
+	idx := newFakeFaissIndex(delay)
+	rb := newRequestBatcher(idx)
+	b.Cleanup(rb.stop)
+	b.ResetTimer()
+	b.RunParallel(func(pb *testing.PB) {
+		for pb.Next() {
+			vecs, err := dummyVectorSet(dims)
+			if err != nil {
+				b.Fatalf("unexpected error: %v", err)
+			}
+			_, _, err = rb.search(vecs, int64(k))
+			if err != nil {
+				b.Fatalf("unexpected error: %v", err)
+			}
+		}
+	})
+}

--- a/faiss_vector_wrapper.go
+++ b/faiss_vector_wrapper.go
@@ -1035,3 +1035,26 @@ func (v *vectorSet) binarize() {
 	// convert the floatData to binary format and store in binaryData
 	v.binaryData = convertToBinary(v.floatData, v.dim)
 }
+
+func (v *vectorSet) clone() *vectorSet {
+	// create a new vectorSet with the same dimensions and number of vectors
+	clone := &vectorSet{
+		dim:        v.dim,
+		nvecs:      v.nvecs,
+		floatData:  slices.Clone(v.floatData),
+		binaryData: slices.Clone(v.binaryData),
+	}
+	return clone
+}
+
+func (v *vectorSet) mergeWith(other *vectorSet) {
+	// sanity check to ensure the two vector sets are compatible for merging
+	if v.dim != other.dim {
+		return
+	}
+	// merge the float data
+	v.floatData = append(v.floatData, other.floatData...)
+	v.nvecs += other.nvecs
+	// invalidate the binary data as the float data has changed
+	v.binaryData = nil
+}

--- a/faiss_vector_wrapper.go
+++ b/faiss_vector_wrapper.go
@@ -983,7 +983,7 @@ type vectorSet struct {
 }
 
 func newVectorSet(dim int, data []float32) (*vectorSet, error) {
-	if len(data) != dim || dim <= 0 {
+	if len(data) == 0 || dim <= 0 || len(data)%dim != 0 {
 		return nil, fmt.Errorf("invalid vector data: dims %d, data length %d", dim, len(data))
 	}
 	nvecs := len(data) / dim

--- a/faiss_vector_wrapper.go
+++ b/faiss_vector_wrapper.go
@@ -41,12 +41,14 @@ const (
 	// up to the total number of eligible centroids available
 	nprobeIncreaseThreshold = 2
 
+	// binaryOversampleValue is the multiplier used to determine how many additional vectors to retrieve
+	// from the binary index as an oversampling strategy to improve recall.
 	binaryOversampleValue = 4
 )
 
 // vectorIndexWrapper conforms to scorch_segment_api's VectorIndex interface
 type vectorIndexWrapper struct {
-	index        *faissIndex
+	index        faissIndex
 	mapping      *idMapping
 	exclude      *bitmap
 	fieldID      uint16
@@ -61,17 +63,14 @@ type vectorIndexWrapper struct {
 }
 
 func (v *vectorIndexWrapper) Search(qVector []float32, k int64, params json.RawMessage) (segment.VecPostingsList, error) {
-
 	if v.index == nil {
 		// vector index not found, so return empty postings list
 		return emptyVecPostingsList, nil
 	}
-
-	if !v.index.validateDims(len(qVector)) {
+	if !(v.index.dim() == len(qVector)) {
 		// dimensionality mismatch, so return empty postings list
 		return emptyVecPostingsList, nil
 	}
-
 	// check if number of docs or number of vectors is zero
 	if v.mapping == nil || v.mapping.numVectors() == 0 || v.mapping.numDocuments() == 0 {
 		// no vectors or no documents indexed, so return empty postings list
@@ -82,8 +81,12 @@ func (v *vectorIndexWrapper) Search(qVector []float32, k int64, params json.RawM
 		// all vectors excluded, so return empty postings list
 		return emptyVecPostingsList, nil
 	}
-
-	rs, err := v.searchWithoutIDs(qVector, k, v.exclude, params)
+	// create a vector set using the query vector
+	qVecSet, err := newVectorSet(len(qVector), qVector)
+	if err != nil {
+		return nil, err
+	}
+	rs, err := v.searchWithoutIDs(qVecSet, k, v.exclude, params)
 	if err != nil {
 		return nil, err
 	}
@@ -102,7 +105,7 @@ func (v *vectorIndexWrapper) SearchWithFilter(qVector []float32, k int64,
 		// vector index not found, so return empty postings list
 		return emptyVecPostingsList, nil
 	}
-	if !v.index.validateDims(len(qVector)) {
+	if !(v.index.dim() == len(qVector)) {
 		// dimensionality mismatch, so return empty postings list
 		return emptyVecPostingsList, nil
 	}
@@ -156,38 +159,25 @@ func (v *vectorIndexWrapper) SearchWithFilter(qVector []float32, k int64,
 	if numSelected == v.mapping.numVectors() {
 		return v.Search(qVector, k, params)
 	}
-
-	// If a binary index is present and is not an IVF index,
-	// then we can perform the search directly on the binary index
-	if v.index.bIndex != nil && !v.index.bIndex.IsIVFIndex() {
-		rs, err := v.searchWithIDs(qVector, k, includeBM, params)
+	// get a vector set using the query vector
+	qVecSet, err := newVectorSet(len(qVector), qVector)
+	if err != nil {
+		return nil, err
+	}
+	// try to cast the index to an IVF index
+	ivfPtr := v.index.castIVF()
+	if ivfPtr == nil {
+		// perform search with included IDs in the bitmap, since
+		// this is not an IVF index
+		rs, err := v.searchWithIDs(qVecSet, k, includeBM, params)
 		if err != nil {
 			return nil, err
 		}
 		// populate the postings list from the result set
 		return getPostingsList(rs), nil
 	}
-
-	// If a binary index is not present and the FAISS index is not an IVF index,
-	// then we can perform the search directly on the FAISS index
-	if v.index.bIndex == nil && !v.index.fIndex.IsIVFIndex() {
-		// perform search with included IDs in the bitmap
-		rs, err := v.searchWithIDs(qVector, k, includeBM, params)
-		if err != nil {
-			return nil, err
-		}
-		// populate the postings list from the result set
-		return getPostingsList(rs), nil
-	}
-
 	// Getting the IVF index parameters, nprobe and nlist, set at index time.
-	var nprobe, nlist int
-	if v.index.bIndex != nil {
-		nprobe, nlist = v.index.bIndex.IVFParams()
-	} else {
-		nprobe, nlist = v.index.fIndex.IVFParams()
-	}
-
+	nprobe, nlist := ivfPtr.ivfParams()
 	// Create a FAISS selector based on the include bitmap.
 	includeSelector, err := getIncludeSelector(includeBM)
 	if err != nil {
@@ -199,14 +189,7 @@ func (v *vectorIndexWrapper) SearchWithFilter(qVector []float32, k int64,
 	// Determining which clusters, identified by centroid ID,
 	// have at least one eligible vector and hence, ought to be
 	// probed.
-	var clusterVectorCounts []int64
-	if v.index.bIndex != nil {
-		clusterVectorCounts, err =
-			v.index.bIndex.ObtainClusterVectorCountsFromIVFIndex(includeSelector, nlist)
-	} else {
-		clusterVectorCounts, err =
-			v.index.fIndex.ObtainClusterVectorCountsFromIVFIndex(includeSelector, nlist)
-	}
+	clusterVectorCounts, err := ivfPtr.clusterVectorCounts(includeSelector, nlist)
 	if err != nil {
 		return nil, err
 	}
@@ -234,22 +217,7 @@ func (v *vectorIndexWrapper) SearchWithFilter(qVector []float32, k int64,
 	defer centroidSelector.Delete()
 	// Search the coarse quantizer to order the centroids based on proximity
 	// to the query vector.
-	var eligibleCentroidIDs []int64
-	var centroidDistances []float32
-	var binaryCentroidDistances []int32
-	if v.index.bIndex != nil {
-		eligibleCentroidIDs, binaryCentroidDistances, err =
-			v.index.bIndex.ObtainClustersWithDistancesFromIVFIndex(convertToBinary(qVector, len(qVector)),
-				centroidSelector, int64(centroidCount))
-		centroidDistances = make([]float32, len(binaryCentroidDistances))
-		for i, dist := range binaryCentroidDistances {
-			centroidDistances[i] = float32(dist)
-		}
-	} else {
-		eligibleCentroidIDs, centroidDistances, err =
-			v.index.fIndex.ObtainClustersWithDistancesFromIVFIndex(qVector, centroidSelector,
-				int64(centroidCount))
-	}
+	eligibleCentroidIDs, centroidDistances, err := ivfPtr.searchQuantizer(qVecSet, centroidSelector, int64(centroidCount))
 	if err != nil {
 		return nil, err
 	}
@@ -289,8 +257,8 @@ func (v *vectorIndexWrapper) SearchWithFilter(qVector []float32, k int64,
 	// unless overridden dynamically, either by the search parameters
 	// or by the deduplication logic in searchClustersFromIVFIndex.
 	rs, err := v.searchClustersFromIVFIndex(
-		eligibleCentroidIDs, centroidDistances, binaryCentroidDistances, centroidsToProbe,
-		qVector, k, includeBM, params)
+		eligibleCentroidIDs, centroidDistances, centroidsToProbe,
+		qVecSet, k, includeBM, params)
 	if err != nil {
 		return nil, err
 	}
@@ -309,28 +277,14 @@ func (v *vectorIndexWrapper) Size() uint64 {
 
 func (v *vectorIndexWrapper) ObtainKCentroidCardinalitiesFromIVFIndex(limit int, descending bool) (
 	[]index.CentroidCardinality, error) {
-	if v.index.fIndex == nil || !v.index.fIndex.IsIVFIndex() {
+	if v.index == nil {
 		return nil, nil
 	}
-
-	var cardinalities []uint64
-	var centroids [][]float32
-	var err error
-	if v.index.bIndex != nil && v.index.bIndex.IsIVFIndex() {
-		var bCentroids [][]uint8
-		cardinalities, bCentroids, err = v.index.bIndex.ObtainKCentroidCardinalitiesFromIVFIndex(limit, descending)
-		if bCentroids != nil {
-			centroids = make([][]float32, len(bCentroids))
-			for i := range bCentroids {
-				centroids[i] = make([]float32, len(bCentroids[i]))
-				for j := range bCentroids[i] {
-					centroids[i][j] = float32(bCentroids[i][j])
-				}
-			}
-		}
-	} else {
-		cardinalities, centroids, err = v.index.fIndex.ObtainKCentroidCardinalitiesFromIVFIndex(limit, descending)
+	var ivfIdx faissIndexIVF
+	if ivfIdx = v.index.castIVF(); ivfIdx == nil {
+		return nil, nil
 	}
+	cardinalities, centroids, err := ivfIdx.centroidCardinalities(limit, descending)
 	if err != nil {
 		return nil, err
 	}
@@ -365,7 +319,7 @@ func (v *vectorIndexWrapper) docSearch(k int64, numDocs uint64,
 	// we have multi-vector documents leading to duplicates in docIDs retrieved
 	numIter := 0
 	// get the metric type of the index to help with deduplication logic
-	metricType := v.index.fIndex.MetricType()
+	metricType := v.index.metricType()
 	// we keep searching until we have k unique docIDs or we have exhausted the vector index
 	// or we have reached the maximum number of deduplication iterations allowed
 	for numIter < maxMultiVectorDocSearchRetries && rs.size() < k && !exhausted {
@@ -433,13 +387,8 @@ func (v *vectorIndexWrapper) docSearch(k int64, numDocs uint64,
 
 // searchWithoutIDs performs a search on the vector index to retrieve the top K documents
 // while excluding any vector IDs specified in the exclude bitmap.
-func (v *vectorIndexWrapper) searchWithoutIDs(qVector []float32, k int64,
+func (v *vectorIndexWrapper) searchWithoutIDs(qVector *vectorSet, k int64,
 	exclude *bitmap, params json.RawMessage) (resultSet, error) {
-	var binQVector []byte
-	if v.index.bIndex != nil {
-		binQVector = convertToBinary(qVector, len(qVector))
-	}
-
 	return v.docSearch(k, v.sb.numDocs,
 		func() ([]float32, []int64, error) {
 			// build the FAISS selector based on the exclude bitmap, if any.
@@ -457,28 +406,7 @@ func (v *vectorIndexWrapper) searchWithoutIDs(qVector []float32, k int64,
 			if sel != nil {
 				defer sel.Delete()
 			}
-
-			if v.index.bIndex != nil {
-				// search the binary index with oversampling and then do a re-ranking on the
-				// FAISS index to get the top K results
-				_, binIDs, err := v.index.bIndex.SearchWithoutIDs(binQVector, binaryOversampleValue*k,
-					sel, params)
-				if err != nil {
-					return nil, nil, err
-				}
-				distances, err := v.index.fIndex.DistCompute(qVector, binIDs)
-				if err != nil {
-					return nil, nil, err
-				}
-
-				// quick select algorithm for inplace partial sorting to get top K results
-				// based on distances/scores
-				scores, labels := topNIDsByDistance(distances, binIDs, int(k))
-				return scores, labels, nil
-			} else {
-				return v.index.fIndex.SearchWithoutIDs(qVector, k, sel, params)
-			}
-
+			return v.index.searchWithoutIDs(qVector, k, sel, params)
 		},
 		func(numIter int, labels []int64) bool {
 			// if this is the first loop iteration and we have < k unique docIDs,
@@ -513,12 +441,7 @@ func (v *vectorIndexWrapper) searchWithoutIDs(qVector []float32, k int64,
 // searchWithIDs performs a search on the vector index to retrieve the top K documents while only
 // considering the vector IDs specified in the include bitmap.
 // NOTE: The include bitmap must NOT be nil and must have at least one vector ID set.
-func (v *vectorIndexWrapper) searchWithIDs(qVector []float32, k int64, include *bitmap, params json.RawMessage) (resultSet, error) {
-	var binQVector []byte
-	if v.index.bIndex != nil {
-		binQVector = convertToBinary(qVector, len(qVector))
-	}
-
+func (v *vectorIndexWrapper) searchWithIDs(vecSet *vectorSet, k int64, include *bitmap, params json.RawMessage) (resultSet, error) {
 	return v.docSearch(k, v.sb.numDocs,
 		func() ([]float32, []int64, error) {
 			// build the FAISS selector based on the include bitmap.
@@ -534,27 +457,7 @@ func (v *vectorIndexWrapper) searchWithIDs(qVector []float32, k int64, include *
 			if sel != nil {
 				defer sel.Delete()
 			}
-
-			if v.index.bIndex != nil {
-				// search the binary index with oversampling and then do a re-ranking on the
-				// FAISS index to get the top K results
-				_, binIDs, err := v.index.bIndex.SearchWithIDs(binQVector, binaryOversampleValue*k,
-					sel, params)
-				if err != nil {
-					return nil, nil, err
-				}
-				distances, err := v.index.fIndex.DistCompute(qVector, binIDs)
-				if err != nil {
-					return nil, nil, err
-				}
-
-				// quick select algorithm for inplace partial sorting to get top K results
-				// based on distances/scores
-				scores, labels := topNIDsByDistance(distances, binIDs, int(k))
-				return scores, labels, nil
-			} else {
-				return v.index.fIndex.SearchWithIDs(qVector, k, sel, params)
-			}
+			return v.index.searchWithIDs(vecSet, k, sel, params)
 		},
 		func(numIter int, labels []int64) bool {
 			// if this is the first loop iteration and we have < k unique docIDs,
@@ -589,12 +492,10 @@ func (v *vectorIndexWrapper) searchWithIDs(qVector []float32, k int64, include *
 // If after a few iterations we haven't found enough documents, it dynamically increases the number of
 // clusters searched (up to the number of eligible centroids) to ensure we can find k unique documents.
 func (v *vectorIndexWrapper) searchClustersFromIVFIndex(eligibleCentroidIDs []int64, centroidDis []float32,
-	binCentroidDis []int32, centroidsToProbe int, qVector []float32, k int64, include *bitmap, params json.RawMessage) (
+	centroidsToProbe int, qVecSet *vectorSet, k int64, include *bitmap, params json.RawMessage) (
 	resultSet, error) {
-	var binQVector []byte
-	if v.index.bIndex != nil {
-		binQVector = convertToBinary(qVector, len(qVector))
-	}
+	// get ivf index pointer, should not be nil at this point since this method is only called after confirming its an ivf index
+	ivfPtr := v.index.castIVF()
 	var totalEligibleCentroids = len(eligibleCentroidIDs)
 	return v.docSearch(k, v.sb.numDocs,
 		func() ([]float32, []int64, error) {
@@ -611,26 +512,8 @@ func (v *vectorIndexWrapper) searchClustersFromIVFIndex(eligibleCentroidIDs []in
 			if sel != nil {
 				defer sel.Delete()
 			}
-			if v.index.bIndex != nil {
-				// search the binary index without oversampling, since we are already searching a
-				// limited number of centroids specified by centroidsToProbe
-				_, binIds, err := v.index.bIndex.SearchClustersFromIVFIndex(eligibleCentroidIDs, binCentroidDis,
-					centroidsToProbe, binQVector, k, sel, params)
-				if err != nil {
-					return nil, nil, err
-				}
-
-				// reranking is still necessary since hamming distance has a lot of collisions
-				distances, err := v.index.fIndex.DistCompute(qVector, binIds)
-				if err != nil {
-					return nil, nil, err
-				}
-
-				return distances, binIds, nil
-			} else {
-				return v.index.fIndex.SearchClustersFromIVFIndex(eligibleCentroidIDs, centroidDis, centroidsToProbe,
-					qVector, k, sel, params)
-			}
+			return ivfPtr.searchClusters(eligibleCentroidIDs, centroidDis, centroidsToProbe,
+				qVecSet, k, sel, params)
 		},
 		func(numIter int, labels []int64) bool {
 			// if this is the first loop iteration and we have < k unique docIDs,
@@ -750,56 +633,6 @@ func getPostingsList(rs resultSet) segment.VecPostingsList {
 		rv.postings.Add(code)
 	})
 	return rv
-}
-
-// ------------------------------------------------------------------------------
-// faissIndex wrapper
-// ------------------------------------------------------------------------------
-
-type faissIndex struct {
-	fIndex *faiss.IndexImpl
-	bIndex *faiss.BinaryIndexImpl
-}
-
-func (fi *faissIndex) close() {
-	if fi.fIndex != nil {
-		fi.fIndex.Close()
-	}
-	if fi.bIndex != nil {
-		fi.bIndex.Close()
-	}
-}
-
-func (fi *faissIndex) size() (indexSize uint64) {
-	if fi.fIndex != nil {
-		indexSize += fi.fIndex.Size()
-	}
-	if fi.bIndex != nil {
-		indexSize += fi.bIndex.Size()
-	}
-	return indexSize
-}
-
-// ValidateDims validates the dimensions of the faiss index
-// against the expected query dimensions.
-func (fi *faissIndex) validateDims(expectedDims int) bool {
-	// check dims for float index
-	if fi.fIndex != nil {
-		if fi.fIndex.D() != expectedDims {
-			return false
-		}
-	} else {
-		// float index is mandatory
-		return false
-	}
-
-	// check dims only if binary index is present
-	if fi.bIndex != nil {
-		if fi.bIndex.D() != expectedDims {
-			return false
-		}
-	}
-	return true
 }
 
 // ------------------------------------------------------------------------------
@@ -1129,4 +962,76 @@ func topNIDsByDistance(dist []float32, ids []int64, n int) ([]float32, []int64) 
 
 	// Return top-N IDs (unordered)
 	return dist[target:], ids[target:]
+}
+
+// -----------------------------------------------------------------------------
+// vectorSet
+// -----------------------------------------------------------------------------
+type vectorSet struct {
+	// dimensionality of each vector
+	dim int
+	// number of vectors represented
+	nvecs int
+	// float vectors stored in row-major format,
+	// i.e. for N vectors of D dimensions,
+	// the length of this slice is N*D,
+	floatData []float32
+	// row-major binary representation of the float vectors,
+	// where each bit represents the sign bit
+	// of the corresponding float value.
+	binaryData []uint8
+}
+
+func newVectorSet(dim int, data []float32) (*vectorSet, error) {
+	if len(data) != dim || dim <= 0 {
+		return nil, fmt.Errorf("invalid vector data: dims %d, data length %d", dim, len(data))
+	}
+	nvecs := len(data) / dim
+	return &vectorSet{
+		dim:       dim,
+		nvecs:     nvecs,
+		floatData: data,
+	}, nil
+}
+
+// converts float32 vectors into binary format based on the sign bit
+// of the float32 values.
+func convertToBinary(vecs []float32, dims int) []uint8 {
+	nvecs := len(vecs) / dims
+	packed := make([]uint8, 0, nvecs*(dims+7)/8)
+	var cur uint8
+	var count int
+	for i := 0; i < nvecs; i++ {
+		count = 0
+		for j := 0; j < dims; j++ {
+			value := vecs[i*dims+j]
+			// Apply the threshold: convert the float32 to 1 or 0 based on threshold
+			if value >= 0.0 {
+				// Shift the bit into the correct position in the byte
+				cur |= (1 << (7 - count))
+			}
+			count++
+			// When we have 8 bits, store the byte and reset for the next byte
+			if count == 8 {
+				packed = append(packed, cur)
+				cur = 0
+				count = 0
+			}
+		}
+		// If there are any remaining bits, pack them into a byte and append
+		if count > 0 {
+			cur <<= (8 - count)
+			packed = append(packed, cur)
+		}
+	}
+	return packed
+}
+
+func (v *vectorSet) binarize() {
+	// if binaryData is already populated, no need to convert again
+	if v.binaryData != nil {
+		return
+	}
+	// convert the floatData to binary format and store in binaryData
+	v.binaryData = convertToBinary(v.floatData, v.dim)
 }

--- a/faiss_vector_wrapper.go
+++ b/faiss_vector_wrapper.go
@@ -67,7 +67,7 @@ func (v *vectorIndexWrapper) Search(qVector []float32, k int64, params json.RawM
 		// vector index not found, so return empty postings list
 		return emptyVecPostingsList, nil
 	}
-	if !(v.index.dim() == len(qVector)) {
+	if v.index.dim() != len(qVector) {
 		// dimensionality mismatch, so return empty postings list
 		return emptyVecPostingsList, nil
 	}
@@ -105,7 +105,7 @@ func (v *vectorIndexWrapper) SearchWithFilter(qVector []float32, k int64,
 		// vector index not found, so return empty postings list
 		return emptyVecPostingsList, nil
 	}
-	if !(v.index.dim() == len(qVector)) {
+	if v.index.dim() != len(qVector) {
 		// dimensionality mismatch, so return empty postings list
 		return emptyVecPostingsList, nil
 	}

--- a/section_faiss_vector_index.go
+++ b/section_faiss_vector_index.go
@@ -45,26 +45,17 @@ const (
 	// Divide the estimated nprobe with this value to optimize
 	// for latency.
 	nprobeLatencyOptimization = 2
-	// Config flat to mmap BIVF backing index
-	MMapBIVF = "mmap_bivf"
 )
 
-// Vector index types currently supported.
-const (
-	// IndexTypeFlat is a flat index type for exact search.
-	IndexTypeFlat = iota
-	// IndexTypeSQ is a scalar quantized flat index that requires training
-	// but no direct map
-	IndexTypeSQ
-	// IndexTypeIVF is an IVF index type for approximate search.
-	IndexTypeIVF
-)
-
+// Vector index types supported.
 type faissIndexType uint64
 
-// Vector index section implementation types
 const (
+	// faissFP32Index represents the standard float32 index in Faiss,
+	// which stores vectors in 32-bit floating point format.
 	faissFP32Index faissIndexType = iota
+	// faissBIVFIndex represents the binary IVF index in Faiss,
+	// which stores vectors in a 8-bit binary format.
 	faissBIVFIndex
 )
 
@@ -99,7 +90,6 @@ type vecIndexInfo struct {
 	vecIds            []int64
 	indexOptimizedFor string
 	indexType         faissIndexType
-	index             *faissIndex
 }
 
 // Merge merges vector indexes from multiple segments into a single index.
@@ -160,7 +150,6 @@ func (v *faissVectorIndexSection) Merge(opaque map[int]resetable, segments []*Se
 			newIndexInfo := &vecIndexInfo{
 				indexOptimizedFor: index.VectorIndexOptimizationsReverseLookup[int(indexOptimizationTypeInt)],
 				vecIds:            make([]int64, 0, numVecs),
-				index:             &faissIndex{},
 			}
 			for vecID := 0; vecID < int(numVecs); vecID++ {
 				docID, n := binary.Uvarint(sb.mem[pos : pos+binary.MaxVarintLen64])
@@ -284,12 +273,15 @@ func (v *vectorIndexOpaque) mergeAndWriteVectorIndexes(sbs []*SegmentBase,
 	var indexOptimizedFor string
 	var indexType faissIndexType
 	var validMerge bool
+	// reconstructed faiss indexes for the vector indexes being merged,
+	// indexed by their position in vecIndexes slice.
+	reconsIndexes := make([]*faiss.IndexImpl, len(vecIndexes))
 	for segI, segBase := range sbs {
 		// Considering merge operations on vector indexes are expensive, it is
 		// worth including an early exit if the merge is aborted, saving us
 		// the resource spikes, even if temporary.
 		if isClosed(closeCh) {
-			freeReconstructedIndexes(vecIndexes)
+			freeReconstructedIndexes(reconsIndexes)
 			return seg.ErrClosed
 		}
 		// track which index we are currently processing
@@ -304,7 +296,7 @@ func (v *vectorIndexOpaque) mergeAndWriteVectorIndexes(sbs []*SegmentBase,
 		// reconstruct the faiss index from the bytes
 		faissIndex, err := faiss.ReadIndexFromBuffer(indexBytes, faissIOFlags)
 		if err != nil {
-			freeReconstructedIndexes(vecIndexes)
+			freeReconstructedIndexes(reconsIndexes)
 			return err
 		}
 		// set the dims and metric values from the constructed index.
@@ -320,8 +312,9 @@ func (v *vectorIndexOpaque) mergeAndWriteVectorIndexes(sbs []*SegmentBase,
 			reconsCap = indexReconsLen
 		}
 		indexDataCap += indexReconsLen
-		// update the index currently being processed to store the faiss index.
-		currVecIndex.index.fIndex = faissIndex
+		// track the reconstruct index for this vector index, which will be used
+		// to reconstruct the vectors corresponding to the valid vector IDs for this index.
+		reconsIndexes[segI] = faissIndex
 	}
 	// not a valid merge operation as there are no valid indexes to merge.
 	if !validMerge {
@@ -336,22 +329,21 @@ func (v *vectorIndexOpaque) mergeAndWriteVectorIndexes(sbs []*SegmentBase,
 	// total number of vectors in the vector index after merge
 	// used to determine the index type to be created.
 	nvecs := 0
-	for _, currVecIndex := range vecIndexes {
+	for idx, currVecIndex := range vecIndexes {
 		if isClosed(closeCh) {
-			freeReconstructedIndexes(vecIndexes)
+			freeReconstructedIndexes(reconsIndexes)
 			return seg.ErrClosed
 		}
 		currNumVecs := len(currVecIndex.vecIds)
-		currFaissIndex := currVecIndex.index.fIndex
 		// reconstruct the vectors only if present, it could be that
 		// some of the indexes had all of their vectors updated/deleted.
-		if currNumVecs > 0 && currFaissIndex != nil {
+		if currNumVecs > 0 && reconsIndexes[idx] != nil {
 			neededReconsLen := currNumVecs * dims
 			recons = recons[:neededReconsLen]
 			var err error
-			recons, err = currFaissIndex.ReconstructBatch(currVecIndex.vecIds, recons)
+			recons, err = reconsIndexes[idx].ReconstructBatch(currVecIndex.vecIds, recons)
 			if err != nil {
-				freeReconstructedIndexes(vecIndexes)
+				freeReconstructedIndexes(reconsIndexes)
 				return err
 			}
 			indexData = append(indexData, recons...)
@@ -362,22 +354,30 @@ func (v *vectorIndexOpaque) mergeAndWriteVectorIndexes(sbs []*SegmentBase,
 	if nvecs == 0 {
 		// no valid vectors for this index, so we don't even have to
 		// record it in the section
-		freeReconstructedIndexes(vecIndexes)
+		freeReconstructedIndexes(reconsIndexes)
 		return nil
 	}
 	// freeing the reconstructed indexes immediately - waiting till the end
 	// to do the same is not needed because the following operations don't need
 	// the reconstructed ones anymore and doing so will hold up memory which can
 	// be detrimental while creating indexes during introduction.
-	freeReconstructedIndexes(vecIndexes)
+	freeReconstructedIndexes(reconsIndexes)
 	// create the faiss index to hold the merged data, and add the
 	// reconstructed vectors into it.
-	fIndexBytes, err := makeFaissFP32Index(indexData, metric, indexOptimizedFor,
-		dims, nvecs)
+	config := &faissIndexConfig{
+		indexType:        faissFP32Index,
+		optimizationType: indexOptimizedFor,
+		numVecs:          nvecs,
+		metricType:       metric,
+	}
+	vecSet, err := newVectorSet(dims, indexData)
 	if err != nil {
 		return err
 	}
-
+	fIndexBytes, err := makeFaissIndex(vecSet, config)
+	if err != nil {
+		return err
+	}
 	// get a temporary buffer for writing out the index
 	tempBuf := v.grabBuf(binary.MaxVarintLen64)
 	// write the type of the vector index
@@ -397,16 +397,20 @@ func (v *vectorIndexOpaque) mergeAndWriteVectorIndexes(sbs []*SegmentBase,
 	if err != nil {
 		return err
 	}
-
 	if indexType == faissBIVFIndex {
 		// create the binary index to hold the merged data, and
 		// add the reconstructed vectors into it.
-		bIndexBytes, err := makeFaissBinaryIndex(indexData, indexOptimizedFor,
-			dims, nvecs)
+		vecSet.binarize()
+		config := &faissIndexConfig{
+			indexType:        faissBIVFIndex,
+			optimizationType: indexOptimizedFor,
+			numVecs:          nvecs,
+			metricType:       metric,
+		}
+		bIndexBytes, err := makeFaissIndex(vecSet, config)
 		if err != nil {
 			return err
 		}
-
 		// write the length of the serialized binary vector index bytes
 		n = binary.PutUvarint(tempBuf, uint64(len(bIndexBytes)))
 		_, err = w.Write(tempBuf[:n])
@@ -419,112 +423,70 @@ func (v *vectorIndexOpaque) mergeAndWriteVectorIndexes(sbs []*SegmentBase,
 			return err
 		}
 	}
-
 	return err
 }
 
-// returns the serialized faiss index bytes for the given vector data and index config.
-func makeFaissFP32Index(vecs []float32, metric int, indexOptimizedFor string,
-	dims int, nvecs int) ([]byte, error) {
-
-	nlist := determineCentroids(nvecs)
-	description, indexClass := determineFP32IndexToUse(nvecs, nlist, indexOptimizedFor)
-
-	index, err := faiss.IndexFactory(dims, description, metric)
+// returns the serialized faiss index for the given vector data and index config.
+func makeFaissIndex(vecs *vectorSet, config *faissIndexConfig) ([]byte, error) {
+	// create the faiss index based on the provided description string, and the metric type.
+	index, err := faissIndexFactory(config)
 	if err != nil {
 		return nil, err
 	}
 	// ensure the faiss index is closed after use
-	defer index.Close()
-
+	defer index.close()
 	// if we are using an IVF index, set the direct map and train it
-	if indexClass == IndexTypeIVF {
+	if ivfIndex, ok := index.castIVF(); ok {
 		// the direct map maintained in the IVF index is essential for the
 		// reconstruction of vectors based on the sequential vector IDs in the
 		// future merges use direct map type 1 -> array based direct map, since
 		// we have sequential vector IDs starting from 0 to N-1.
-		err = index.SetDirectMap(1)
+		err = ivfIndex.setDirectMap(1)
 		if err != nil {
 			return nil, err
 		}
-
+		// the number of centroids (nlist) for the IVF index.
+		nlist := determineCentroids(config.numVecs)
 		// calculate nprobe using a heuristic.
-		nprobe := calculateNprobe(nlist, indexOptimizedFor)
-		index.SetNProbe(nprobe)
-
+		nprobe := calculateNprobe(nlist, config.optimizationType)
+		// calculate nprobe using a heuristic.
+		ivfIndex.setNProbe(nprobe)
 		// train the vector index, essentially performs k-means clustering to partition
 		// the data space of indexData such that during the search time, we probe
 		// only a subset of vectors -> non-exhaustive search. could be a time
 		// consuming step when the indexData is large.
-
-	}
-	if indexClass == IndexTypeSQ || indexClass == IndexTypeIVF {
-		err = index.Train(vecs)
+		err = ivfIndex.train(vecs)
+		if err != nil {
+			return nil, err
+		}
+	} else if sqIndex, ok := index.castSQ(); ok {
+		err = sqIndex.train(vecs)
 		if err != nil {
 			return nil, err
 		}
 	}
 	// add the vectors to the index using sequential vector IDs starting
 	// from 0 to N-1
-	err = index.Add(vecs)
+	err = index.add(vecs)
 	if err != nil {
 		return nil, err
 	}
-
 	// serialize the merged index into a byte slice, and write it out
-	indexBytes, err := faiss.WriteIndexIntoBuffer(index)
+	indexBytes, err := index.serialize()
 	if err != nil {
 		return nil, err
 	}
-
 	return indexBytes, nil
-}
-
-// converts float32 vectors into binary format based on the sign bit
-// of the float32 values.
-func convertToBinary(vecs []float32, dims int) []uint8 {
-	nvecs := len(vecs) / dims
-	packed := make([]uint8, 0, nvecs*(dims+7)/8)
-	var cur uint8
-	var count int
-
-	for i := 0; i < nvecs; i++ {
-		count = 0
-		for j := 0; j < dims; j++ {
-			value := vecs[i*dims+j]
-			// Apply the threshold: convert the float32 to 1 or 0 based on threshold
-			if value >= 0.0 {
-				// Shift the bit into the correct position in the byte
-				cur |= (1 << (7 - count))
-			}
-
-			count++
-
-			// When we have 8 bits, store the byte and reset for the next byte
-			if count == 8 {
-				packed = append(packed, cur)
-				cur = 0
-				count = 0
-			}
-		}
-		// If there are any remaining bits, pack them into a byte and append
-		if count > 0 {
-			cur <<= (8 - count)
-			packed = append(packed, cur)
-		}
-	}
-
-	return packed
 }
 
 // returns the index description string and index type constant for the binary
 // index to be created based on the number of vectors and centroids.
-func determineBinaryIndexToUse(nvecs, nlist int) (string, int) {
+func determineBinaryIndexToUse(nvecs, nlist int) string {
 	switch {
 	case nvecs >= 1000:
-		return fmt.Sprintf("BIVF%d", nlist), IndexTypeIVF
+		return fmt.Sprintf("BIVF%d", nlist)
 	default:
-		return "BFlat", IndexTypeFlat
+		return "BFlat"
 	}
 }
 
@@ -537,67 +499,11 @@ func determineIndexTypeFromOptimization(indexOptimizedFor string) faissIndexType
 	return faissFP32Index
 }
 
-// returns the serialized faiss binary index bytes for the given vector data and index config.
-func makeFaissBinaryIndex(vecs []float32, indexOptimizedFor string, dims int,
-	nvecs int) ([]byte, error) {
-
-	nlist := determineCentroids(nvecs)
-	description, indexClass := determineBinaryIndexToUse(nvecs, nlist)
-
-	index, err := faiss.BinaryIndexFactory(dims, description)
-	if err != nil {
-		return nil, err
-	}
-	// ensure the faiss index is closed after use
-	defer index.Close()
-
-	// convert the float32 vectors into binary format
-	bvecs := convertToBinary(vecs, dims)
-
-	// if we are using an IVF index, set the direct map and train it
-	if indexClass == IndexTypeIVF {
-		// the direct map maintained in the IVF index is essential for the
-		// reconstruction of vectors based on the sequential vector IDs in the
-		// future merges use direct map type 1 -> array based direct map, since
-		// we have sequential vector IDs starting from 0 to N-1.
-		err = index.SetDirectMap(1)
-		if err != nil {
-			return nil, err
-		}
-
-		// calculate nprobe using a heuristic.
-		nprobe := calculateNprobe(nlist, indexOptimizedFor)
-		index.SetNProbe(nprobe)
-
-		// train the vector index, essentially performs k-means clustering to partition
-		// the data space of indexData such that during the search time, we probe
-		// only a subset of vectors -> non-exhaustive search. could be a time
-		// consuming step when the indexData is large.
-		err = index.Train(bvecs)
-		if err != nil {
-			return nil, err
-		}
-	}
-
-	err = index.Add(bvecs)
-	if err != nil {
-		return nil, err
-	}
-
-	// serialize the merged binary index into a byte slice, and write it out
-	mergedBIndexBytes, err := faiss.WriteBinaryIndexIntoBuffer(index)
-	if err != nil {
-		return nil, err
-	}
-
-	return mergedBIndexBytes, nil
-}
-
 // freeReconstructedIndexes closes all faiss indexes in the provided slice.
-func freeReconstructedIndexes(indexes []*vecIndexInfo) {
-	for _, entry := range indexes {
-		if entry.index != nil {
-			entry.index.close()
+func freeReconstructedIndexes(reconsIndexes []*faiss.IndexImpl) {
+	for _, entry := range reconsIndexes {
+		if entry != nil {
+			entry.Close()
 		}
 	}
 }
@@ -628,26 +534,25 @@ func determineCentroids(nvecs int) int {
 	return nlist
 }
 
-// determineIndexToUse returns a description string for the index and quantizer type,
-// and an index type constant.
-func determineFP32IndexToUse(nvecs, nlist int, indexOptimizedFor string) (string, int) {
+// determineFloat32IndexToUse returns a description string for the float32
+// index and quantizer type, and an index type constant.
+func determineFloat32IndexToUse(nvecs, nlist int, optimizationType string) string {
 	if nvecs < 1000 {
-		return "Flat", IndexTypeFlat
+		return "Flat"
 	}
-
-	switch indexOptimizedFor {
+	switch optimizationType {
 	case index.IndexBIVFWithBackingFlat:
-		return "Flat", IndexTypeFlat
+		return "Flat"
 	case index.IndexBIVFWithBackingSQ8:
-		return "SQ8", IndexTypeSQ
+		return "SQ8"
 	case index.IndexOptimizedForMemoryEfficient:
-		return fmt.Sprintf("IVF%d,SQ4", nlist), IndexTypeIVF
+		return fmt.Sprintf("IVF%d,SQ4", nlist)
 	default:
 		switch {
 		case nvecs >= 10000:
-			return fmt.Sprintf("IVF%d,SQ8", nlist), IndexTypeIVF
+			return fmt.Sprintf("IVF%d,SQ8", nlist)
 		default:
-			return fmt.Sprintf("IVF%d,Flat", nlist), IndexTypeIVF
+			return fmt.Sprintf("IVF%d,Flat", nlist)
 		}
 	}
 }
@@ -671,14 +576,23 @@ func (vo *vectorIndexOpaque) writeVectorIndexes(w *CountHashWriter) error {
 			// use the same FAISS metric for inner product and cosine similarity
 			metric = faiss.MetricInnerProduct
 		}
-		fIndexBytes, err := makeFaissFP32Index(content.vectors, metric, content.optimizedFor,
-			content.dimension, nvecs)
+		// create a vector set wrapping the vector data
+		vecSet, err := newVectorSet(content.dimension, content.vectors)
 		if err != nil {
 			return err
 		}
-
-		indexType := determineIndexTypeFromOptimization(content.optimizedFor)
-
+		// create the faiss float32 index for the vectors associated with this field and get the
+		// serialized index bytes to be written out to the segment.
+		config := &faissIndexConfig{
+			indexType:        faissFP32Index,
+			optimizationType: content.optimizedFor,
+			numVecs:          nvecs,
+			metricType:       metric,
+		}
+		fIndexBytes, err := makeFaissIndex(vecSet, config)
+		if err != nil {
+			return err
+		}
 		// record the fieldStart value for this section.
 		fieldStart := w.Count()
 		// writing out two offset values to indicate that the current field's
@@ -721,6 +635,8 @@ func (vo *vectorIndexOpaque) writeVectorIndexes(w *CountHashWriter) error {
 				return err
 			}
 		}
+		// determine the type of vector index to be created based on the index optimization
+		indexType := determineIndexTypeFromOptimization(content.optimizedFor)
 		// write the type of the vector index
 		n = binary.PutUvarint(tempBuf, uint64(indexType))
 		_, err = w.Write(tempBuf[:n])
@@ -739,25 +655,31 @@ func (vo *vectorIndexOpaque) writeVectorIndexes(w *CountHashWriter) error {
 			return err
 		}
 		if indexType == faissBIVFIndex {
-			bIndexBytes, err := makeFaissBinaryIndex(content.vectors, content.optimizedFor,
-				content.dimension, nvecs)
+			// if the index type to be created requires a binary index,
+			// binarize the vector data in the vector set.
+			vecSet.binarize()
+			// bivf config
+			config := &faissIndexConfig{
+				indexType:        faissBIVFIndex,
+				optimizationType: content.optimizedFor,
+				numVecs:          nvecs,
+				metricType:       metric,
+			}
+			bIndexBytes, err := makeFaissIndex(vecSet, config)
 			if err != nil {
 				return err
 			}
-
 			// write the length of the serialized binary vector index bytes
 			n = binary.PutUvarint(tempBuf, uint64(len(bIndexBytes)))
 			_, err = w.Write(tempBuf[:n])
 			if err != nil {
 				return err
 			}
-
 			// write the binary vector index data
 			_, err = w.Write(bIndexBytes)
 			if err != nil {
 				return err
 			}
-
 		}
 		// accounts for whatever data has been written out to the writer.
 		vo.incrementBytesWritten(uint64(w.Count() - fieldStart))
@@ -878,5 +800,42 @@ func (v *vectorIndexOpaque) Set(key string, val interface{}) {
 	switch key {
 	case "fieldsOptions":
 		v.fieldsOptions = val.(map[string]index.FieldIndexingOptions)
+	}
+}
+
+// ---------------------------------
+// Faiss Index Factory
+// ---------------------------------
+type faissIndexConfig struct {
+	indexType        faissIndexType
+	dimension        int
+	metricType       int
+	numVecs          int
+	optimizationType string
+}
+
+// Factory function to create a faissIndex for the given index config.
+func faissIndexFactory(cfg *faissIndexConfig) (faissIndex, error) {
+	switch cfg.indexType {
+	case faissFP32Index:
+		nlist := determineCentroids(cfg.numVecs)
+		description := determineFloat32IndexToUse(cfg.numVecs, nlist, cfg.optimizationType)
+		idx, err := faiss.IndexFactory(cfg.dimension, description, cfg.metricType)
+		if err != nil {
+			return nil, err
+		}
+		return newFaissFloat32Index(idx)
+	case faissBIVFIndex:
+		nlist := determineCentroids(cfg.numVecs)
+		description := determineBinaryIndexToUse(cfg.numVecs, nlist)
+		idx, err := faiss.BinaryIndexFactory(cfg.dimension, description)
+		if err != nil {
+			return nil, err
+		}
+		// set no backing index on purpose as we use the factory in the
+		// indexing path, where each index is handled independently
+		return newFaissBinaryIndex(idx, nil)
+	default:
+		return nil, fmt.Errorf("unsupported index type: %v", cfg.indexType)
 	}
 }

--- a/section_faiss_vector_index.go
+++ b/section_faiss_vector_index.go
@@ -436,7 +436,7 @@ func makeFaissIndex(vecs *vectorSet, config *faissIndexConfig) ([]byte, error) {
 	// ensure the faiss index is closed after use
 	defer index.close()
 	// if we are using an IVF index, set the direct map and train it
-	if ivfIndex, ok := index.castIVF(); ok {
+	if ivfIndex := index.castIVF(); ivfIndex != nil {
 		// the direct map maintained in the IVF index is essential for the
 		// reconstruction of vectors based on the sequential vector IDs in the
 		// future merges use direct map type 1 -> array based direct map, since
@@ -459,7 +459,7 @@ func makeFaissIndex(vecs *vectorSet, config *faissIndexConfig) ([]byte, error) {
 		if err != nil {
 			return nil, err
 		}
-	} else if sqIndex, ok := index.castSQ(); ok {
+	} else if sqIndex := index.castSQ(); sqIndex != nil {
 		err = sqIndex.train(vecs)
 		if err != nil {
 			return nil, err

--- a/section_faiss_vector_index.go
+++ b/section_faiss_vector_index.go
@@ -439,7 +439,6 @@ func makeFaissIndex(vecs *vectorSet, config *faissIndexConfig) ([]byte, error) {
 		nlist := determineCentroids(config.numVecs)
 		// calculate nprobe using a heuristic.
 		nprobe := calculateNprobe(nlist, config.optimizationType)
-		// calculate nprobe using a heuristic.
 		ivfIndex.setNProbe(nprobe)
 		// train the vector index, essentially performs k-means clustering to partition
 		// the data space of indexData such that during the search time, we probe

--- a/section_faiss_vector_index.go
+++ b/section_faiss_vector_index.go
@@ -364,12 +364,7 @@ func (v *vectorIndexOpaque) mergeAndWriteVectorIndexes(sbs []*SegmentBase,
 	freeReconstructedIndexes(reconsIndexes)
 	// create the faiss index to hold the merged data, and add the
 	// reconstructed vectors into it.
-	config := &faissIndexConfig{
-		indexType:        faissFP32Index,
-		optimizationType: indexOptimizedFor,
-		numVecs:          nvecs,
-		metricType:       metric,
-	}
+	config := newFaissIndexConfig(faissFP32Index, indexOptimizedFor, dims, metric, nvecs)
 	vecSet, err := newVectorSet(dims, indexData)
 	if err != nil {
 		return err
@@ -401,12 +396,7 @@ func (v *vectorIndexOpaque) mergeAndWriteVectorIndexes(sbs []*SegmentBase,
 		// create the binary index to hold the merged data, and
 		// add the reconstructed vectors into it.
 		vecSet.binarize()
-		config := &faissIndexConfig{
-			indexType:        faissBIVFIndex,
-			optimizationType: indexOptimizedFor,
-			numVecs:          nvecs,
-			metricType:       metric,
-		}
+		config := newFaissIndexConfig(faissBIVFIndex, indexOptimizedFor, dims, metric, nvecs)
 		bIndexBytes, err := makeFaissIndex(vecSet, config)
 		if err != nil {
 			return err
@@ -583,12 +573,7 @@ func (vo *vectorIndexOpaque) writeVectorIndexes(w *CountHashWriter) error {
 		}
 		// create the faiss float32 index for the vectors associated with this field and get the
 		// serialized index bytes to be written out to the segment.
-		config := &faissIndexConfig{
-			indexType:        faissFP32Index,
-			optimizationType: content.optimizedFor,
-			numVecs:          nvecs,
-			metricType:       metric,
-		}
+		config := newFaissIndexConfig(faissFP32Index, content.optimizedFor, content.dimension, metric, nvecs)
 		fIndexBytes, err := makeFaissIndex(vecSet, config)
 		if err != nil {
 			return err
@@ -659,12 +644,7 @@ func (vo *vectorIndexOpaque) writeVectorIndexes(w *CountHashWriter) error {
 			// binarize the vector data in the vector set.
 			vecSet.binarize()
 			// bivf config
-			config := &faissIndexConfig{
-				indexType:        faissBIVFIndex,
-				optimizationType: content.optimizedFor,
-				numVecs:          nvecs,
-				metricType:       metric,
-			}
+			config := newFaissIndexConfig(faissBIVFIndex, content.optimizedFor, content.dimension, metric, nvecs)
 			bIndexBytes, err := makeFaissIndex(vecSet, config)
 			if err != nil {
 				return err
@@ -812,6 +792,16 @@ type faissIndexConfig struct {
 	metricType       int
 	numVecs          int
 	optimizationType string
+}
+
+func newFaissIndexConfig(idxType faissIndexType, optimizationType string, dimension, metricType, numVecs int) *faissIndexConfig {
+	return &faissIndexConfig{
+		indexType:        idxType,
+		dimension:        dimension,
+		metricType:       metricType,
+		numVecs:          numVecs,
+		optimizationType: optimizationType,
+	}
 }
 
 // Factory function to create a faissIndex for the given index config.


### PR DESCRIPTION
**faissIndex**
- Replaced the monolithic `faissIndex` struct with a `faissIndex` interface, with `faissFloat32Index` and `faissBinaryIndex` as concrete implementations.
- Eliminated pervasive if `bIndex != nil` branching across all search paths.
- Introduced `vectorSet` type to wrap float/binary vector data, with lazy binarization.
- Added a unified `faissIndexFactory` to centralize index construction.
- Requires https://github.com/blevesearch/go-faiss/pull/51.

**Request Batcher**
- Add latency-aware batching for vector search requests using a timer-driven coalescing queue.
- Merge compatible requests (same k) and execute them together to reduce number of Faiss calls.
- Ensure bounded latency via per-request deadlines using package-level variables for the `LatencyBudget`, which is the time a request queue will wait before flushing.
- Add traffic-dependent flush timer, which tries to ensure high QPS in low and high req/s scenarios.  