### PR TITLE
Simplify the implementation of vector search filter logic

### DIFF
--- a/faiss_vector_index.go
+++ b/faiss_vector_index.go
@@ -46,11 +46,7 @@ type faissIndex interface {
 	// performs a search on the index using the provided query vector and parameters, with an optional
 	// exclude selector to indicate a "blocklist" of indexed vectors to ignore during search.
 	// It returns the distances and corresponding vector IDs of the top k results.
-	searchWithoutIDs(qVector *vectorSet, k int64, selector faiss.Selector, params json.RawMessage) ([]float32, []int64, error)
-	// performs a search on the index using the provided query vector and parameters, with a required
-	// include selector to indicate an "allowlist" of indexed vectors to consider during search.
-	// It returns the distances and corresponding vector IDs of the top k results.
-	searchWithIDs(qVector *vectorSet, k int64, selector faiss.Selector, params json.RawMessage) ([]float32, []int64, error)
+	searchWithSelector(qVector *vectorSet, k int64, selector faiss.Selector, params json.RawMessage) ([]float32, []int64, error)
 	// serializes the index into a byte slice,
 	// which can be stored or transmitted.
 	serialize() ([]byte, error)

--- a/faiss_vector_index_bivf.go
+++ b/faiss_vector_index_bivf.go
@@ -74,46 +74,24 @@ func (b *faissBinaryIndex) reconstructBatch(vecIDs []int64, prealloc []float32) 
 	return nil, errNotSupported
 }
 
-func (b *faissBinaryIndex) searchWithoutIDs(qVector *vectorSet, k int64, selector faiss.Selector, params json.RawMessage) ([]float32, []int64, error) {
+func (b *faissBinaryIndex) searchWithSelector(qVector *vectorSet, k int64, selector faiss.Selector, params json.RawMessage) ([]float32, []int64, error) {
 	// search the binary index with oversampling and then do a re-ranking on the
 	// FAISS index to get the top K results
 	// first binarize the query vector if not already done
 	qVector.binarize()
-	_, binIDs, err := b.binary.SearchWithoutIDs(qVector.binaryData, binaryOversampleValue*k,
-		selector, params)
-	if err != nil {
-		return nil, nil, err
-	}
-	var scores []float32
-	var labels []int64
-	// if we have a backing index for re-ranking, compute the distances/scores for the
-	// retrieved binary IDs and then get the top K results based on those distances/scores.
-	if b.backing != nil {
-		distances, err := b.backing.DistCompute(qVector.floatData, binIDs)
-		if err != nil {
-			return nil, nil, err
-		}
-		// quick select algorithm for inplace partial sorting to get top K results
-		// based on distances/scores
-		scores, labels = topNIDsByDistance(distances, binIDs, int(k))
-	} else {
-		// if we don't have a backing index for re-ranking, we return error since we cannot return meaningful
-		// scores without a backing index to compute distances/scores for the retrieved binary IDs.
-		return nil, nil, errNotSupported
-	}
-	return scores, labels, nil
-}
 
-func (b *faissBinaryIndex) searchWithIDs(qVector *vectorSet, k int64, selector faiss.Selector, params json.RawMessage) ([]float32, []int64, error) {
-	// search the binary index with oversampling and then do a re-ranking on the
-	// FAISS index to get the top K results
-	// first binarize the query vector if not already done
-	qVector.binarize()
-	_, binIDs, err := b.binary.SearchWithIDs(qVector.binaryData, binaryOversampleValue*k,
-		selector, params)
+	var binIDs []int64
+	var err error
+	if selector == nil {
+		_, binIDs, err = b.binary.Search(qVector.binaryData, binaryOversampleValue*k)
+	} else {
+		_, binIDs, err = b.binary.SearchWithSelector(qVector.binaryData, binaryOversampleValue*k,
+			selector, params)
+	}
 	if err != nil {
 		return nil, nil, err
 	}
+
 	var scores []float32
 	var labels []int64
 	// if we have a backing index for re-ranking, compute the distances/scores for the

--- a/faiss_vector_index_bivf.go
+++ b/faiss_vector_index_bivf.go
@@ -82,7 +82,7 @@ func (b *faissBinaryIndex) searchWithSelector(qVector *vectorSet, k int64, selec
 
 	var binIDs []int64
 	var err error
-	if selector == nil {
+	if params == nil && selector == nil {
 		_, binIDs, err = b.binary.Search(qVector.binaryData, binaryOversampleValue*k)
 	} else {
 		_, binIDs, err = b.binary.SearchWithSelector(qVector.binaryData, binaryOversampleValue*k,

--- a/faiss_vector_index_float32.go
+++ b/faiss_vector_index_float32.go
@@ -64,7 +64,7 @@ func (f *faissFloat32Index) reconstructBatch(vecIDs []int64, prealloc []float32)
 }
 
 func (f *faissFloat32Index) searchWithSelector(qVector *vectorSet, k int64, selector faiss.Selector, params json.RawMessage) ([]float32, []int64, error) {
-	if selector == nil {
+	if params == nil && selector == nil {
 		return f.idx.Search(qVector.floatData, k)
 	}
 	return f.idx.SearchWithSelector(qVector.floatData, k, selector, params)

--- a/faiss_vector_index_float32.go
+++ b/faiss_vector_index_float32.go
@@ -63,12 +63,11 @@ func (f *faissFloat32Index) reconstructBatch(vecIDs []int64, prealloc []float32)
 	return f.idx.ReconstructBatch(vecIDs, prealloc)
 }
 
-func (f *faissFloat32Index) searchWithoutIDs(qVector *vectorSet, k int64, selector faiss.Selector, params json.RawMessage) ([]float32, []int64, error) {
-	return f.idx.SearchWithoutIDs(qVector.floatData, k, selector, params)
-}
-
-func (f *faissFloat32Index) searchWithIDs(qVector *vectorSet, k int64, selector faiss.Selector, params json.RawMessage) ([]float32, []int64, error) {
-	return f.idx.SearchWithIDs(qVector.floatData, k, selector, params)
+func (f *faissFloat32Index) searchWithSelector(qVector *vectorSet, k int64, selector faiss.Selector, params json.RawMessage) ([]float32, []int64, error) {
+	if selector == nil {
+		return f.idx.Search(qVector.floatData, k)
+	}
+	return f.idx.SearchWithSelector(qVector.floatData, k, selector, params)
 }
 
 func (f *faissFloat32Index) serialize() ([]byte, error) {

--- a/faiss_vector_wrapper.go
+++ b/faiss_vector_wrapper.go
@@ -451,12 +451,14 @@ func (v *vectorIndexWrapper) searchWithIDs(vecSet *vectorSet, k int64, include *
 			if err != nil {
 				return nil, nil, err
 			}
+			if sel == nil {
+				return nil, nil, fmt.Errorf("requires valid include selector, got nil")
+			}
+
 			// NOTE: the selector being freed does NOT free the inner bitmap, as we control
 			// its lifecycle in GO, to reuse the bitmap across iterations, if needed, for
 			// multi-vector document retrieval.
-			if sel != nil {
-				defer sel.Delete()
-			}
+			defer sel.Delete()
 			return v.index.searchWithSelector(vecSet, k, sel, params)
 		},
 		func(numIter int, labels []int64) bool {

--- a/faiss_vector_wrapper.go
+++ b/faiss_vector_wrapper.go
@@ -406,7 +406,7 @@ func (v *vectorIndexWrapper) searchWithoutIDs(qVector *vectorSet, k int64,
 			if sel != nil {
 				defer sel.Delete()
 			}
-			return v.index.searchWithoutIDs(qVector, k, sel, params)
+			return v.index.searchWithSelector(qVector, k, sel, params)
 		},
 		func(numIter int, labels []int64) bool {
 			// if this is the first loop iteration and we have < k unique docIDs,
@@ -457,7 +457,7 @@ func (v *vectorIndexWrapper) searchWithIDs(vecSet *vectorSet, k int64, include *
 			if sel != nil {
 				defer sel.Delete()
 			}
-			return v.index.searchWithIDs(vecSet, k, sel, params)
+			return v.index.searchWithSelector(vecSet, k, sel, params)
 		},
 		func(numIter int, labels []int64) bool {
 			// if this is the first loop iteration and we have < k unique docIDs,

--- a/go.mod
+++ b/go.mod
@@ -20,3 +20,5 @@ require (
 	github.com/spf13/pflag v1.0.9 // indirect
 	golang.org/x/sys v0.40.0 // indirect
 )
+
+replace github.com/blevesearch/go-faiss => /Users/thejas.orkombu/fts/blevesearch/go-faiss

--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,7 @@ go 1.24.0
 require (
 	github.com/RoaringBitmap/roaring/v2 v2.14.5
 	github.com/blevesearch/bleve_index_api v1.3.9
-	github.com/blevesearch/go-faiss v1.0.30
+	github.com/blevesearch/go-faiss v1.0.33
 	github.com/blevesearch/mmap-go v1.2.0
 	github.com/blevesearch/scorch_segment_api/v2 v2.4.5
 	github.com/blevesearch/vellum v1.2.0
@@ -20,5 +20,3 @@ require (
 	github.com/spf13/pflag v1.0.9 // indirect
 	golang.org/x/sys v0.40.0 // indirect
 )
-
-replace github.com/blevesearch/go-faiss => /Users/thejas.orkombu/fts/blevesearch/go-faiss

--- a/go.sum
+++ b/go.sum
@@ -4,6 +4,8 @@ github.com/bits-and-blooms/bitset v1.24.2 h1:M7/NzVbsytmtfHbumG+K2bremQPMJuqv1JD
 github.com/bits-and-blooms/bitset v1.24.2/go.mod h1:7hO7Gc7Pp1vODcmWvKMRA9BNmbv6a/7QIWpPxHddWR8=
 github.com/blevesearch/bleve_index_api v1.3.9 h1:TLoiBaqcfWGfI1Il0+zzky452uYCPoSMosDSltkCfKs=
 github.com/blevesearch/bleve_index_api v1.3.9/go.mod h1:xvd48t5XMeeioWQ5/jZvgLrV98flT2rdvEJ3l/ki4Ko=
+github.com/blevesearch/go-faiss v1.0.33 h1:7GG3ZGIm6nFRnaJqp6/FylPIQe6W2lki192RJd2E+Zc=
+github.com/blevesearch/go-faiss v1.0.33/go.mod h1:OMGQwOaRRYxrmeNdMrXJPvVx8gBnvE5RYrr0BahNnkk=
 github.com/blevesearch/mmap-go v1.2.0 h1:l33nNKPFcBjJUMwem6sAYJPUzhUCABoK9FxZDGiFNBI=
 github.com/blevesearch/mmap-go v1.2.0/go.mod h1:Vd6+20GBhEdwJnU1Xohgt88XCD/CTWcqbCNxkZpyBo0=
 github.com/blevesearch/scorch_segment_api/v2 v2.4.5 h1:Q7Bzpyk86xS22TgTd4VQfSvzZAybDEJ90hNOGqyNqlI=

--- a/go.sum
+++ b/go.sum
@@ -4,8 +4,6 @@ github.com/bits-and-blooms/bitset v1.24.2 h1:M7/NzVbsytmtfHbumG+K2bremQPMJuqv1JD
 github.com/bits-and-blooms/bitset v1.24.2/go.mod h1:7hO7Gc7Pp1vODcmWvKMRA9BNmbv6a/7QIWpPxHddWR8=
 github.com/blevesearch/bleve_index_api v1.3.9 h1:TLoiBaqcfWGfI1Il0+zzky452uYCPoSMosDSltkCfKs=
 github.com/blevesearch/bleve_index_api v1.3.9/go.mod h1:xvd48t5XMeeioWQ5/jZvgLrV98flT2rdvEJ3l/ki4Ko=
-github.com/blevesearch/go-faiss v1.0.30 h1:pWX3/Si4Z7GlwsD2eRXoF3SfVaDkg8plBlPdUKuhGts=
-github.com/blevesearch/go-faiss v1.0.30/go.mod h1:OMGQwOaRRYxrmeNdMrXJPvVx8gBnvE5RYrr0BahNnkk=
 github.com/blevesearch/mmap-go v1.2.0 h1:l33nNKPFcBjJUMwem6sAYJPUzhUCABoK9FxZDGiFNBI=
 github.com/blevesearch/mmap-go v1.2.0/go.mod h1:Vd6+20GBhEdwJnU1Xohgt88XCD/CTWcqbCNxkZpyBo0=
 github.com/blevesearch/scorch_segment_api/v2 v2.4.5 h1:Q7Bzpyk86xS22TgTd4VQfSvzZAybDEJ90hNOGqyNqlI=


### PR DESCRIPTION
- we don't ideally need two different functions in the interface which can be consolidated as part of the go-faiss's `Selector` interface, which is actually a parameter to these functions
- needs to be backported to v16.x as well https://github.com/blevesearch/zapx/pull/396