### PR TITLE
MB-71216: implement fast merge for binary index class

### DIFF
--- a/centroid_index.go
+++ b/centroid_index.go
@@ -21,6 +21,7 @@ import (
 	"encoding/binary"
 	"fmt"
 
+	index "github.com/blevesearch/bleve_index_api"
 	faiss "github.com/blevesearch/go-faiss"
 )
 
@@ -38,10 +39,13 @@ func (sb *SegmentBase) GetCoarseQuantizer(field string) (interface{}, error) {
 
 	pos := int(vectorSection)
 	// doc values and vector optimization type
-	for i := 0; i < 3; i++ {
+	for i := 0; i < 2; i++ {
 		_, n := binary.Uvarint(sb.mem[pos : pos+binary.MaxVarintLen64])
 		pos += n
 	}
+
+	optType, n := binary.Uvarint(sb.mem[pos : pos+binary.MaxVarintLen64])
+	pos += n
 
 	numVecs, n := binary.Uvarint(sb.mem[pos : pos+binary.MaxVarintLen64])
 	pos += n
@@ -69,6 +73,10 @@ func (sb *SegmentBase) GetCoarseQuantizer(field string) (interface{}, error) {
 	}
 	pos += int(indexSize)
 
+	// store the config in the faissIndex object itself since we want to know the
+	// whether we want to hit the fast merge path or not while merging the segments
+	indexConfig := newFaissIndexConfig(faissIndexType(indexType), index.VectorIndexOptimizationsReverseLookup[int(optType)],
+		faissIndex.D(), 0, int(numVecs), determineCentroids(int(numVecs)), false)
 	if faissIndexType(indexType) == faissBIVFIndex {
 		binaryIndexSize, n := binary.Uvarint(sb.mem[pos : pos+binary.MaxVarintLen64])
 		pos += n
@@ -76,7 +84,7 @@ func (sb *SegmentBase) GetCoarseQuantizer(field string) (interface{}, error) {
 		if err != nil {
 			return nil, err
 		}
-		return newFaissBinaryIndex(binaryIndex, faissIndex)
+		return newFaissBinaryIndexWithConfig(binaryIndex, faissIndex, indexConfig)
 	}
-	return newFaissFloat32Index(faissIndex)
+	return newFaissFloat32IndexWithConfig(faissIndex, indexConfig)
 }

--- a/centroid_index.go
+++ b/centroid_index.go
@@ -57,14 +57,26 @@ func (sb *SegmentBase) GetCoarseQuantizer(field string) (interface{}, error) {
 	}
 
 	// type of index
-	_, n = binary.Uvarint(sb.mem[pos : pos+binary.MaxVarintLen64])
+	indexType, n := binary.Uvarint(sb.mem[pos : pos+binary.MaxVarintLen64])
 	pos += n
 	indexSize, n := binary.Uvarint(sb.mem[pos : pos+binary.MaxVarintLen64])
 	pos += n
 
+	// todo: might wanna use the vector cache here, early tests didn't show a big diff
 	faissIndex, err := faiss.ReadIndexFromBuffer(sb.mem[pos:pos+int(indexSize)], faissIOFlags)
 	if err != nil {
 		return nil, err
 	}
-	return faissIndex, nil
+	pos += int(indexSize)
+
+	if faissIndexType(indexType) == faissBIVFIndex {
+		binaryIndexSize, n := binary.Uvarint(sb.mem[pos : pos+binary.MaxVarintLen64])
+		pos += n
+		binaryIndex, err := faiss.ReadBinaryIndexFromBuffer(sb.mem[pos:pos+int(binaryIndexSize)], faissIOFlags)
+		if err != nil {
+			return nil, err
+		}
+		return newFaissBinaryIndex(binaryIndex, faissIndex)
+	}
+	return newFaissFloat32Index(faissIndex)
 }

--- a/centroid_index.go
+++ b/centroid_index.go
@@ -21,7 +21,6 @@ import (
 	"encoding/binary"
 	"fmt"
 
-	index "github.com/blevesearch/bleve_index_api"
 	faiss "github.com/blevesearch/go-faiss"
 )
 
@@ -39,13 +38,10 @@ func (sb *SegmentBase) GetCoarseQuantizer(field string) (interface{}, error) {
 
 	pos := int(vectorSection)
 	// doc values and vector optimization type
-	for i := 0; i < 2; i++ {
+	for i := 0; i < 3; i++ {
 		_, n := binary.Uvarint(sb.mem[pos : pos+binary.MaxVarintLen64])
 		pos += n
 	}
-
-	optType, n := binary.Uvarint(sb.mem[pos : pos+binary.MaxVarintLen64])
-	pos += n
 
 	numVecs, n := binary.Uvarint(sb.mem[pos : pos+binary.MaxVarintLen64])
 	pos += n
@@ -73,10 +69,6 @@ func (sb *SegmentBase) GetCoarseQuantizer(field string) (interface{}, error) {
 	}
 	pos += int(indexSize)
 
-	// store the config in the faissIndex object itself since we want to know the
-	// whether we want to hit the fast merge path or not while merging the segments
-	indexConfig := newFaissIndexConfig(faissIndexType(indexType), index.VectorIndexOptimizationsReverseLookup[int(optType)],
-		faissIndex.D(), 0, int(numVecs), determineCentroids(int(numVecs)), false)
 	if faissIndexType(indexType) == faissBIVFIndex {
 		binaryIndexSize, n := binary.Uvarint(sb.mem[pos : pos+binary.MaxVarintLen64])
 		pos += n
@@ -84,7 +76,7 @@ func (sb *SegmentBase) GetCoarseQuantizer(field string) (interface{}, error) {
 		if err != nil {
 			return nil, err
 		}
-		return newFaissBinaryIndexWithConfig(binaryIndex, faissIndex, indexConfig)
+		return newFaissBinaryIndex(binaryIndex, faissIndex)
 	}
-	return newFaissFloat32IndexWithConfig(faissIndex, indexConfig)
+	return newFaissFloat32Index(faissIndex)
 }

--- a/faiss_vector_index.go
+++ b/faiss_vector_index.go
@@ -94,6 +94,9 @@ type faissIndexIVF interface {
 	// IVF index that is trained on the same data and used to assign vectors
 	// to clusters in the IVF index.
 	setQuantizers(trainedIndex faissIndexIVF) error
+	// quantization return the type of quantization used which can help determing if
+	// the fast merge path is applicable or not using the trained index
+	quantization() string
 	// merged another faiss index into the current IVF index,
 	// with an offset to adjust vector IDs from the other index.
 	mergeFrom(other faissIndex, offset int64) error

--- a/faiss_vector_index.go
+++ b/faiss_vector_index.go
@@ -41,8 +41,8 @@ type faissIndex interface {
 	metricType() int
 	// ntotal returns the total number of vectors currently stored in the index.
 	ntotal() int64
-	// based on the optimization type and the index details we decide and return a
-	// boolean indicating whether the index is eligible for fast merge.
+	// based on the optimization type and the index details we decide and return
+	// whether the participating child index is eligible to be fast merged or not
 	isMergeable(optimizedFor string) bool
 	// reconstructBatch reconstructs the original vectors for the given vector IDs in the index.
 	reconstructBatch(vecIDs []int64, prealloc []float32) ([]float32, error)
@@ -94,8 +94,8 @@ type faissIndexIVF interface {
 	// IVF index that is trained on the same data and used to assign vectors
 	// to clusters in the IVF index.
 	setQuantizers(trainedIndex faissIndexIVF) error
-	// quantization return the type of quantization used which can help determing if
-	// the fast merge path is applicable or not using the trained index
+	// quantization returns the type of quantization of the trained IVF index based
+	// on which we can determine if its viable to be used for fast merge or not
 	quantization() string
 	// merged another faiss index into the current IVF index,
 	// with an offset to adjust vector IDs from the other index.

--- a/faiss_vector_index.go
+++ b/faiss_vector_index.go
@@ -42,8 +42,6 @@ type faissIndex interface {
 	metricType() int
 	// ntotal returns the total number of vectors currently stored in the index.
 	ntotal() int64
-	// returns whether index is eligible for fast merge
-	isMergeable() bool
 	// reconstructBatch reconstructs the original vectors for the given vector IDs in the index.
 	reconstructBatch(vecIDs []int64, prealloc []float32) ([]float32, error)
 	// performs a search on the index using the provided query vector and and retrieves the top K nearest neighbors.
@@ -95,6 +93,8 @@ type faissIndexIVF interface {
 	// IVF index that is trained on the same data and used to assign vectors
 	// to clusters in the IVF index.
 	setQuantizers(trainedIndex faissIndexIVF) error
+	// returns whether the participating index is eligible for fast merge
+	isMergeable() bool
 	// merged another faiss index into the current IVF index,
 	// with an offset to adjust vector IDs from the other index.
 	mergeFrom(other faissIndex, offset int64) error

--- a/faiss_vector_index.go
+++ b/faiss_vector_index.go
@@ -41,6 +41,9 @@ type faissIndex interface {
 	metricType() int
 	// ntotal returns the total number of vectors currently stored in the index.
 	ntotal() int64
+	// based on the optimization type and the index details we decide and return a
+	// boolean indicating whether the index is eligible for fast merge.
+	isMergeable(optimizedFor string) bool
 	// reconstructBatch reconstructs the original vectors for the given vector IDs in the index.
 	reconstructBatch(vecIDs []int64, prealloc []float32) ([]float32, error)
 	// performs a search on the index using the provided query vector and and retrieves the top K nearest neighbors.

--- a/faiss_vector_index.go
+++ b/faiss_vector_index.go
@@ -25,6 +25,7 @@ import (
 )
 
 var (
+	errNilConfig    error = errors.New("faiss index config is nil")
 	errNilIndex     error = errors.New("faiss index is nil")
 	errNotSupported error = errors.New("operation not supported")
 )
@@ -41,9 +42,8 @@ type faissIndex interface {
 	metricType() int
 	// ntotal returns the total number of vectors currently stored in the index.
 	ntotal() int64
-	// based on the optimization type and the index details we decide and return
-	// whether the participating child index is eligible to be fast merged or not
-	isMergeable(optimizedFor string) bool
+	// returns whether index is eligible for fast merge
+	isMergeable() bool
 	// reconstructBatch reconstructs the original vectors for the given vector IDs in the index.
 	reconstructBatch(vecIDs []int64, prealloc []float32) ([]float32, error)
 	// performs a search on the index using the provided query vector and and retrieves the top K nearest neighbors.
@@ -64,6 +64,7 @@ type faissIndex interface {
 
 // Interface for IVF-specific operations on Faiss vector indices.
 type faissIndexIVF interface {
+	faissIndex
 	// returns the count of the selected vector IDs in each
 	// cluster of the IVF index, based on the provided selector.
 	clusterVectorCounts(sel faiss.Selector, nlist int) ([]int64, error)
@@ -94,9 +95,6 @@ type faissIndexIVF interface {
 	// IVF index that is trained on the same data and used to assign vectors
 	// to clusters in the IVF index.
 	setQuantizers(trainedIndex faissIndexIVF) error
-	// quantization returns the type of quantization of the trained IVF index based
-	// on which we can determine if its viable to be used for fast merge or not
-	quantization() string
 	// merged another faiss index into the current IVF index,
 	// with an offset to adjust vector IDs from the other index.
 	mergeFrom(other faissIndex, offset int64) error

--- a/faiss_vector_index.go
+++ b/faiss_vector_index.go
@@ -90,7 +90,7 @@ type faissIndexIVF interface {
 	// sets the quantizers for the IVF index. The quantizer is a separate
 	// IVF index that is trained on the same data and used to assign vectors
 	// to clusters in the IVF index.
-	setQuantizers(centroidIndex faissIndexIVF) error
+	setQuantizers(trainedIndex faissIndexIVF) error
 	// merged another faiss index into the current IVF index,
 	// with an offset to adjust vector IDs from the other index.
 	mergeFrom(other faissIndex, offset int64) error

--- a/faiss_vector_index_bivf.go
+++ b/faiss_vector_index_bivf.go
@@ -49,15 +49,15 @@ func newFaissBinaryIndexWithConfig(binary *faiss.BinaryIndexImpl, backing *faiss
 	if binary == nil || backing == nil {
 		return nil, errNilIndex
 	}
+	if cfg == nil {
+		return nil, errNilConfig
+	}
+
 	return &faissBinaryIndex{
 		cfg:     cfg,
 		backing: backing,
 		binary:  binary,
 	}, nil
-}
-
-func (b *faissBinaryIndex) quantization() string {
-	return quantizationType(b.cfg.optimizationType, b.binary.Ntotal())
 }
 
 func (b *faissBinaryIndex) add(vecs *vectorSet) error {
@@ -286,13 +286,21 @@ func (b *faissBinaryIndex) setQuantizers(trainedIndex faissIndexIVF) error {
 	return errNotSupported
 }
 
-func (b *faissBinaryIndex) isMergeable(optimizedFor string) bool {
-	// note: currently the only the bivf-sq8 type indexes are eligible for fast merge
-	return b.binary.IsIVFIndex() && optimizedFor == index.IndexBIVFWithBackingSQ8
+func (b *faissBinaryIndex) isMergeable() bool {
+	if b.cfg != nil {
+		switch b.cfg.optimizationType {
+		case index.IndexBIVFWithBackingFlat, index.IndexBIVFWithBackingSQ8:
+			return b.backing.Ntotal() > 1000
+		}
+	}
+	return false
 }
 
 func (b *faissBinaryIndex) mergeFrom(other faissIndex, offset int64) error {
 	if idx, ok := other.(*faissBinaryIndex); ok {
+		if !idx.isMergeable() {
+			return errNotSupported
+		}
 		// merge the binary and the backing index, both flat and SQ8 indexes support
 		// merge_from API underneath the hood. the add_id is kept to 0 since we will
 		// be merging the largest set of indexes which will be sequential in the list

--- a/faiss_vector_index_bivf.go
+++ b/faiss_vector_index_bivf.go
@@ -29,6 +29,7 @@ import (
 // Faiss Binary IVF Index
 // ---------------------------------
 type faissBinaryIndex struct {
+	cfg     *faissIndexConfig
 	backing *faiss.IndexImpl
 	binary  *faiss.BinaryIndexImpl
 }
@@ -42,6 +43,21 @@ func newFaissBinaryIndex(binary *faiss.BinaryIndexImpl, backing *faiss.IndexImpl
 		backing: backing,
 		binary:  binary,
 	}, nil
+}
+
+func newFaissBinaryIndexWithConfig(binary *faiss.BinaryIndexImpl, backing *faiss.IndexImpl, cfg *faissIndexConfig) (index faissIndex, err error) {
+	if binary == nil || backing == nil {
+		return nil, errNilIndex
+	}
+	return &faissBinaryIndex{
+		cfg:     cfg,
+		backing: backing,
+		binary:  binary,
+	}, nil
+}
+
+func (b *faissBinaryIndex) quantization() string {
+	return quantizationType(b.cfg.optimizationType, b.binary.Ntotal())
 }
 
 func (b *faissBinaryIndex) add(vecs *vectorSet) error {

--- a/faiss_vector_index_bivf.go
+++ b/faiss_vector_index_bivf.go
@@ -289,8 +289,11 @@ func (b *faissBinaryIndex) setQuantizers(trainedIndex faissIndexIVF) error {
 func (b *faissBinaryIndex) isMergeable() bool {
 	if b.cfg != nil {
 		switch b.cfg.optimizationType {
-		case index.IndexBIVFWithBackingFlat, index.IndexBIVFWithBackingSQ8:
-			return b.backing.Ntotal() > 1000
+		case index.IndexBIVFWithBackingFlat:
+			// the flat backing index currently doesn't support merge_from
+			return false
+		case index.IndexBIVFWithBackingSQ8:
+			return b.backing.Ntotal() > ivfThreshold
 		}
 	}
 	return false

--- a/faiss_vector_index_bivf.go
+++ b/faiss_vector_index_bivf.go
@@ -21,6 +21,7 @@ import (
 	"encoding/binary"
 	"encoding/json"
 
+	index "github.com/blevesearch/bleve_index_api"
 	faiss "github.com/blevesearch/go-faiss"
 )
 
@@ -267,6 +268,11 @@ func (b *faissBinaryIndex) setQuantizers(trainedIndex faissIndexIVF) error {
 		return nil
 	}
 	return errNotSupported
+}
+
+func (b *faissBinaryIndex) isMergeable(optimizedFor string) bool {
+	// note: currently the only the bivf-sq8 type indexes are eligible for fast merge
+	return b.binary.IsIVFIndex() && optimizedFor == index.IndexBIVFWithBackingSQ8
 }
 
 func (b *faissBinaryIndex) mergeFrom(other faissIndex, offset int64) error {

--- a/faiss_vector_index_bivf.go
+++ b/faiss_vector_index_bivf.go
@@ -254,7 +254,7 @@ func (b *faissBinaryIndex) setQuantizers(trainedIndex faissIndexIVF) error {
 	if idx, ok := trainedIndex.(*faissBinaryIndex); ok {
 		// set quantizers for the binary and the backing index if its an SQ8 index
 		var err error
-		if idx.backing != nil && idx.backing.IsSQIndex() {
+		if idx.backing.IsSQIndex() {
 			err = b.backing.SetQuantizers(idx.backing)
 			if err != nil {
 				return err

--- a/faiss_vector_index_bivf.go
+++ b/faiss_vector_index_bivf.go
@@ -251,11 +251,40 @@ func (b *faissBinaryIndex) trainAndAdd(trainingData *vectorSet, vecsToAdd *vecto
 }
 
 func (b *faissBinaryIndex) setQuantizers(trainedIndex faissIndexIVF) error {
-	// not supported for binary indexes, returns error
+	if idx, ok := trainedIndex.(*faissBinaryIndex); ok {
+		// set quantizers for the binary and the backing index if its an SQ8 index
+		var err error
+		if idx.backing != nil && idx.backing.IsSQIndex() {
+			err = b.backing.SetQuantizers(idx.backing)
+			if err != nil {
+				return err
+			}
+		}
+		err = b.binary.SetQuantizers(idx.binary)
+		if err != nil {
+			return err
+		}
+		return nil
+	}
 	return errNotSupported
 }
 
 func (b *faissBinaryIndex) mergeFrom(other faissIndex, offset int64) error {
-	// merging is not supported for binary indexes, return error
+	if idx, ok := other.(*faissBinaryIndex); ok {
+		// merge the binary and the backing index, both flat and SQ8 indexes support
+		// merge_from API underneath the hood. the add_id is kept to 0 since we will
+		// be merging the largest set of indexes which will be sequential in the list
+		// of segments being merged, so there won't be any ID conflicts.
+		err := b.backing.MergeFrom(idx.backing, 0)
+		if err != nil {
+			return err
+		}
+		err = b.binary.MergeFrom(idx.binary, offset)
+		if err != nil {
+			return err
+		}
+
+		return nil
+	}
 	return errNotSupported
 }

--- a/faiss_vector_index_float32.go
+++ b/faiss_vector_index_float32.go
@@ -29,6 +29,7 @@ import (
 // Faiss Float32 Index
 // ---------------------------------
 type faissFloat32Index struct {
+	cfg *faissIndexConfig
 	idx *faiss.IndexImpl
 }
 
@@ -39,6 +40,20 @@ func newFaissFloat32Index(idx *faiss.IndexImpl) (index faissIndex, err error) {
 	return &faissFloat32Index{
 		idx: idx,
 	}, nil
+}
+
+func newFaissFloat32IndexWithConfig(idx *faiss.IndexImpl, cfg *faissIndexConfig) (index faissIndex, err error) {
+	if idx == nil {
+		return nil, errNilIndex
+	}
+	return &faissFloat32Index{
+		idx: idx,
+		cfg: cfg,
+	}, nil
+}
+
+func (f *faissFloat32Index) quantization() string {
+	return quantizationType(f.cfg.optimizationType, f.idx.Ntotal())
 }
 
 func (f *faissFloat32Index) add(vecs *vectorSet) error {
@@ -158,9 +173,12 @@ func (f *faissFloat32Index) setQuantizers(trainedIndex faissIndexIVF) error {
 }
 
 func (f *faissFloat32Index) isMergeable(optimizedFor string) bool {
-	// only the ones that are of IVF index family and optimized for IVF RabitQ or
-	// are large enough to have SQ8 quantization are eligible for fast merge
-	return f.idx.IsIVFIndex() && (optimizedFor == index.IndexIVFRaBitQ || f.ntotal() >= ivfSq8Threshold)
+	// merge criteria:
+	// - optimization is ivf,rabitq
+	// - optimization is memory efficient
+	// - total vecs > ivfSq8Threshold => SQ8 quantization is used
+	return f.idx.IsIVFIndex() && (optimizedFor == index.IndexIVFRaBitQ ||
+		optimizedFor == index.IndexOptimizedForMemoryEfficient || f.ntotal() >= ivfSq8Threshold)
 }
 
 func (f *faissFloat32Index) mergeFrom(other faissIndex, offset int64) error {

--- a/faiss_vector_index_float32.go
+++ b/faiss_vector_index_float32.go
@@ -21,6 +21,7 @@ import (
 	"encoding/binary"
 	"encoding/json"
 
+	index "github.com/blevesearch/bleve_index_api"
 	faiss "github.com/blevesearch/go-faiss"
 )
 
@@ -154,6 +155,12 @@ func (f *faissFloat32Index) setQuantizers(trainedIndex faissIndexIVF) error {
 		return errNotSupported
 	}
 	return f.idx.SetQuantizers(centroidFaissIndex.idx)
+}
+
+func (f *faissFloat32Index) isMergeable(optimizedFor string) bool {
+	// only the ones that are of IVF index family and optimized for IVF RabitQ or
+	// are large enough to have SQ8 quantization are eligible for fast merge
+	return f.idx.IsIVFIndex() && (optimizedFor == index.IndexIVFRaBitQ || f.ntotal() >= ivfSq8Threshold)
 }
 
 func (f *faissFloat32Index) mergeFrom(other faissIndex, offset int64) error {

--- a/faiss_vector_index_float32.go
+++ b/faiss_vector_index_float32.go
@@ -175,17 +175,14 @@ func (f *faissFloat32Index) setQuantizers(trainedIndex faissIndexIVF) error {
 func (f *faissFloat32Index) isMergeable() bool {
 	if f.cfg != nil {
 		switch f.cfg.optimizationType {
-		case index.IndexBIVFWithBackingFlat:
-			// currently if the backing index is flat, we're not going to perform fast merge
-			return false
-		case index.IndexBIVFWithBackingSQ8:
+		case index.IndexBIVFWithBackingFlat, index.IndexBIVFWithBackingSQ8:
 			fallthrough
 		case index.IndexOptimizedForMemoryEfficient:
 			fallthrough
 		case index.IndexIVFRaBitQ:
-			return f.idx.Ntotal() > 1000
+			return f.idx.Ntotal() > ivfThreshold
 		default:
-			return f.idx.Ntotal() > 10000
+			return f.idx.Ntotal() > ivfSq8Threshold
 
 		}
 	}

--- a/faiss_vector_index_float32.go
+++ b/faiss_vector_index_float32.go
@@ -46,14 +46,14 @@ func newFaissFloat32IndexWithConfig(idx *faiss.IndexImpl, cfg *faissIndexConfig)
 	if idx == nil {
 		return nil, errNilIndex
 	}
+	if cfg == nil {
+		return nil, errNilConfig
+	}
+
 	return &faissFloat32Index{
 		idx: idx,
 		cfg: cfg,
 	}, nil
-}
-
-func (f *faissFloat32Index) quantization() string {
-	return quantizationType(f.cfg.optimizationType, f.idx.Ntotal())
 }
 
 func (f *faissFloat32Index) add(vecs *vectorSet) error {
@@ -172,13 +172,24 @@ func (f *faissFloat32Index) setQuantizers(trainedIndex faissIndexIVF) error {
 	return f.idx.SetQuantizers(centroidFaissIndex.idx)
 }
 
-func (f *faissFloat32Index) isMergeable(optimizedFor string) bool {
-	// merge criteria:
-	// - optimization is ivf,rabitq
-	// - optimization is memory efficient
-	// - total vecs > ivfSq8Threshold => SQ8 quantization is used
-	return f.idx.IsIVFIndex() && (optimizedFor == index.IndexIVFRaBitQ ||
-		optimizedFor == index.IndexOptimizedForMemoryEfficient || f.ntotal() >= ivfSq8Threshold)
+func (f *faissFloat32Index) isMergeable() bool {
+	if f.cfg != nil {
+		switch f.cfg.optimizationType {
+		case index.IndexBIVFWithBackingFlat:
+			// currently if the backing index is flat, we're not going to perform fast merge
+			return false
+		case index.IndexBIVFWithBackingSQ8:
+			fallthrough
+		case index.IndexOptimizedForMemoryEfficient:
+			fallthrough
+		case index.IndexIVFRaBitQ:
+			return f.idx.Ntotal() > 1000
+		default:
+			return f.idx.Ntotal() > 10000
+
+		}
+	}
+	return false
 }
 
 func (f *faissFloat32Index) mergeFrom(other faissIndex, offset int64) error {
@@ -186,5 +197,9 @@ func (f *faissFloat32Index) mergeFrom(other faissIndex, offset int64) error {
 	if !ok {
 		return errNotSupported
 	}
-	return f.idx.MergeFrom(otherFaissIndex.idx, offset)
+
+	if otherFaissIndex.isMergeable() {
+		return f.idx.MergeFrom(otherFaissIndex.idx, offset)
+	}
+	return errNotSupported
 }

--- a/faiss_vector_index_float32.go
+++ b/faiss_vector_index_float32.go
@@ -146,10 +146,10 @@ func (f *faissFloat32Index) trainAndAdd(trainingData *vectorSet, vecsToAdd *vect
 	return f.add(vecsToAdd)
 }
 
-func (f *faissFloat32Index) setQuantizers(centroidIndex faissIndexIVF) error {
-	centroidFaissIndex, ok := centroidIndex.(*faissFloat32Index)
+func (f *faissFloat32Index) setQuantizers(trainedIndex faissIndexIVF) error {
+	centroidFaissIndex, ok := trainedIndex.(*faissFloat32Index)
 	if !ok {
-		// if not a float32 centroid index, we cannot set it as the quantizer
+		// if not a float32 trained index, we cannot set it as the quantizer
 		// for the current index, return an error.
 		return errNotSupported
 	}

--- a/faiss_vector_index_float32.go
+++ b/faiss_vector_index_float32.go
@@ -175,15 +175,12 @@ func (f *faissFloat32Index) setQuantizers(trainedIndex faissIndexIVF) error {
 func (f *faissFloat32Index) isMergeable() bool {
 	if f.cfg != nil {
 		switch f.cfg.optimizationType {
-		case index.IndexBIVFWithBackingFlat, index.IndexBIVFWithBackingSQ8:
-			fallthrough
-		case index.IndexOptimizedForMemoryEfficient:
-			fallthrough
-		case index.IndexIVFRaBitQ:
-			return f.idx.Ntotal() > ivfThreshold
+		case index.IndexOptimizedForLatency, index.IndexOptimizedForRecall:
+			return f.ntotal() > ivfSq8Threshold
+		case index.IndexOptimizedForMemoryEfficient, index.IndexIVFRaBitQ:
+			return f.ntotal() > ivfThreshold
 		default:
-			return f.idx.Ntotal() > ivfSq8Threshold
-
+			return false
 		}
 	}
 	return false

--- a/faiss_vector_index_gpu_float32.go
+++ b/faiss_vector_index_gpu_float32.go
@@ -72,6 +72,11 @@ func newFaissGPUFloat32Index(cpuIdx *faiss.IndexImpl) (faissIndex, error) {
 	return f, nil
 }
 
+func (f *faissGPUFloat32Index) quantization() string {
+	// not necessary for gpu indexes since this API is very specific to fast merge
+	return ""
+}
+
 // waitGPU blocks until initGPU has completed
 func (f *faissGPUFloat32Index) waitGPU() {
 	<-f.doneCh

--- a/faiss_vector_index_gpu_float32.go
+++ b/faiss_vector_index_gpu_float32.go
@@ -276,6 +276,10 @@ func (f *faissGPUFloat32Index) setQuantizers(trainedIndex faissIndexIVF) error {
 	return errNotSupported
 }
 
+func (f *faissGPUFloat32Index) isMergeable(optimizedFor string) bool {
+	return false
+}
+
 func (f *faissGPUFloat32Index) mergeFrom(other faissIndex, offset int64) error {
 	return errNotSupported
 }

--- a/faiss_vector_index_gpu_float32.go
+++ b/faiss_vector_index_gpu_float32.go
@@ -272,7 +272,7 @@ func (f *faissGPUFloat32Index) trainAndAddCPU(trainingData *vectorSet, vecsToAdd
 	return f.cpuIdx.Add(vecsToAdd.floatData)
 }
 
-func (f *faissGPUFloat32Index) setQuantizers(centroidIndex faissIndexIVF) error {
+func (f *faissGPUFloat32Index) setQuantizers(trainedIndex faissIndexIVF) error {
 	return errNotSupported
 }
 

--- a/faiss_vector_index_gpu_float32.go
+++ b/faiss_vector_index_gpu_float32.go
@@ -72,11 +72,6 @@ func newFaissGPUFloat32Index(cpuIdx *faiss.IndexImpl) (faissIndex, error) {
 	return f, nil
 }
 
-func (f *faissGPUFloat32Index) quantization() string {
-	// not necessary for gpu indexes since this API is very specific to fast merge
-	return ""
-}
-
 // waitGPU blocks until initGPU has completed
 func (f *faissGPUFloat32Index) waitGPU() {
 	<-f.doneCh
@@ -281,7 +276,7 @@ func (f *faissGPUFloat32Index) setQuantizers(trainedIndex faissIndexIVF) error {
 	return errNotSupported
 }
 
-func (f *faissGPUFloat32Index) isMergeable(optimizedFor string) bool {
+func (f *faissGPUFloat32Index) isMergeable() bool {
 	return false
 }
 

--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,7 @@ go 1.24.0
 require (
 	github.com/RoaringBitmap/roaring/v2 v2.14.5
 	github.com/blevesearch/bleve_index_api v1.3.11
-	github.com/blevesearch/go-faiss v1.0.35
+	github.com/blevesearch/go-faiss v1.0.36
 	github.com/blevesearch/mmap-go v1.2.0
 	github.com/blevesearch/scorch_segment_api/v2 v2.4.7
 	github.com/blevesearch/vellum v1.2.0

--- a/go.sum
+++ b/go.sum
@@ -4,8 +4,8 @@ github.com/bits-and-blooms/bitset v1.24.2 h1:M7/NzVbsytmtfHbumG+K2bremQPMJuqv1JD
 github.com/bits-and-blooms/bitset v1.24.2/go.mod h1:7hO7Gc7Pp1vODcmWvKMRA9BNmbv6a/7QIWpPxHddWR8=
 github.com/blevesearch/bleve_index_api v1.3.11 h1:x29vbV8OjWfLcrDVd7Lr1q+BkLNS0JWNEig0MCVnKH4=
 github.com/blevesearch/bleve_index_api v1.3.11/go.mod h1:xvd48t5XMeeioWQ5/jZvgLrV98flT2rdvEJ3l/ki4Ko=
-github.com/blevesearch/go-faiss v1.0.35 h1:DJF8yKgH8/n+Oo4E047Jy4oDeRivOugfMb6Cih//JjI=
-github.com/blevesearch/go-faiss v1.0.35/go.mod h1:OMGQwOaRRYxrmeNdMrXJPvVx8gBnvE5RYrr0BahNnkk=
+github.com/blevesearch/go-faiss v1.0.36 h1:qrP6LZX7xrQQ3pOF2B+t+5E+brlOzwQUzZrGLHz4IeU=
+github.com/blevesearch/go-faiss v1.0.36/go.mod h1:OMGQwOaRRYxrmeNdMrXJPvVx8gBnvE5RYrr0BahNnkk=
 github.com/blevesearch/mmap-go v1.2.0 h1:l33nNKPFcBjJUMwem6sAYJPUzhUCABoK9FxZDGiFNBI=
 github.com/blevesearch/mmap-go v1.2.0/go.mod h1:Vd6+20GBhEdwJnU1Xohgt88XCD/CTWcqbCNxkZpyBo0=
 github.com/blevesearch/scorch_segment_api/v2 v2.4.7 h1:GlMzW08hcsM3DnLUxhyF/1PcDal1qtvvIuytuph5djw=

--- a/section_faiss_vector_index.go
+++ b/section_faiss_vector_index.go
@@ -48,7 +48,7 @@ const (
 	nprobeLatencyOptimization = 2
 	// The threshold for number of vectors beyond which we consider fast merging
 	// using faiss's native merge capabilities, instead of reconstructing and adding
-	// vectors one by one. This is currently only applicable for IVFSQ8 indexes.
+	// vectors one by one
 	ivfSq8Threshold = 10000
 )
 
@@ -64,9 +64,9 @@ const (
 	faissBIVFIndex
 )
 
-// Errors for invariant violations related to fast merge and centroid index retrieval.
+// Errors for invariant violations related to fast merge and trained index retrieval.
 var (
-	ErrorCentroidIndexNotIVF  error = errors.New("centroid index is not an IVF index, which is required for fast merge")
+	ErrorTrainedIndexNotIVF   error = errors.New("trained index is not an IVF index, which is required for fast merge")
 	ErrorFastMergeIndexNotIVF error = errors.New("fast merge is only supported for IVF indexes")
 )
 
@@ -128,9 +128,9 @@ func (v *faissVectorIndexSection) Merge(opaque map[int]resetable, segments []*Se
 		indexes = indexes[:0] // resizing the slices
 		vecSegs = vecSegs[:0]
 		vecToDocID = vecToDocID[:0]
-		// flag to indicate if there are no deleted/updated vectors
+		// flag to indicate if there are deleted/updated vectors
 		// in any of the vector indexes being merged.
-		noDrops := true
+		var drops bool
 		for segI, sb := range segments {
 			if isClosed(closeCh) {
 				return seg.ErrClosed
@@ -194,7 +194,7 @@ func (v *faissVectorIndexSection) Merge(opaque map[int]resetable, segments []*Se
 				} else {
 					// some vectors are dropped, so we can't do a fast merge using faiss's
 					// native merge capabilities, because of the data drift issue.
-					noDrops = false
+					drops = true
 				}
 			}
 
@@ -228,15 +228,16 @@ func (v *faissVectorIndexSection) Merge(opaque map[int]resetable, segments []*Se
 			return err
 		}
 
-		var centroidIndex faissIndexIVF
-		if noDrops {
-			centroidIndex, err = centroidIndexFromConfig(vo.config, fieldName)
-			if err != nil {
-				return err
-			}
+		// we're going to use the trained index template regardless of whether there's
+		// a update/delete in the segments being merged and we let the fast merge
+		// path handle what exactly to in such cases.
+		trainedIndex, err := trainedIndexFromConfig(vo.config, fieldName)
+		if err != nil {
+			return err
 		}
+
 		useGPU := vo.fieldsOptions[fieldName].UseGPU()
-		err = vo.mergeAndWriteVectorIndexes(centroidIndex, vecSegs, indexes, w, closeCh, useGPU)
+		err = vo.mergeAndWriteVectorIndexes(trainedIndex, vecSegs, indexes, w, closeCh, useGPU, drops)
 		if err != nil {
 			return err
 		}
@@ -244,10 +245,10 @@ func (v *faissVectorIndexSection) Merge(opaque map[int]resetable, segments []*Se
 	return nil
 }
 
-func centroidIndexFromConfig(config map[string]interface{}, fieldName string) (faissIndexIVF, error) {
+func trainedIndexFromConfig(config map[string]interface{}, fieldName string) (faissIndexIVF, error) {
 	var trainedIndexFor index.TrainedIndexCallbackFn
 	var training bool
-	var rv *faiss.IndexImpl
+	var rv faissIndex
 	if cb, ok := config[index.TrainedIndexCallback]; ok {
 		trainedIndexFor = cb.(index.TrainedIndexCallbackFn)
 	}
@@ -264,22 +265,18 @@ func centroidIndexFromConfig(config map[string]interface{}, fieldName string) (f
 			return nil, err
 		}
 		if trainedIndex != nil {
-			rv = trainedIndex.(*faiss.IndexImpl)
+			rv = trainedIndex.(faissIndex)
 		}
 	}
 	if rv == nil {
 		return nil, nil
 	}
 
-	faissIndex, err := newFaissFloat32Index(rv)
-	if err != nil {
-		return nil, err
+	trainedIndex := rv.castIVF()
+	if trainedIndex == nil {
+		return nil, ErrorTrainedIndexNotIVF
 	}
-	centroidIndex := faissIndex.castIVF()
-	if centroidIndex == nil {
-		return nil, ErrorCentroidIndexNotIVF
-	}
-	return centroidIndex, nil
+	return trainedIndex, nil
 }
 
 func (v *vectorIndexOpaque) flushSectionMetadata(fieldID int, w *FileWriter,
@@ -351,9 +348,30 @@ func calculateNprobe(nlist int, indexOptimizedFor string) int32 {
 	return nprobe
 }
 
+func (v *vectorIndexOpaque) canMerge(indexInfo *vecIndexInfo, indexType faissIndexType) bool {
+	if indexInfo.index.castIVF() == nil {
+		// cant do fast merge on a non-IVF index
+		return false
+	}
+	switch indexType {
+	case faissBIVFIndex:
+		// since all the bivf indexes are of the same class, its safe to merge them
+		return true
+	case faissFP32Index:
+		// for FP32 IVF indexes, we can do a fast merge using faiss's native merge capabilities
+		// only if the indexes use the same quantizer. We merge indexes which are
+		// optimized for RaBitQ or above a certain threshold after which only SQ8
+		// kicks in for the IVF indexes.
+		return indexInfo.indexOptimizedFor == index.IndexIVFRaBitQ ||
+			indexInfo.index.ntotal() >= ivfSq8Threshold
+	default:
+		return false
+	}
+}
+
 // todo: need to detect and handle data drift in a more intelligent way
-func (v *vectorIndexOpaque) fastMergeIndexes(centroidIndex faissIndexIVF, dims, metric int, indexType faissIndexType,
-	optimizedFor string, vecIndexes []*vecIndexInfo, w *FileWriter, closeCh chan struct{}) error {
+func (v *vectorIndexOpaque) fastMergeIndexes(trainedIndex faissIndexIVF, cfg *faissIndexConfig,
+	drops bool, vecIndexes []*vecIndexInfo, w *FileWriter, closeCh chan struct{}) error {
 	finalMergeCandidate := -1
 	var nvecs, reconsCap int
 	for i := 0; i < len(vecIndexes); i++ {
@@ -363,19 +381,18 @@ func (v *vectorIndexOpaque) fastMergeIndexes(centroidIndex faissIndexIVF, dims, 
 		vecCount := len(vecIndexes[i].vecIds)
 		if vecCount == 0 {
 			continue
-		} else if (vecIndexes[i].indexOptimizedFor == index.IndexIVFRaBitQ &&
-			vecIndexes[i].index.castIVF() != nil) ||
-			vecCount >= ivfSq8Threshold {
-			// merging only the large indexes (IVFSQ8 family)
-			// all IVF<same class> indexes are eligible for merging
-			//
+		} else if !drops && v.canMerge(vecIndexes[i], cfg.indexType) {
 			// try to seek the pointer in the vecIndexes list to a point after
 			// which all indexes are not eligible for fast merge.
 			if i > finalMergeCandidate {
 				finalMergeCandidate = i
 			}
 		} else {
-			indexReconsLen := vecCount * dims
+			// if there are some deletes or updates in the segments being merged,
+			// we can't say definitely which mutation can cause a data drift solely
+			// by the vector count - as a fallback mechanism we reconstruct + add
+			// the vectors in this scenario using the trained template.
+			indexReconsLen := vecCount * cfg.dimension
 			if indexReconsLen > reconsCap {
 				reconsCap = indexReconsLen
 			}
@@ -383,11 +400,12 @@ func (v *vectorIndexOpaque) fastMergeIndexes(centroidIndex faissIndexIVF, dims, 
 		nvecs += vecCount
 	}
 
-	nprobe, nlist := centroidIndex.ivfParams()
-	// set a custom nlist value in the config for the merged index,
-	//  which is same as the centroid index's nlist.
-	cfg := newFaissIndexConfig(indexType, optimizedFor, dims, metric, nvecs, nlist, false)
-	// create the merged index based on the centroid index's config.
+	// create a faissIndex for merged index using nlist and nprobe from trained index's
+	// config and we avoid using the GPU for fast merge since the underlying faiss
+	// code doesn't support merge_from API on GPU indexes.
+	nprobe, nlist := trainedIndex.ivfParams()
+	cfg.nlist = nlist
+	cfg.useGPU = false
 	faissIndex, err := faissIndexFactory(cfg)
 	if err != nil {
 		return err
@@ -406,9 +424,9 @@ func (v *vectorIndexOpaque) fastMergeIndexes(centroidIndex faissIndexIVF, dims, 
 	// setting the same nprobe value in the merged index as the centroid
 	// index to ensure that we probe the same number of clusters
 	ivfIdx.setNProbe(int32(nprobe))
-	// The centroid index will be an IVFSQ8 index - but with no vectors in it.
+	// The trained index will be an IVFSQ8 index - but with no vectors in it.
 	// The coarse quantizer of that index will be cloned over here
-	err = ivfIdx.setQuantizers(centroidIndex)
+	err = ivfIdx.setQuantizers(trainedIndex)
 	if err != nil {
 		return err
 	}
@@ -420,7 +438,7 @@ func (v *vectorIndexOpaque) fastMergeIndexes(centroidIndex faissIndexIVF, dims, 
 		if isClosed(closeCh) {
 			return seg.ErrClosed
 		}
-		floatIdx := vecIndexes[i].index
+		childIdx := vecIndexes[i].index
 		vecs := vecIndexes[i].vecIds
 		numVecs := len(vecs)
 		// note: the merge candidates are almost always in descending order of size
@@ -430,21 +448,24 @@ func (v *vectorIndexOpaque) fastMergeIndexes(centroidIndex faissIndexIVF, dims, 
 		// point we can be sure of no updates/deletes -> the candidates will be
 		// in a continuous block from the beginning.
 		if i <= finalMergeCandidate {
-			err = ivfIdx.mergeFrom(floatIdx, faissIndex.ntotal())
+			err = ivfIdx.mergeFrom(childIdx, faissIndex.ntotal())
 			if err != nil {
 				return err
 			}
 		} else {
 			// reconstruction will be done on IVFFlat and Flat indexes
-			neededReconsLen := numVecs * dims
+			neededReconsLen := numVecs * cfg.dimension
 			reconsVecs = reconsVecs[:neededReconsLen]
-			reconsVecs, err := floatIdx.reconstructBatch(vecs, reconsVecs)
+			reconsVecs, err := childIdx.reconstructBatch(vecs, reconsVecs)
 			if err != nil {
 				return err
 			}
-			vecSet, err := newVectorSet(dims, reconsVecs)
+			vecSet, err := newVectorSet(cfg.dimension, reconsVecs)
 			if err != nil {
 				return err
+			}
+			if cfg.indexType == faissBIVFIndex {
+				vecSet.binarize()
 			}
 			err = faissIndex.add(vecSet)
 			if err != nil {
@@ -455,7 +476,7 @@ func (v *vectorIndexOpaque) fastMergeIndexes(centroidIndex faissIndexIVF, dims, 
 
 	tempBuf := v.grabBuf(binary.MaxVarintLen64)
 	// write the type of the vector index
-	n := binary.PutUvarint(tempBuf, uint64(indexType))
+	n := binary.PutUvarint(tempBuf, uint64(cfg.indexType))
 	_, err = w.Write(tempBuf[:n])
 	if err != nil {
 		return err
@@ -464,8 +485,8 @@ func (v *vectorIndexOpaque) fastMergeIndexes(centroidIndex faissIndexIVF, dims, 
 	return faissIndex.write(tempBuf, w)
 }
 
-func (v *vectorIndexOpaque) mergeAndWriteVectorIndexes(centroidIndex faissIndexIVF, sbs []*SegmentBase,
-	vecIndexes []*vecIndexInfo, w *FileWriter, closeCh chan struct{}, useGPU bool) error {
+func (v *vectorIndexOpaque) mergeAndWriteVectorIndexes(trainedIndex faissIndexIVF, sbs []*SegmentBase,
+	vecIndexes []*vecIndexInfo, w *FileWriter, closeCh chan struct{}, useGPU, drops bool) error {
 	// safe to assume that all the indexes are of the same config values, given
 	// that they are extracted from the field mapping info.
 	var dims, metric, indexDataCap, reconsCap, nvecs int
@@ -496,7 +517,7 @@ func (v *vectorIndexOpaque) mergeAndWriteVectorIndexes(centroidIndex faissIndexI
 			return err
 		}
 		ioFlags := faissIOFlags
-		if centroidIndex == nil {
+		if trainedIndex == nil {
 			ioFlags = faissIOFlagsReadOnly
 		}
 		// reconstruct the faiss index from the bytes
@@ -567,15 +588,16 @@ func (v *vectorIndexOpaque) mergeAndWriteVectorIndexes(centroidIndex faissIndexI
 		return nil
 	}
 
+	// create the faiss index to hold the merged data, either via fast merge or reconstruction
+	config := newFaissIndexConfig(indexType, indexOptimizedFor, dims, metric, nvecs, determineCentroids(nvecs), useGPU)
 	// Fast Merge Path:
 	// fast merge only applicable for:
 	// - IVFSQ8 indexes beyond a certain size threshold.
-	// - the centroid index is available.
+	// - the trained index is available.
 	// - RabitQ optimization
-	if centroidIndex != nil &&
-		(indexOptimizedFor == index.IndexIVFRaBitQ ||
-			(nvecs >= ivfSq8Threshold && indexType == faissFP32Index)) {
-		err := v.fastMergeIndexes(centroidIndex, dims, metric, indexType, indexOptimizedFor, vecIndexes, w, closeCh)
+	if trainedIndex != nil &&
+		(indexOptimizedFor == index.IndexIVFRaBitQ || nvecs >= ivfSq8Threshold) {
+		err := v.fastMergeIndexes(trainedIndex, config, drops, vecIndexes, w, closeCh)
 		if err != nil {
 			return err
 		}
@@ -618,14 +640,11 @@ func (v *vectorIndexOpaque) mergeAndWriteVectorIndexes(centroidIndex faissIndexI
 	// the reconstructed ones anymore and doing so will hold up memory which can
 	// be detrimental while creating indexes during introduction.
 	freeReconstructedIndexes(vecIndexes)
-	// create the faiss index to hold the merged data, and add the
-	// reconstructed vectors into it.
-	config := newFaissIndexConfig(indexType, indexOptimizedFor, dims, metric, nvecs, determineCentroids(nvecs), useGPU)
+
 	vecSet, err := newVectorSet(dims, indexData)
 	if err != nil {
 		return err
 	}
-
 	return v.writeFaissIndex(vecSet, config, w)
 }
 
@@ -647,6 +666,7 @@ func (v *vectorIndexOpaque) writeFaissIndex(vecs *vectorSet, config *faissIndexC
 	// if we are using an IVF index, train and add first, then set the direct map
 	// and nprobe. The order matters for GPU indexes: CloneToCPU (done inside
 	// trainAndAdd) clears the direct map and nprobe, so they must be set after.
+	// binarize the vectors for BIVF indexes
 	if ivfIndex := index.castIVF(); ivfIndex != nil {
 		// train the vector index and add the vectors to it. The training step
 		// performs k-means clustering to partition the data space such that during

--- a/section_faiss_vector_index.go
+++ b/section_faiss_vector_index.go
@@ -46,6 +46,9 @@ const (
 	// Divide the estimated nprobe with this value to optimize
 	// for latency.
 	nprobeLatencyOptimization = 2
+	// The threshold for number of vectors beyond which we start building the ivf class
+	// of indexes
+	ivfThreshold = 1000
 	// The threshold for number of vectors beyond which we consider fast merging
 	// using faiss's native merge capabilities, instead of reconstructing and adding
 	// vectors one by one
@@ -559,7 +562,7 @@ func (v *vectorIndexOpaque) mergeAndWriteVectorIndexes(trainedIndex faissIndexIV
 	// if we have a trained index use the fast merge to perform the merge without
 	// re-training and reconstructing the vectors. we perform the fast merge
 	// only if the quantization type matches between the trained index and the final merged index
-	if trainedIndex != nil && trainedIndex.isMergeable() && canFastMerge(indexOptimizedFor, nvecs) {
+	if !useGPU && canFastMerge(trainedIndex, indexOptimizedFor, nvecs) {
 		err := v.fastMergeIndexes(trainedIndex, config, drops, vecIndexes, w, closeCh)
 		if err != nil {
 			return err
@@ -679,7 +682,7 @@ func (v *vectorIndexOpaque) writeFaissIndex(vecs *vectorSet, config *faissIndexC
 // index to be created based on the number of vectors and centroids.
 func determineBinaryIndexToUse(nvecs, nlist int) string {
 	switch {
-	case nvecs >= 1000:
+	case nvecs >= ivfThreshold:
 		return fmt.Sprintf("BIVF%d", nlist)
 	default:
 		return "BFlat"
@@ -720,7 +723,7 @@ func determineCentroids(nvecs int) int {
 	switch {
 	case nvecs >= 200000:
 		nlist = int(4 * math.Sqrt(float64(nvecs)))
-	case nvecs >= 1000:
+	case nvecs >= ivfThreshold:
 		// 100 points per cluster is a reasonable default, considering the default
 		// minimum and maximum points per cluster is 39 and 256 respectively.
 		// Since it's a recommendation to have a minimum of 10 clusters, 1000(100 * 10)
@@ -733,7 +736,7 @@ func determineCentroids(nvecs int) int {
 // determineFloat32IndexToUse returns a description string for the float32
 // index and quantizer type, and an index type constant.
 func determineFloat32IndexToUse(nvecs, nlist int, optimizationType string) string {
-	if nvecs < 1000 {
+	if nvecs < ivfThreshold {
 		return "Flat"
 	}
 	switch optimizationType {
@@ -983,20 +986,6 @@ type faissIndexConfig struct {
 	useGPU           bool
 }
 
-func canFastMerge(opt string, nvecs int) bool {
-	switch opt {
-	case index.IndexBIVFWithBackingFlat, index.IndexBIVFWithBackingSQ8:
-		fallthrough
-	case index.IndexOptimizedForMemoryEfficient:
-		fallthrough
-	case index.IndexIVFRaBitQ:
-		return nvecs > 1000
-	default:
-		return nvecs > ivfSq8Threshold
-	}
-
-}
-
 func newFaissIndexConfig(idxType faissIndexType, optimizationType string, dimension, metricType, numVecs, nlist int, useGPU bool) *faissIndexConfig {
 	return &faissIndexConfig{
 		indexType:        idxType,
@@ -1040,4 +1029,28 @@ func faissIndexFactory(cfg *faissIndexConfig) (faissIndex, error) {
 	default:
 		return nil, errNotSupported
 	}
+}
+
+// canFastMerge determines whether we can use the fast merge capabilities of faiss based on
+//   - the presence of a trained index
+//   - the optimization type of the index.
+//   - the total number of vectors being merged.
+func canFastMerge(trainedIndex faissIndexIVF, opt string, totalVecs int) bool {
+	// if the trained index isn't IVF or not available, fallback to naive merge
+	if trainedIndex == nil {
+		return false
+	}
+
+	var minVecsForFastMerge int
+	switch opt {
+	case index.IndexBIVFWithBackingFlat, index.IndexBIVFWithBackingSQ8:
+		fallthrough
+	case index.IndexOptimizedForMemoryEfficient:
+		fallthrough
+	case index.IndexIVFRaBitQ:
+		minVecsForFastMerge = ivfThreshold
+	default:
+		minVecsForFastMerge = ivfSq8Threshold
+	}
+	return trainedIndex.ntotal() > int64(minVecsForFastMerge) && totalVecs > minVecsForFastMerge
 }

--- a/section_faiss_vector_index.go
+++ b/section_faiss_vector_index.go
@@ -351,106 +351,90 @@ func calculateNprobe(nlist int, indexOptimizedFor string) int32 {
 // todo: need to detect and handle data drift in a more intelligent way
 func (v *vectorIndexOpaque) fastMergeIndexes(trainedIndex faissIndexIVF, cfg *faissIndexConfig,
 	drops bool, vecIndexes []*vecIndexInfo, w *FileWriter, closeCh chan struct{}) error {
-	var reconsCap int
-	fastMergeCandidates := make(map[int]struct{}, len(vecIndexes))
-	for i := 0; i < len(vecIndexes); i++ {
-		if isClosed(closeCh) {
-			return seg.ErrClosed
-		}
-		vecCount := len(vecIndexes[i].vecIds)
-		if vecCount == 0 {
-			continue
-		}
-		if !drops && vecIndexes[i].index.isMergeable(cfg.optimizationType) {
-			fastMergeCandidates[i] = struct{}{}
-		} else {
-			// if there are some deletes or updates in the segments being merged,
-			// we can't say definitely which mutation can cause a data drift solely
-			// by the vector count - as a fallback mechanism we reconstruct + add
-			// the vectors in this scenario using the trained template.
-			indexReconsLen := vecCount * cfg.dimension
-			if indexReconsLen > reconsCap {
-				reconsCap = indexReconsLen
-			}
-		}
-	}
-
 	// create a faissIndex for merged index using nlist and nprobe from trained index's
 	// config and we avoid using the GPU for fast merge since the underlying faiss
 	// code doesn't support merge_from API on GPU indexes.
 	nprobe, nlist := trainedIndex.ivfParams()
 	cfg.nlist = nlist
 	cfg.useGPU = false
-	faissIndex, err := faissIndexFactory(cfg)
+	mergedIdx, err := faissIndexFactory(cfg)
 	if err != nil {
 		return err
 	}
-	defer faissIndex.close()
+	defer mergedIdx.close()
 
 	// cast to IVF index to be able to set the quantizer for the fast merge
-	ivfIdx := faissIndex.castIVF()
-	if ivfIdx == nil {
+	ivfMergedIdx := mergedIdx.castIVF()
+	if ivfMergedIdx == nil {
 		return ErrorFastMergeIndexNotIVF
 	}
-	err = ivfIdx.setDirectMap(1)
+	err = ivfMergedIdx.setDirectMap(1)
 	if err != nil {
 		return err
 	}
 	// setting the same nprobe value in the merged index as the centroid
 	// index to ensure that we probe the same number of clusters
-	ivfIdx.setNProbe(int32(nprobe))
+	ivfMergedIdx.setNProbe(int32(nprobe))
 	// The trained index will be an IVFSQ8 index - but with no vectors in it.
 	// The coarse quantizer of that index will be cloned over here
-	err = ivfIdx.setQuantizers(trainedIndex)
+	err = ivfMergedIdx.setQuantizers(trainedIndex)
 	if err != nil {
 		return err
 	}
 
-	// reconstruction will be needed indexes that are not eligible or
-	// failed to fast merge, so we prepare a buffer for that.
-	reconsVecs := make([]float32, 0, reconsCap)
-	for i := 0; i < len(vecIndexes); i++ {
+	var reconsVecs []float32
+	reconsAndAddFrom := func(vecIDs []int64, srcIdx faissIndex) error {
+		neededReconsLen := len(vecIDs) * cfg.dimension
+		if cap(reconsVecs) < neededReconsLen {
+			reconsVecs = make([]float32, neededReconsLen)
+		}
+		reconsVecs = reconsVecs[:neededReconsLen]
+		reconsVecs, err = srcIdx.reconstructBatch(vecIDs, reconsVecs)
+		if err != nil {
+			return err
+		}
+
+		vecSet, err := newVectorSet(cfg.dimension, reconsVecs)
+		if err != nil {
+			return err
+		}
+		if cfg.indexType == faissBIVFIndex {
+			vecSet.binarize()
+		}
+		// add to target index the reconstructed vectors for the valid vector IDs from the source index.
+		err = mergedIdx.add(vecSet)
+		if err != nil {
+			return err
+		}
+		reconsVecs = reconsVecs[:0]
+		return nil
+	}
+
+	for _, vi := range vecIndexes {
 		if isClosed(closeCh) {
 			return seg.ErrClosed
 		}
-
-		childIdx := vecIndexes[i].index
-		vecs := vecIndexes[i].vecIds
-		numVecs := len(vecs)
-		neededReconsLen := numVecs * cfg.dimension
-		reconsAndAdd := true
-		if _, ok := fastMergeCandidates[i]; ok {
-			delete(fastMergeCandidates, i)
-			if err = ivfIdx.mergeFrom(childIdx, faissIndex.ntotal()); err == nil {
-				reconsAndAdd = false
-			} else {
-				// fall back to reconstruction and grow the recons buffer if
-				// the current capacity is insufficient.
-				if neededReconsLen > cap(reconsVecs) {
-					reconsVecs = make([]float32, 0, neededReconsLen)
+		childIdx := vi.index
+		if drops {
+			// if there are some deletes or updates in the segments being merged,
+			// we can't say definitely which mutation can cause a data drift solely
+			// by the vector count - as a fallback mechanism we reconstruct + add
+			// the vectors in this scenario using the trained template since we can't
+			// use merge_from.
+			err = reconsAndAddFrom(vi.vecIds, childIdx)
+			if err != nil {
+				return err
+			}
+		} else {
+			// if no drops, then we can use merge_from
+			if err = ivfMergedIdx.mergeFrom(childIdx, mergedIdx.ntotal()); err != nil {
+				// either the childIdx isn't compatible for fast merge or merge_from failed
+				// so, in either case we can fallback to reconstructing and adding the vectors
+				// one by one from the source index to the target index as a error handling mechanism.
+				err = reconsAndAddFrom(vi.vecIds, childIdx)
+				if err != nil {
+					return err
 				}
-			}
-		}
-
-		// for indexes that are not eligible for fast merge and the ones that error'd
-		// out in the process fall back to reconstructing and adding the vectors
-		// in order of the vecIndexes list to be in-line the vector ID mapping.
-		if reconsAndAdd {
-			reconsVecs = reconsVecs[:neededReconsLen]
-			reconsVecs, err = childIdx.reconstructBatch(vecs, reconsVecs)
-			if err != nil {
-				return err
-			}
-			vecSet, err := newVectorSet(cfg.dimension, reconsVecs)
-			if err != nil {
-				return err
-			}
-			if cfg.indexType == faissBIVFIndex {
-				vecSet.binarize()
-			}
-			err = faissIndex.add(vecSet)
-			if err != nil {
-				return err
 			}
 		}
 	}
@@ -463,7 +447,7 @@ func (v *vectorIndexOpaque) fastMergeIndexes(trainedIndex faissIndexIVF, cfg *fa
 		return err
 	}
 
-	return faissIndex.write(tempBuf, w)
+	return mergedIdx.write(tempBuf, w)
 }
 
 func (v *vectorIndexOpaque) mergeAndWriteVectorIndexes(trainedIndex faissIndexIVF, sbs []*SegmentBase,
@@ -524,7 +508,8 @@ func (v *vectorIndexOpaque) mergeAndWriteVectorIndexes(trainedIndex faissIndexIV
 
 		// track the reconstruct index for this vector index, which will be used
 		// to reconstruct the vectors corresponding to the valid vector IDs for this index.
-		fIndex, err := newFaissFloat32Index(faissIndex)
+		config := newFaissIndexConfig(indexType, indexOptimizedFor, dims, metric, currNumVecs, determineCentroids(currNumVecs), useGPU)
+		fIndex, err := newFaissFloat32IndexWithConfig(faissIndex, config)
 		if err != nil {
 			freeReconstructedIndexes(vecIndexes)
 			return err
@@ -548,7 +533,7 @@ func (v *vectorIndexOpaque) mergeAndWriteVectorIndexes(trainedIndex faissIndexIV
 				freeReconstructedIndexes(vecIndexes)
 				return err
 			}
-			vecIndexes[segI].index, err = newFaissBinaryIndex(binaryIndex, faissIndex)
+			vecIndexes[segI].index, err = newFaissBinaryIndexWithConfig(binaryIndex, faissIndex, config)
 			if err != nil {
 				freeReconstructedIndexes(vecIndexes)
 				return err
@@ -574,7 +559,7 @@ func (v *vectorIndexOpaque) mergeAndWriteVectorIndexes(trainedIndex faissIndexIV
 	// if we have a trained index use the fast merge to perform the merge without
 	// re-training and reconstructing the vectors. we perform the fast merge
 	// only if the quantization type matches between the trained index and the final merged index
-	if trainedIndex != nil && trainedIndex.quantization() == quantizationType(indexOptimizedFor, int64(nvecs)) {
+	if trainedIndex != nil && trainedIndex.isMergeable() && canFastMerge(indexOptimizedFor, nvecs) {
 		err := v.fastMergeIndexes(trainedIndex, config, drops, vecIndexes, w, closeCh)
 		if err != nil {
 			return err
@@ -600,7 +585,7 @@ func (v *vectorIndexOpaque) mergeAndWriteVectorIndexes(trainedIndex faissIndexIV
 		// reconstruct the vectors only if present, it could be that
 		// some of the indexes had all of their vectors updated/deleted.
 		if currNumVecs > 0 && vecIndexes[idx] != nil {
-			neededReconsLen := currNumVecs * dims
+			neededReconsLen := currNumVecs * config.dimension
 			recons = recons[:neededReconsLen]
 			var err error
 			fIndex := vecIndexes[idx].index
@@ -619,7 +604,7 @@ func (v *vectorIndexOpaque) mergeAndWriteVectorIndexes(trainedIndex faissIndexIV
 	// be detrimental while creating indexes during introduction.
 	freeReconstructedIndexes(vecIndexes)
 
-	vecSet, err := newVectorSet(dims, indexData)
+	vecSet, err := newVectorSet(config.dimension, indexData)
 	if err != nil {
 		return err
 	}
@@ -998,19 +983,17 @@ type faissIndexConfig struct {
 	useGPU           bool
 }
 
-func quantizationType(opt string, ntotal int64) string {
-	if opt == index.IndexIVFRaBitQ {
-		return "RaBitQ"
-	} else if opt == index.IndexOptimizedForMemoryEfficient {
-		return "SQ4"
-	} else if opt == index.IndexBIVFWithBackingSQ8 {
-		return "SQ8"
-	} else if opt == index.IndexBIVFWithBackingFlat {
-		return "Flat"
-	} else if ntotal >= ivfSq8Threshold {
-		return "SQ8"
+func canFastMerge(opt string, nvecs int) bool {
+	switch opt {
+	case index.IndexBIVFWithBackingFlat, index.IndexBIVFWithBackingSQ8:
+		fallthrough
+	case index.IndexOptimizedForMemoryEfficient:
+		fallthrough
+	case index.IndexIVFRaBitQ:
+		return nvecs > 1000
+	default:
+		return nvecs > ivfSq8Threshold
 	}
-	return "Flat"
 
 }
 

--- a/section_faiss_vector_index.go
+++ b/section_faiss_vector_index.go
@@ -348,33 +348,11 @@ func calculateNprobe(nlist int, indexOptimizedFor string) int32 {
 	return nprobe
 }
 
-func (v *vectorIndexOpaque) canMerge(indexInfo *vecIndexInfo, indexType faissIndexType) bool {
-	if indexInfo.index.castIVF() == nil {
-		// cant do fast merge on a non-IVF index
-		return false
-	}
-	switch indexType {
-	case faissBIVFIndex:
-		// since all the bivf indexes are of the same class, its safe to merge them
-		// note: currently we support fast merge only on the SQ8 backing indexes
-		return indexInfo.indexOptimizedFor == index.IndexBIVFWithBackingSQ8
-	case faissFP32Index:
-		// for FP32 IVF indexes, we can do a fast merge using faiss's native merge capabilities
-		// only if the indexes use the same quantizer. We merge indexes which are
-		// optimized for RaBitQ or above a certain threshold after which only SQ8
-		// kicks in for the IVF indexes.
-		return indexInfo.indexOptimizedFor == index.IndexIVFRaBitQ ||
-			indexInfo.index.ntotal() >= ivfSq8Threshold
-	default:
-		return false
-	}
-}
-
 // todo: need to detect and handle data drift in a more intelligent way
 func (v *vectorIndexOpaque) fastMergeIndexes(trainedIndex faissIndexIVF, cfg *faissIndexConfig,
 	drops bool, vecIndexes []*vecIndexInfo, w *FileWriter, closeCh chan struct{}) error {
-	finalMergeCandidate := -1
-	var nvecs, reconsCap int
+	var reconsCap int
+	fastMergeCandidates := make(map[int]struct{}, len(vecIndexes))
 	for i := 0; i < len(vecIndexes); i++ {
 		if isClosed(closeCh) {
 			return seg.ErrClosed
@@ -382,12 +360,9 @@ func (v *vectorIndexOpaque) fastMergeIndexes(trainedIndex faissIndexIVF, cfg *fa
 		vecCount := len(vecIndexes[i].vecIds)
 		if vecCount == 0 {
 			continue
-		} else if !drops && v.canMerge(vecIndexes[i], cfg.indexType) {
-			// try to seek the pointer in the vecIndexes list to a point after
-			// which all indexes are not eligible for fast merge.
-			if i > finalMergeCandidate {
-				finalMergeCandidate = i
-			}
+		}
+		if !drops && vecIndexes[i].index.isMergeable(cfg.optimizationType) {
+			fastMergeCandidates[i] = struct{}{}
 		} else {
 			// if there are some deletes or updates in the segments being merged,
 			// we can't say definitely which mutation can cause a data drift solely
@@ -398,7 +373,6 @@ func (v *vectorIndexOpaque) fastMergeIndexes(trainedIndex faissIndexIVF, cfg *fa
 				reconsCap = indexReconsLen
 			}
 		}
-		nvecs += vecCount
 	}
 
 	// create a faissIndex for merged index using nlist and nprobe from trained index's
@@ -432,32 +406,38 @@ func (v *vectorIndexOpaque) fastMergeIndexes(trainedIndex faissIndexIVF, cfg *fa
 		return err
 	}
 
-	// reconstruction will be needed for the smaller indexes that are not
-	// eligible for fast merge, so we prepare a buffer for that.
+	// reconstruction will be needed indexes that are not eligible or
+	// failed to fast merge, so we prepare a buffer for that.
 	reconsVecs := make([]float32, 0, reconsCap)
 	for i := 0; i < len(vecIndexes); i++ {
 		if isClosed(closeCh) {
 			return seg.ErrClosed
 		}
+
 		childIdx := vecIndexes[i].index
 		vecs := vecIndexes[i].vecIds
 		numVecs := len(vecs)
-		// note: the merge candidates are almost always in descending order of size
-		// chances are they'll be the first "n" indexes in the vecIndexes list
-		//
-		// the reasoning is that scorch passes this as a sorted list and at this
-		// point we can be sure of no updates/deletes -> the candidates will be
-		// in a continuous block from the beginning.
-		if i <= finalMergeCandidate {
-			err = ivfIdx.mergeFrom(childIdx, faissIndex.ntotal())
-			if err != nil {
-				return err
+		neededReconsLen := numVecs * cfg.dimension
+		reconsAndAdd := true
+		if _, ok := fastMergeCandidates[i]; ok {
+			delete(fastMergeCandidates, i)
+			if err = ivfIdx.mergeFrom(childIdx, faissIndex.ntotal()); err == nil {
+				reconsAndAdd = false
+			} else {
+				// fall back to reconstruction and grow the recons buffer if
+				// the current capacity is insufficient.
+				if neededReconsLen > cap(reconsVecs) {
+					reconsVecs = make([]float32, 0, neededReconsLen)
+				}
 			}
-		} else {
-			// reconstruction will be done on IVFFlat and Flat indexes
-			neededReconsLen := numVecs * cfg.dimension
+		}
+
+		// for indexes that are not eligible for fast merge and the ones that error'd
+		// out in the process fall back to reconstructing and adding the vectors
+		// in order of the vecIndexes list to be in-line the vector ID mapping.
+		if reconsAndAdd {
 			reconsVecs = reconsVecs[:neededReconsLen]
-			reconsVecs, err := childIdx.reconstructBatch(vecs, reconsVecs)
+			reconsVecs, err = childIdx.reconstructBatch(vecs, reconsVecs)
 			if err != nil {
 				return err
 			}
@@ -591,13 +571,9 @@ func (v *vectorIndexOpaque) mergeAndWriteVectorIndexes(trainedIndex faissIndexIV
 
 	// create the faiss index to hold the merged data, either via fast merge or reconstruction
 	config := newFaissIndexConfig(indexType, indexOptimizedFor, dims, metric, nvecs, determineCentroids(nvecs), useGPU)
-	// Fast Merge Path:
-	// fast merge only applicable for:
-	// - IVFSQ8 indexes beyond a certain size threshold.
-	// - the trained index is available.
-	// - RabitQ optimization
-	if trainedIndex != nil &&
-		(indexOptimizedFor == index.IndexIVFRaBitQ || nvecs >= ivfSq8Threshold) {
+	// if we have a trained index use the fast merge to perform the merge without
+	// re-training and reconstructing the vectors
+	if trainedIndex != nil {
 		err := v.fastMergeIndexes(trainedIndex, config, drops, vecIndexes, w, closeCh)
 		if err != nil {
 			return err
@@ -667,7 +643,6 @@ func (v *vectorIndexOpaque) writeFaissIndex(vecs *vectorSet, config *faissIndexC
 	// if we are using an IVF index, train and add first, then set the direct map
 	// and nprobe. The order matters for GPU indexes: CloneToCPU (done inside
 	// trainAndAdd) clears the direct map and nprobe, so they must be set after.
-	// binarize the vectors for BIVF indexes
 	if ivfIndex := index.castIVF(); ivfIndex != nil {
 		// train the vector index and add the vectors to it. The training step
 		// performs k-means clustering to partition the data space such that during

--- a/section_faiss_vector_index.go
+++ b/section_faiss_vector_index.go
@@ -233,7 +233,7 @@ func (v *faissVectorIndexSection) Merge(opaque map[int]resetable, segments []*Se
 
 		// we're going to use the trained index template regardless of whether there's
 		// a update/delete in the segments being merged and we let the fast merge
-		// path handle what exactly to in such cases.
+		// path handle what exactly to do in such cases.
 		trainedIndex, err := trainedIndexFromConfig(vo.config, fieldName)
 		if err != nil {
 			return err
@@ -355,11 +355,9 @@ func calculateNprobe(nlist int, indexOptimizedFor string) int32 {
 func (v *vectorIndexOpaque) fastMergeIndexes(trainedIndex faissIndexIVF, cfg *faissIndexConfig,
 	drops bool, vecIndexes []*vecIndexInfo, w *FileWriter, closeCh chan struct{}) error {
 	// create a faissIndex for merged index using nlist and nprobe from trained index's
-	// config and we avoid using the GPU for fast merge since the underlying faiss
-	// code doesn't support merge_from API on GPU indexes.
+	// config and we're hitting the fast merge path only if we've not enabled GPU
 	nprobe, nlist := trainedIndex.ivfParams()
 	cfg.nlist = nlist
-	cfg.useGPU = false
 	mergedIdx, err := faissIndexFactory(cfg)
 	if err != nil {
 		return err
@@ -378,8 +376,8 @@ func (v *vectorIndexOpaque) fastMergeIndexes(trainedIndex faissIndexIVF, cfg *fa
 	// setting the same nprobe value in the merged index as the centroid
 	// index to ensure that we probe the same number of clusters
 	ivfMergedIdx.setNProbe(int32(nprobe))
-	// The trained index will be an IVFSQ8 index - but with no vectors in it.
-	// The coarse quantizer of that index will be cloned over here
+	// using the trained index to copy the quantizers and set them in the final
+	// merged index if possible
 	err = ivfMergedIdx.setQuantizers(trainedIndex)
 	if err != nil {
 		return err
@@ -429,7 +427,6 @@ func (v *vectorIndexOpaque) fastMergeIndexes(trainedIndex faissIndexIVF, cfg *fa
 				return err
 			}
 		} else {
-			// if no drops, then we can use merge_from
 			if err = ivfMergedIdx.mergeFrom(childIdx, mergedIdx.ntotal()); err != nil {
 				// either the childIdx isn't compatible for fast merge or merge_from failed
 				// so, in either case we can fallback to reconstructing and adding the vectors
@@ -559,9 +556,8 @@ func (v *vectorIndexOpaque) mergeAndWriteVectorIndexes(trainedIndex faissIndexIV
 
 	// create the faiss index to hold the merged data, either via fast merge or reconstruction
 	config := newFaissIndexConfig(indexType, indexOptimizedFor, dims, metric, nvecs, determineCentroids(nvecs), useGPU)
-	// if we have a trained index use the fast merge to perform the merge without
-	// re-training and reconstructing the vectors. we perform the fast merge
-	// only if the quantization type matches between the trained index and the final merged index
+	// we perform fast merge if we're not using the GPU and if the trained index
+	// is compatible to be used for fast merge
 	if !useGPU && canFastMerge(trainedIndex, indexOptimizedFor, nvecs) {
 		err := v.fastMergeIndexes(trainedIndex, config, drops, vecIndexes, w, closeCh)
 		if err != nil {

--- a/section_faiss_vector_index.go
+++ b/section_faiss_vector_index.go
@@ -356,7 +356,8 @@ func (v *vectorIndexOpaque) canMerge(indexInfo *vecIndexInfo, indexType faissInd
 	switch indexType {
 	case faissBIVFIndex:
 		// since all the bivf indexes are of the same class, its safe to merge them
-		return true
+		// note: currently we support fast merge only on the SQ8 backing indexes
+		return indexInfo.indexOptimizedFor == index.IndexBIVFWithBackingSQ8
 	case faissFP32Index:
 		// for FP32 IVF indexes, we can do a fast merge using faiss's native merge capabilities
 		// only if the indexes use the same quantizer. We merge indexes which are

--- a/section_faiss_vector_index.go
+++ b/section_faiss_vector_index.go
@@ -572,8 +572,9 @@ func (v *vectorIndexOpaque) mergeAndWriteVectorIndexes(trainedIndex faissIndexIV
 	// create the faiss index to hold the merged data, either via fast merge or reconstruction
 	config := newFaissIndexConfig(indexType, indexOptimizedFor, dims, metric, nvecs, determineCentroids(nvecs), useGPU)
 	// if we have a trained index use the fast merge to perform the merge without
-	// re-training and reconstructing the vectors
-	if trainedIndex != nil {
+	// re-training and reconstructing the vectors. we perform the fast merge
+	// only if the quantization type matches between the trained index and the final merged index
+	if trainedIndex != nil && trainedIndex.quantization() == quantizationType(indexOptimizedFor, int64(nvecs)) {
 		err := v.fastMergeIndexes(trainedIndex, config, drops, vecIndexes, w, closeCh)
 		if err != nil {
 			return err
@@ -995,6 +996,22 @@ type faissIndexConfig struct {
 	optimizationType string
 	nlist            int
 	useGPU           bool
+}
+
+func quantizationType(opt string, ntotal int64) string {
+	if opt == index.IndexIVFRaBitQ {
+		return "RaBitQ"
+	} else if opt == index.IndexOptimizedForMemoryEfficient {
+		return "SQ4"
+	} else if opt == index.IndexBIVFWithBackingSQ8 {
+		return "SQ8"
+	} else if opt == index.IndexBIVFWithBackingFlat {
+		return "Flat"
+	} else if ntotal >= ivfSq8Threshold {
+		return "SQ8"
+	}
+	return "Flat"
+
 }
 
 func newFaissIndexConfig(idxType faissIndexType, optimizationType string, dimension, metricType, numVecs, nlist int, useGPU bool) *faissIndexConfig {


### PR DESCRIPTION
- implement the `mergeFrom` and `setQuantizers` APIs for binary class indexes.
- this PR includes fast merge support for
    - memory-efficient and rabitq optimized indexes
    - bivf indexes having sq8 as the backing index type
- the fast merge path is hit only if both the trainedIndex and the finalMergedIndex are eligible for fast merge, this check ensures that we don't error out and lose data as a fallback mechanism.
- in case of updates/deletes on the index, we avoid re-training the index since that at a later point in time we might end up merging indexes with different centroid layout - that'll cause a panic. 
