### PR TITLE
[v17] Add Request Batcher Module

### DIFF
--- a/faiss_vector_index.go
+++ b/faiss_vector_index.go
@@ -91,9 +91,18 @@ type faissIndexIVF interface {
 	train(trainingData *vectorSet) error
 }
 
+// Interface for SQ-specific operations on Faiss vector indices.
 type faissIndexSQ interface {
 	// trains the SQ index on the provided training data. This step is necessary to
 	// perform quantization of the vector space, which enables efficient storage and
 	// search of high-dimensional vectors.
 	train(trainingData *vectorSet) error
+}
+
+// Interface for batched search operations on Faiss vector indices.
+type faissIndexBatch interface {
+	// performs a batch search on the index using the provided query vector and parameters,
+	// and returns the distances and corresponding vector IDs of the top k results.
+	// NOTE: only vector search requests with the same `k` are batched together.
+	batchSearch(qVector *vectorSet, k int64) ([]float32, []int64, error)
 }

--- a/faiss_vector_request_batcher.go
+++ b/faiss_vector_request_batcher.go
@@ -1,0 +1,260 @@
+//  Copyright (c) 2026 Couchbase, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// 		http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//go:build vectors
+// +build vectors
+
+package zap
+
+import (
+	"errors"
+	"time"
+)
+
+var (
+	// the latency budget for processing a batch of search requests.
+	// This is the maximum amount of time that the batcher will wait before
+	// executing a batch of search requests.
+	// - Higher the latency budget, higher the throughput of the batcher, but also higher the latency for individual search requests.
+	// - Lower the latency budget, lower the throughput of the batcher, but also lower the latency for individual search requests.
+	LatencyBudget time.Duration = 250 * time.Millisecond
+)
+
+var (
+	errBatcherStopped error = errors.New("batcher has been stopped")
+)
+
+// The requestBatcher interface defines the contract for a component that batches search requests to a Faiss index.
+type requestBatcher interface {
+	// search executes a search request against the Faiss index,
+	// potentially batching it with other requests for improved performance.
+	search(qVector *vectorSet, k int64) ([]float32, []int64, error)
+	// stop signals the batcher to stop processing requests and clean up any resources.
+	stop()
+}
+
+// The requestBatcher is responsible for batching search requests to a Faiss index.
+// It will accumulate incoming search requests and execute them in batches to improve performance.
+// The batcher will use the provided Faiss index to perform the searches, and it
+// will manage the batching logic, including timing and concurrency control.
+type batcher struct {
+	// the coalesce queue that manages the batching of incoming search requests.
+	cq *coalesceQueue
+}
+
+func newRequestBatcher(idx faissIndex) requestBatcher {
+	b := &batcher{
+		cq: newCoalesceQueue(idx),
+	}
+	return b
+}
+
+func (b *batcher) search(qVector *vectorSet, k int64) ([]float32, []int64, error) {
+	// create a new batch request for this search query.
+	req, respCh := newBatchRequest(qVector, k)
+	// check if the batcher has been stopped before processing the search request.
+	select {
+	case b.cq.enqueueCh <- req:
+	case <-b.cq.stopCh:
+		return nil, nil, errBatcherStopped
+	}
+	// wait for the search results to be sent back through the response channel,
+	// and return those results to the caller.
+	resp := <-respCh
+	return resp.distances, resp.ids, resp.err
+}
+
+func (b *batcher) stop() {
+	b.cq.stop()
+}
+
+// --------------------------------------------------
+// batch request
+// --------------------------------------------------
+
+type batchRequest struct {
+	qVector  *vectorSet
+	k        int64
+	respCh   []chan *batchResponse
+	deadline time.Time
+}
+
+func newBatchRequest(qVector *vectorSet, k int64) (*batchRequest, chan *batchResponse) {
+	// response channel for sending the search results back to the requester.
+	respChan := make(chan *batchResponse, 1)
+	return &batchRequest{
+		qVector:  qVector,
+		k:        k,
+		respCh:   []chan *batchResponse{respChan},
+		deadline: time.Now().Add(LatencyBudget),
+	}, respChan
+}
+
+func (r *batchRequest) canMerge(other *batchRequest) bool {
+	// for now, we can only merge requests that have the same k value,
+	// since the Faiss search API requires a single k value for each search.
+	return r.k == other.k
+}
+
+func (r *batchRequest) mergeWith(other *batchRequest) {
+	if !r.canMerge(other) {
+		return
+	}
+	// merge the query vectors of the two requests by concatenating them together.
+	r.qVector.mergeWith(other.qVector)
+	// append the response channels from the other request to this request, so that when the search results are ready,
+	// we can send the results back to all requesters that were merged into this batch.
+	r.respCh = append(r.respCh, other.respCh...)
+	// retain the earliest deadline among the merged requests, so that the batch will be executed within the latency budget of all merged requests.
+	if other.deadline.Before(r.deadline) {
+		r.deadline = other.deadline
+	}
+}
+
+func (r *batchRequest) sendResponse(distances []float32, ids []int64, err error) {
+	// we may have multiple batches merged together, so we need segregate the results for each original request
+	// and send them back to the appropriate response channels.
+	for i, respCh := range r.respCh {
+		offset := int64(i) * r.k
+		// calculate the start and end indices for the results corresponding to this response channel.
+		curDistances := distances[offset : offset+r.k]
+		curIDs := ids[offset : offset+r.k]
+		// send the results back to the requester through the response channel.
+		respCh <- newBatchResponse(curDistances, curIDs, err)
+		// close the response channel to signal that the response has been sent and there will be no more data.
+		close(respCh)
+	}
+}
+
+// --------------------------------------------------
+// batch response
+// --------------------------------------------------
+
+type batchResponse struct {
+	distances []float32
+	ids       []int64
+	err       error
+}
+
+func newBatchResponse(distances []float32, ids []int64, err error) *batchResponse {
+	return &batchResponse{
+		distances: distances,
+		ids:       ids,
+		err:       err,
+	}
+}
+
+// --------------------------------------------------
+// coalesceQueue
+// --------------------------------------------------
+
+type coalesceQueue struct {
+	// the Faiss index that this coalesce queue will execute search requests against.
+	idx faissIndex
+	// channel for enqueuing new batch requests into the queue.
+	enqueueCh chan *batchRequest
+	// channel for signaling the batcher to stop processing requests and shut down.
+	stopCh chan struct{}
+	// queue of pending batch requests that are waiting to be processed.
+	queue []*batchRequest
+
+	timer *time.Timer
+}
+
+func newCoalesceQueue(idx faissIndex) *coalesceQueue {
+	rv := &coalesceQueue{
+		idx:       idx,
+		queue:     make([]*batchRequest, 0),
+		enqueueCh: make(chan *batchRequest),
+		stopCh:    make(chan struct{}),
+	}
+	go rv.monitor()
+	return rv
+}
+
+func (q *coalesceQueue) stop() {
+	close(q.stopCh)
+}
+
+func (q *coalesceQueue) monitor() {
+	var dequeueTimer <-chan time.Time
+	for {
+		select {
+		case req := <-q.enqueueCh:
+			// enqueue the new batch request into the coalesce queue.
+			q.enqueue(req)
+			// reset the dequeue timer after adding a new request.
+			dequeueTimer = q.resetTimer()
+		case <-dequeueTimer:
+			// when the timer fires, it means that at least one batch request in the queue has
+			// reached its deadline and needs to be executed.
+			q.flush()
+			// the queue is flushed after processing, so we need to reset the timer for the next batch of requests in the queue (if any).
+			dequeueTimer = q.resetTimer()
+		case <-q.stopCh:
+			// flush the queue one last time before stopping, to ensure that any pending requests are processed.
+			q.flush()
+			return
+		}
+	}
+}
+
+func (q *coalesceQueue) enqueue(req *batchRequest) {
+	// since we are adding a new request to the queue, we need to reset the timer to ensure that the
+	// batch will be executed within the latency budget of all requests in the queue.
+	// try to find an existing batch request in the queue that can be merged with this new request.
+	for _, pendingReq := range q.queue {
+		if pendingReq.canMerge(req) {
+			// if we find a compatible request, merge this new request into the existing batch request and return.
+			pendingReq.mergeWith(req)
+			return
+		}
+	}
+	// if we didn't find any compatible request to merge with, add this new request to the end of the queue.
+	q.queue = append(q.queue, req)
+}
+
+func (q *coalesceQueue) resetTimer() <-chan time.Time {
+	if len(q.queue) == 0 {
+		return nil
+	}
+	// find earliest deadline
+	earliest := q.queue[0].deadline
+	for _, r := range q.queue[1:] {
+		if r.deadline.Before(earliest) {
+			earliest = r.deadline
+		}
+	}
+	// calculate the duration until the earliest deadline, and reset the timer to trigger at that time.
+	d := time.Until(earliest)
+	if d < 0 {
+		d = 0
+	}
+	if q.timer != nil {
+		q.timer.Reset(d)
+	} else {
+		q.timer = time.NewTimer(d)
+	}
+	return q.timer.C
+}
+
+func (q *coalesceQueue) flush() {
+	// execute all the requests in the queue, and empty the queue afterwards.
+	for _, req := range q.queue {
+		distances, ids, err := q.idx.searchWithoutIDs(req.qVector, req.k, nil, nil)
+		req.sendResponse(distances, ids, err)
+	}
+	// clear the queue after processing all the requests.
+	q.queue = q.queue[:0]
+}

--- a/faiss_vector_request_batcher.go
+++ b/faiss_vector_request_batcher.go
@@ -44,7 +44,7 @@ type requestBatcher struct {
 	cq *coalesceQueue
 }
 
-func newRequestBatcher(idx faissIndex) *requestBatcher {
+func newRequestBatcher(idx faissIndexBatch) *requestBatcher {
 	b := &requestBatcher{
 		cq: newCoalesceQueue(idx),
 	}
@@ -158,7 +158,7 @@ func newBatchResponse(distances []float32, ids []int64, err error) *batchRespons
 
 type coalesceQueue struct {
 	// the Faiss index that this coalesce queue will execute search requests against.
-	idx faissIndex
+	idx faissIndexBatch
 	// channel for enqueuing new batch requests into the queue.
 	enqueueCh chan *batchRequest
 	// channel for signaling the batcher to stop processing requests and shut down.
@@ -171,7 +171,7 @@ type coalesceQueue struct {
 	lastFlush time.Time
 }
 
-func newCoalesceQueue(idx faissIndex) *coalesceQueue {
+func newCoalesceQueue(idx faissIndexBatch) *coalesceQueue {
 	rv := &coalesceQueue{
 		idx:       idx,
 		queue:     make([]*batchRequest, 0),
@@ -253,7 +253,7 @@ func (q *coalesceQueue) enqueue(req *batchRequest) {
 func (q *coalesceQueue) flush() {
 	// execute all the requests in the queue, and empty the queue afterwards.
 	for _, req := range q.queue {
-		distances, ids, err := q.idx.searchWithoutIDs(req.qVector, req.k, nil, nil)
+		distances, ids, err := q.idx.batchSearch(req.qVector, req.k)
 		req.sendResponse(distances, ids, err)
 	}
 	// update the last flush time to now, since we just processed a batch of requests.

--- a/faiss_vector_request_batcher.go
+++ b/faiss_vector_request_batcher.go
@@ -168,7 +168,7 @@ type coalesceQueue struct {
 	stopCh chan struct{}
 	// queue of pending batch requests that are waiting to be processed.
 	queue []*batchRequest
-
+	// timer for automatically triggering the execution of a batch of requests when the earliest deadline is reached.
 	timer *time.Timer
 }
 
@@ -185,6 +185,9 @@ func newCoalesceQueue(idx faissIndex) *coalesceQueue {
 
 func (q *coalesceQueue) stop() {
 	close(q.stopCh)
+	if q.timer != nil {
+		q.timer.Stop()
+	}
 }
 
 func (q *coalesceQueue) monitor() {

--- a/faiss_vector_request_batcher.go
+++ b/faiss_vector_request_batcher.go
@@ -100,6 +100,9 @@ func (r *batchRequest) mergeWith(other *batchRequest) {
 	if !r.canMerge(other) {
 		return
 	}
+	// since we are merging the query vectors of two requests, we need to clone
+	// the original query vector to avoid mutating the original request's query vector when we merge.
+	r.qVector = r.qVector.clone()
 	// merge the query vectors of the two requests by concatenating them together.
 	r.qVector.mergeWith(other.qVector)
 	// append the response channels from the other request to this request, so that when the search results are ready,

--- a/faiss_vector_request_batcher.go
+++ b/faiss_vector_request_batcher.go
@@ -35,32 +35,23 @@ var (
 	errBatcherStopped error = errors.New("batcher has been stopped")
 )
 
-// The requestBatcher interface defines the contract for a component that batches search requests to a Faiss index.
-type requestBatcher interface {
-	// search executes a search request against the Faiss index,
-	// potentially batching it with other requests for improved performance.
-	search(qVector *vectorSet, k int64) ([]float32, []int64, error)
-	// stop signals the batcher to stop processing requests and clean up any resources.
-	stop()
-}
-
 // The requestBatcher is responsible for batching search requests to a Faiss index.
 // It will accumulate incoming search requests and execute them in batches to improve performance.
 // The batcher will use the provided Faiss index to perform the searches, and it
 // will manage the batching logic, including timing and concurrency control.
-type batcher struct {
+type requestBatcher struct {
 	// the coalesce queue that manages the batching of incoming search requests.
 	cq *coalesceQueue
 }
 
-func newRequestBatcher(idx faissIndex) requestBatcher {
-	b := &batcher{
+func newRequestBatcher(idx faissIndex) *requestBatcher {
+	b := &requestBatcher{
 		cq: newCoalesceQueue(idx),
 	}
 	return b
 }
 
-func (b *batcher) search(qVector *vectorSet, k int64) ([]float32, []int64, error) {
+func (b *requestBatcher) search(qVector *vectorSet, k int64) ([]float32, []int64, error) {
 	// create a new batch request for this search query.
 	req, respCh := newBatchRequest(qVector, k)
 	// check if the batcher has been stopped before processing the search request.
@@ -75,7 +66,7 @@ func (b *batcher) search(qVector *vectorSet, k int64) ([]float32, []int64, error
 	return resp.distances, resp.ids, resp.err
 }
 
-func (b *batcher) stop() {
+func (b *requestBatcher) stop() {
 	b.cq.stop()
 }
 

--- a/faiss_vector_request_batcher.go
+++ b/faiss_vector_request_batcher.go
@@ -24,6 +24,7 @@ import (
 
 var (
 	// adaptive batching parameters - these can be tuned based on the expected workload and latency requirements.
+
 	// MinLatencyBudget is the minimum amount of time that the batcher will wait before flushing a batch of requests.
 	MinLatencyBudget time.Duration = 10 * time.Millisecond
 	// MaxLatencyBudget is the maximum amount of time that the batcher will wait before flushing a batch of requests.
@@ -109,13 +110,22 @@ func (r *batchRequest) mergeWith(other *batchRequest) {
 func (r *batchRequest) sendResponse(distances []float32, ids []int64, err error) {
 	// we may have multiple batches merged together, so we need segregate the results for each original request
 	// and send them back to the appropriate response channels.
+	if err != nil {
+		// if there was an error during the search, send the error back to all requesters in this batch.
+		for _, respCh := range r.respCh {
+			respCh <- newBatchResponse(nil, nil, err)
+			close(respCh)
+		}
+		return
+	}
+	// if the search was successful, we need to split the combined results back into individual responses for each original request.
 	for i, respCh := range r.respCh {
 		offset := int64(i) * r.k
 		// calculate the start and end indices for the results corresponding to this response channel.
 		curDistances := distances[offset : offset+r.k]
 		curIDs := ids[offset : offset+r.k]
 		// send the results back to the requester through the response channel.
-		respCh <- newBatchResponse(curDistances, curIDs, err)
+		respCh <- newBatchResponse(curDistances, curIDs, nil)
 		// close the response channel to signal that the response has been sent and there will be no more data.
 		close(respCh)
 	}
@@ -170,10 +180,10 @@ func newCoalesceQueue(idx faissIndex) *coalesceQueue {
 }
 
 func (q *coalesceQueue) stop() {
-	close(q.stopCh)
-	if q.timer != nil {
-		q.timer.Stop()
+	if isClosed(q.stopCh) {
+		return
 	}
+	close(q.stopCh)
 }
 
 func (q *coalesceQueue) monitor() {
@@ -195,6 +205,7 @@ func (q *coalesceQueue) monitor() {
 		case <-q.stopCh:
 			// flush the queue one last time before stopping, to ensure that any pending requests are processed.
 			q.flush()
+			dequeueTimer = nil
 			return
 		}
 	}

--- a/faiss_vector_request_batcher.go
+++ b/faiss_vector_request_batcher.go
@@ -23,12 +23,11 @@ import (
 )
 
 var (
-	// the latency budget for processing a batch of search requests.
-	// This is the maximum amount of time that the batcher will wait before
-	// executing a batch of search requests.
-	// - Higher the latency budget, higher the throughput of the batcher, but also higher the latency for individual search requests.
-	// - Lower the latency budget, lower the throughput of the batcher, but also lower the latency for individual search requests.
-	LatencyBudget time.Duration = 250 * time.Millisecond
+	// adaptive batching parameters - these can be tuned based on the expected workload and latency requirements.
+	// MinLatencyBudget is the minimum amount of time that the batcher will wait before flushing a batch of requests.
+	MinLatencyBudget time.Duration = 10 * time.Millisecond
+	// MaxLatencyBudget is the maximum amount of time that the batcher will wait before flushing a batch of requests.
+	MaxLatencyBudget time.Duration = 250 * time.Millisecond
 )
 
 var (
@@ -75,20 +74,18 @@ func (b *requestBatcher) stop() {
 // --------------------------------------------------
 
 type batchRequest struct {
-	qVector  *vectorSet
-	k        int64
-	respCh   []chan *batchResponse
-	deadline time.Time
+	qVector *vectorSet
+	k       int64
+	respCh  []chan *batchResponse
 }
 
 func newBatchRequest(qVector *vectorSet, k int64) (*batchRequest, chan *batchResponse) {
 	// response channel for sending the search results back to the requester.
 	respChan := make(chan *batchResponse, 1)
 	return &batchRequest{
-		qVector:  qVector,
-		k:        k,
-		respCh:   []chan *batchResponse{respChan},
-		deadline: time.Now().Add(LatencyBudget),
+		qVector: qVector,
+		k:       k,
+		respCh:  []chan *batchResponse{respChan},
 	}, respChan
 }
 
@@ -107,10 +104,6 @@ func (r *batchRequest) mergeWith(other *batchRequest) {
 	// append the response channels from the other request to this request, so that when the search results are ready,
 	// we can send the results back to all requesters that were merged into this batch.
 	r.respCh = append(r.respCh, other.respCh...)
-	// retain the earliest deadline among the merged requests, so that the batch will be executed within the latency budget of all merged requests.
-	if other.deadline.Before(r.deadline) {
-		r.deadline = other.deadline
-	}
 }
 
 func (r *batchRequest) sendResponse(distances []float32, ids []int64, err error) {
@@ -161,6 +154,8 @@ type coalesceQueue struct {
 	queue []*batchRequest
 	// timer for automatically triggering the execution of a batch of requests when the earliest deadline is reached.
 	timer *time.Timer
+	// timestamp of the last time the queue was flushed.
+	lastFlush time.Time
 }
 
 func newCoalesceQueue(idx faissIndex) *coalesceQueue {
@@ -186,16 +181,17 @@ func (q *coalesceQueue) monitor() {
 	for {
 		select {
 		case req := <-q.enqueueCh:
-			// enqueue the new batch request into the coalesce queue.
+			if len(q.queue) == 0 {
+				dequeueTimer = q.startTimer()
+			}
 			q.enqueue(req)
-			// reset the dequeue timer after adding a new request.
-			dequeueTimer = q.resetTimer()
 		case <-dequeueTimer:
 			// when the timer fires, it means that at least one batch request in the queue has
 			// reached its deadline and needs to be executed.
 			q.flush()
-			// the queue is flushed after processing, so we need to reset the timer for the next batch of requests in the queue (if any).
-			dequeueTimer = q.resetTimer()
+			// the queue is flushed after processing, so set the dequeue timer to nil until we have
+			// new requests in the queue that can trigger a new timer.
+			dequeueTimer = nil
 		case <-q.stopCh:
 			// flush the queue one last time before stopping, to ensure that any pending requests are processed.
 			q.flush()
@@ -204,10 +200,31 @@ func (q *coalesceQueue) monitor() {
 	}
 }
 
+func (q *coalesceQueue) startTimer() <-chan time.Time {
+	// Calculate adaptive budget when this is the first request after a flush
+	var budget time.Duration
+	// empty queue.
+	if !q.lastFlush.IsZero() {
+		// Calculate time elapsed since last flush
+		timeSinceLastFlush := time.Since(q.lastFlush)
+		// Adaptive strategy:
+		// - If requests arrive quickly (small timeSinceLastFlush), use higher budget to batch more
+		// - If requests arrive slowly (large timeSinceLastFlush), use lower budget to reduce latency
+		budget = max(MaxLatencyBudget-timeSinceLastFlush, MinLatencyBudget)
+	} else {
+		// First request ever, use maximum budget
+		budget = MaxLatencyBudget
+	}
+	if q.timer != nil {
+		q.timer.Reset(budget)
+	} else {
+		q.timer = time.NewTimer(budget)
+	}
+	return q.timer.C
+}
+
 func (q *coalesceQueue) enqueue(req *batchRequest) {
-	// since we are adding a new request to the queue, we need to reset the timer to ensure that the
-	// batch will be executed within the latency budget of all requests in the queue.
-	// try to find an existing batch request in the queue that can be merged with this new request.
+	// Try to find an existing batch request in the queue that can be merged with this new request.
 	for _, pendingReq := range q.queue {
 		if pendingReq.canMerge(req) {
 			// if we find a compatible request, merge this new request into the existing batch request and return.
@@ -219,35 +236,16 @@ func (q *coalesceQueue) enqueue(req *batchRequest) {
 	q.queue = append(q.queue, req)
 }
 
-func (q *coalesceQueue) resetTimer() <-chan time.Time {
-	if len(q.queue) == 0 {
-		return nil
-	}
-	// find earliest deadline
-	earliest := q.queue[0].deadline
-	for _, r := range q.queue[1:] {
-		if r.deadline.Before(earliest) {
-			earliest = r.deadline
-		}
-	}
-	// calculate the duration until the earliest deadline, and reset the timer to trigger at that time.
-	d := time.Until(earliest)
-	if d < 0 {
-		d = 0
-	}
-	if q.timer != nil {
-		q.timer.Reset(d)
-	} else {
-		q.timer = time.NewTimer(d)
-	}
-	return q.timer.C
-}
-
 func (q *coalesceQueue) flush() {
 	// execute all the requests in the queue, and empty the queue afterwards.
 	for _, req := range q.queue {
 		distances, ids, err := q.idx.searchWithoutIDs(req.qVector, req.k, nil, nil)
 		req.sendResponse(distances, ids, err)
+	}
+	// update the last flush time to now, since we just processed a batch of requests.
+	q.lastFlush = time.Now()
+	if q.timer != nil {
+		q.timer.Stop()
 	}
 	// clear the queue after processing all the requests.
 	q.queue = q.queue[:0]

--- a/faiss_vector_request_batcher_test.go
+++ b/faiss_vector_request_batcher_test.go
@@ -1,0 +1,139 @@
+//  Copyright (c) 2026 Couchbase, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// 		http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//go:build vectors
+// +build vectors
+
+package zap
+
+import (
+	"encoding/json"
+	"sync"
+	"testing"
+	"time"
+
+	faiss "github.com/blevesearch/go-faiss"
+)
+
+// --------------------------
+// fake Faiss index
+// --------------------------
+// placeholder faiss index implementation for testing the request batcher.
+// It allows us to simulate search latency and return predefined distances and IDs for
+// search requests, without needing a real Faiss index or vector data.
+type fakeFaissIndex struct {
+	mu          sync.Mutex
+	searchDelay time.Duration
+}
+
+func (f *fakeFaissIndex) search(vecs *vectorSet, k int64) ([]float32, []int64, error) {
+	if f.searchDelay > 0 {
+		time.Sleep(f.searchDelay)
+	}
+	// generate K random distances and IDs for testing purposes, for each vector in the input vector set.
+	resultSize := vecs.nvecs * int(k)
+	d := make([]float32, resultSize)
+	i := make([]int64, resultSize)
+	for j := 0; j < resultSize; j++ {
+		d[j] = float32(j)
+		i[j] = int64(j)
+	}
+	return d, i, nil
+}
+
+func (f *fakeFaissIndex) searchWithoutIDs(vecs *vectorSet, k int64, _ faiss.Selector, _ json.RawMessage) ([]float32, []int64, error) {
+	return f.search(vecs, k)
+}
+
+func (f *fakeFaissIndex) searchWithIDs(vecs *vectorSet, k int64, _ faiss.Selector, _ json.RawMessage) ([]float32, []int64, error) {
+	return f.search(vecs, k)
+}
+
+func (f *fakeFaissIndex) add(vecs *vectorSet) error {
+	return nil
+}
+
+func (f *fakeFaissIndex) close() {}
+
+func (f *fakeFaissIndex) dim() int {
+	return 0
+}
+
+func (f *fakeFaissIndex) metricType() int {
+	return 0
+}
+
+func (f *fakeFaissIndex) serialize() ([]byte, error) {
+	return nil, nil
+}
+
+func (f *fakeFaissIndex) size() uint64 {
+	return 0
+}
+
+func (f *fakeFaissIndex) castIVF() faissIndexIVF {
+	return nil
+}
+
+func (f *fakeFaissIndex) castSQ() faissIndexSQ {
+	return nil
+}
+
+func newFakeFaissIndex(searchDelay time.Duration) *fakeFaissIndex {
+	return &fakeFaissIndex{
+		searchDelay: searchDelay,
+	}
+}
+
+// --------------------------------------------------
+
+func dummyVectorSet(dim int) (*vectorSet, error) {
+	vec := make([]float32, dim)
+	for i := 0; i < dim; i++ {
+		vec[i] = float32(i)
+	}
+	return newVectorSet(dim, vec)
+}
+
+func BenchmarkRequestBatcherSearch(b *testing.B) {
+	// config
+	dims := 512
+	k := 10
+	delay := 100 * time.Millisecond
+	latencyBudget := 250 * time.Millisecond
+	// impl
+	old := MaxLatencyBudget
+	MaxLatencyBudget = latencyBudget
+	b.Cleanup(func() {
+		MaxLatencyBudget = old
+	})
+	idx := newFakeFaissIndex(delay)
+	rb := newRequestBatcher(idx)
+	b.Cleanup(rb.stop)
+	b.ReportAllocs()
+	b.ResetTimer()
+	b.Run("search_parallel", func(b *testing.B) {
+		b.RunParallel(func(pb *testing.PB) {
+			for pb.Next() {
+				vecs, err := dummyVectorSet(dims)
+				if err != nil {
+					b.Fatalf("unexpected error: %v", err)
+				}
+				_, _, err = rb.search(vecs, int64(k))
+				if err != nil {
+					b.Fatalf("unexpected error: %v", err)
+				}
+			}
+		})
+	})
+}

--- a/faiss_vector_request_batcher_test.go
+++ b/faiss_vector_request_batcher_test.go
@@ -49,6 +49,10 @@ func (f *fakeFaissIndex) search(vecs *vectorSet, k int64) ([]float32, []int64, e
 	return d, i, nil
 }
 
+func (f *fakeFaissIndex) batchSearch(vecs *vectorSet, k int64) ([]float32, []int64, error) {
+	return f.search(vecs, k)
+}
+
 func (f *fakeFaissIndex) searchWithoutIDs(vecs *vectorSet, k int64, _ faiss.Selector, _ json.RawMessage) ([]float32, []int64, error) {
 	return f.search(vecs, k)
 }

--- a/faiss_vector_request_batcher_test.go
+++ b/faiss_vector_request_batcher_test.go
@@ -110,13 +110,7 @@ func BenchmarkRequestBatcherSearch(b *testing.B) {
 	dims := 512
 	k := 10
 	delay := 100 * time.Millisecond
-	latencyBudget := 250 * time.Millisecond
 	// impl
-	old := MaxLatencyBudget
-	MaxLatencyBudget = latencyBudget
-	b.Cleanup(func() {
-		MaxLatencyBudget = old
-	})
 	idx := newFakeFaissIndex(delay)
 	rb := newRequestBatcher(idx)
 	b.Cleanup(rb.stop)

--- a/faiss_vector_request_batcher_test.go
+++ b/faiss_vector_request_batcher_test.go
@@ -18,7 +18,6 @@ package zap
 
 import (
 	"encoding/json"
-	"sync"
 	"testing"
 	"time"
 
@@ -32,7 +31,6 @@ import (
 // It allows us to simulate search latency and return predefined distances and IDs for
 // search requests, without needing a real Faiss index or vector data.
 type fakeFaissIndex struct {
-	mu          sync.Mutex
 	searchDelay time.Duration
 }
 
@@ -105,29 +103,26 @@ func dummyVectorSet(dim int) (*vectorSet, error) {
 	return newVectorSet(dim, vec)
 }
 
-func BenchmarkRequestBatcherSearch(b *testing.B) {
+func BenchmarkBatchedSearch(b *testing.B) {
 	// config
 	dims := 512
 	k := 10
-	delay := 100 * time.Millisecond
+	delay := 50 * time.Millisecond
 	// impl
 	idx := newFakeFaissIndex(delay)
 	rb := newRequestBatcher(idx)
 	b.Cleanup(rb.stop)
-	b.ReportAllocs()
 	b.ResetTimer()
-	b.Run("search_parallel", func(b *testing.B) {
-		b.RunParallel(func(pb *testing.PB) {
-			for pb.Next() {
-				vecs, err := dummyVectorSet(dims)
-				if err != nil {
-					b.Fatalf("unexpected error: %v", err)
-				}
-				_, _, err = rb.search(vecs, int64(k))
-				if err != nil {
-					b.Fatalf("unexpected error: %v", err)
-				}
+	b.RunParallel(func(pb *testing.PB) {
+		for pb.Next() {
+			vecs, err := dummyVectorSet(dims)
+			if err != nil {
+				b.Fatalf("unexpected error: %v", err)
 			}
-		})
+			_, _, err = rb.search(vecs, int64(k))
+			if err != nil {
+				b.Fatalf("unexpected error: %v", err)
+			}
+		}
 	})
 }

--- a/faiss_vector_wrapper.go
+++ b/faiss_vector_wrapper.go
@@ -1035,3 +1035,15 @@ func (v *vectorSet) binarize() {
 	// convert the floatData to binary format and store in binaryData
 	v.binaryData = convertToBinary(v.floatData, v.dim)
 }
+
+func (v *vectorSet) mergeWith(other *vectorSet) {
+	// sanity check to ensure the two vector sets are compatible for merging
+	if v.dim != other.dim {
+		return
+	}
+	// merge the float data
+	v.floatData = append(v.floatData, other.floatData...)
+	v.nvecs += other.nvecs
+	// invalidate the binary data as the float data has changed
+	v.binaryData = nil
+}

--- a/faiss_vector_wrapper.go
+++ b/faiss_vector_wrapper.go
@@ -1036,6 +1036,17 @@ func (v *vectorSet) binarize() {
 	v.binaryData = convertToBinary(v.floatData, v.dim)
 }
 
+func (v *vectorSet) clone() *vectorSet {
+	// create a new vectorSet with the same dimensions and number of vectors
+	clone := &vectorSet{
+		dim:        v.dim,
+		nvecs:      v.nvecs,
+		floatData:  slices.Clone(v.floatData),
+		binaryData: slices.Clone(v.binaryData),
+	}
+	return clone
+}
+
 func (v *vectorSet) mergeWith(other *vectorSet) {
 	// sanity check to ensure the two vector sets are compatible for merging
 	if v.dim != other.dim {


### PR DESCRIPTION
- Add latency-aware batching for vector search requests using a timer-driven coalescing queue.
- Merge compatible requests (same k) and execute them together to reduce number of `Faiss` calls.
- Ensure bounded latency via per-request deadlines using a package-level variable called `LatencyBudget`.