### PR TITLE
bug: use `index.TrainedIndexCallbackFn`

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.24.0
 
 require (
 	github.com/RoaringBitmap/roaring/v2 v2.14.5
-	github.com/blevesearch/bleve_index_api v1.3.5
+	github.com/blevesearch/bleve_index_api v1.3.9
 	github.com/blevesearch/go-faiss v1.0.30
 	github.com/blevesearch/mmap-go v1.2.0
 	github.com/blevesearch/scorch_segment_api/v2 v2.4.4

--- a/go.sum
+++ b/go.sum
@@ -2,8 +2,8 @@ github.com/RoaringBitmap/roaring/v2 v2.14.5 h1:ckd0o545JqDPeVJDgeFoaM21eBixUnlWf
 github.com/RoaringBitmap/roaring/v2 v2.14.5/go.mod h1:eq4wdNXxtJIS/oikeCzdX1rBzek7ANzbth041hrU8Q4=
 github.com/bits-and-blooms/bitset v1.24.2 h1:M7/NzVbsytmtfHbumG+K2bremQPMJuqv1JD3vOaFxp0=
 github.com/bits-and-blooms/bitset v1.24.2/go.mod h1:7hO7Gc7Pp1vODcmWvKMRA9BNmbv6a/7QIWpPxHddWR8=
-github.com/blevesearch/bleve_index_api v1.3.5 h1:Sbfavf0iBRoiYLM5lKCPIrSSYeQXReoRmk53pZnTKYk=
-github.com/blevesearch/bleve_index_api v1.3.5/go.mod h1:xvd48t5XMeeioWQ5/jZvgLrV98flT2rdvEJ3l/ki4Ko=
+github.com/blevesearch/bleve_index_api v1.3.9 h1:TLoiBaqcfWGfI1Il0+zzky452uYCPoSMosDSltkCfKs=
+github.com/blevesearch/bleve_index_api v1.3.9/go.mod h1:xvd48t5XMeeioWQ5/jZvgLrV98flT2rdvEJ3l/ki4Ko=
 github.com/blevesearch/go-faiss v1.0.30 h1:pWX3/Si4Z7GlwsD2eRXoF3SfVaDkg8plBlPdUKuhGts=
 github.com/blevesearch/go-faiss v1.0.30/go.mod h1:OMGQwOaRRYxrmeNdMrXJPvVx8gBnvE5RYrr0BahNnkk=
 github.com/blevesearch/mmap-go v1.2.0 h1:l33nNKPFcBjJUMwem6sAYJPUzhUCABoK9FxZDGiFNBI=

--- a/section_faiss_vector_index.go
+++ b/section_faiss_vector_index.go
@@ -64,12 +64,6 @@ const (
 	faissBIVFIndex
 )
 
-// Callback hooks for custom faiss index construction and handling.
-type (
-	// Returns the centroid index to be used in the fast merge path.
-	TrainedIndexCallbackFn func(indexName string) (interface{}, error)
-)
-
 // Errors for invariant violations related to fast merge and centroid index retrieval.
 var (
 	ErrorCentroidIndexNotIVF  error = errors.New("centroid index is not an IVF index, which is required for fast merge")
@@ -234,11 +228,11 @@ func (v *faissVectorIndexSection) Merge(opaque map[int]resetable, segments []*Se
 }
 
 func centroidIndexFromConfig(config map[string]interface{}, fieldName string) (faissIndexIVF, error) {
-	var trainedIndexFor TrainedIndexCallbackFn
+	var trainedIndexFor index.TrainedIndexCallbackFn
 	var training bool
 	var rv *faiss.IndexImpl
 	if cb, ok := config[index.TrainedIndexCallback]; ok {
-		trainedIndexFor = cb.(TrainedIndexCallbackFn)
+		trainedIndexFor = cb.(index.TrainedIndexCallbackFn)
 	}
 	if tf, ok := config[index.TrainingKey]; ok {
 		training = tf.(bool)


### PR DESCRIPTION
- keep the type of func signatures same across bleve and zap