### PR TITLE
Fix bugs with `SearchWithSelector`

### DIFF
--- a/faiss_vector_index.go
+++ b/faiss_vector_index.go
@@ -43,10 +43,9 @@ type faissIndex interface {
 	ntotal() int64
 	// reconstructBatch reconstructs the original vectors for the given vector IDs in the index.
 	reconstructBatch(vecIDs []int64, prealloc []float32) ([]float32, error)
-	// performs a search on the index using the provided query vector and parameters, with an optional
-	// exclude selector to indicate a "blocklist" of indexed vectors to ignore during search.
-	// It returns the distances and corresponding vector IDs of the top k results.
-	searchWithSelector(qVector *vectorSet, k int64, selector faiss.Selector, params json.RawMessage) ([]float32, []int64, error)
+	// performs a search on the index using the provided query vector and and retrieves the top K nearest neighbors.
+	// Optional search constraints can be applied using the selector and additional search parameters.
+	search(qVector *vectorSet, k int64, selector faiss.Selector, params json.RawMessage) ([]float32, []int64, error)
 	// serializes the index into a byte slice,
 	// which can be stored or transmitted.
 	serialize() ([]byte, error)

--- a/faiss_vector_index_bivf.go
+++ b/faiss_vector_index_bivf.go
@@ -74,24 +74,17 @@ func (b *faissBinaryIndex) reconstructBatch(vecIDs []int64, prealloc []float32) 
 	return nil, errNotSupported
 }
 
-func (b *faissBinaryIndex) searchWithSelector(qVector *vectorSet, k int64, selector faiss.Selector, params json.RawMessage) ([]float32, []int64, error) {
+func (b *faissBinaryIndex) search(qVector *vectorSet, k int64, selector faiss.Selector, params json.RawMessage) ([]float32, []int64, error) {
 	// search the binary index with oversampling and then do a re-ranking on the
 	// FAISS index to get the top K results
 	// first binarize the query vector if not already done
 	qVector.binarize()
-
-	var binIDs []int64
-	var err error
-	if params == nil && selector == nil {
-		_, binIDs, err = b.binary.Search(qVector.binaryData, binaryOversampleValue*k)
-	} else {
-		_, binIDs, err = b.binary.SearchWithSelector(qVector.binaryData, binaryOversampleValue*k,
-			selector, params)
-	}
+	// search the binary index with oversampling to get a larger set of candidate binary IDs for re-ranking
+	_, binIDs, err := b.binary.SearchWithOptions(qVector.binaryData, binaryOversampleValue*k,
+		selector, params)
 	if err != nil {
 		return nil, nil, err
 	}
-
 	var scores []float32
 	var labels []int64
 	// if we have a backing index for re-ranking, compute the distances/scores for the

--- a/faiss_vector_index_float32.go
+++ b/faiss_vector_index_float32.go
@@ -63,11 +63,8 @@ func (f *faissFloat32Index) reconstructBatch(vecIDs []int64, prealloc []float32)
 	return f.idx.ReconstructBatch(vecIDs, prealloc)
 }
 
-func (f *faissFloat32Index) searchWithSelector(qVector *vectorSet, k int64, selector faiss.Selector, params json.RawMessage) ([]float32, []int64, error) {
-	if params == nil && selector == nil {
-		return f.idx.Search(qVector.floatData, k)
-	}
-	return f.idx.SearchWithSelector(qVector.floatData, k, selector, params)
+func (f *faissFloat32Index) search(qVector *vectorSet, k int64, selector faiss.Selector, params json.RawMessage) ([]float32, []int64, error) {
+	return f.idx.SearchWithOptions(qVector.floatData, k, selector, params)
 }
 
 func (f *faissFloat32Index) serialize() ([]byte, error) {

--- a/faiss_vector_wrapper.go
+++ b/faiss_vector_wrapper.go
@@ -404,9 +404,11 @@ func (v *vectorIndexWrapper) searchWithoutIDs(qVector *vectorSet, k int64,
 			// its lifecycle in GO, to reuse the bitmap across iterations, if needed, for
 			// multi-vector document retrieval.
 			if sel != nil {
+				// The selector can be nil here as we may not be excluding any vectors
+				// in which case we can just pass a nil selector to FAISS.
 				defer sel.Delete()
 			}
-			return v.index.searchWithSelector(qVector, k, sel, params)
+			return v.index.search(qVector, k, sel, params)
 		},
 		func(numIter int, labels []int64) bool {
 			// if this is the first loop iteration and we have < k unique docIDs,
@@ -451,15 +453,11 @@ func (v *vectorIndexWrapper) searchWithIDs(vecSet *vectorSet, k int64, include *
 			if err != nil {
 				return nil, nil, err
 			}
-			if sel == nil {
-				return nil, nil, fmt.Errorf("requires valid include selector, got nil")
-			}
-
 			// NOTE: the selector being freed does NOT free the inner bitmap, as we control
 			// its lifecycle in GO, to reuse the bitmap across iterations, if needed, for
 			// multi-vector document retrieval.
 			defer sel.Delete()
-			return v.index.searchWithSelector(vecSet, k, sel, params)
+			return v.index.search(vecSet, k, sel, params)
 		},
 		func(numIter int, labels []int64) bool {
 			// if this is the first loop iteration and we have < k unique docIDs,

--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,7 @@ go 1.24.0
 require (
 	github.com/RoaringBitmap/roaring/v2 v2.14.5
 	github.com/blevesearch/bleve_index_api v1.3.9
-	github.com/blevesearch/go-faiss v1.0.33
+	github.com/blevesearch/go-faiss v1.0.34
 	github.com/blevesearch/mmap-go v1.2.0
 	github.com/blevesearch/scorch_segment_api/v2 v2.4.5
 	github.com/blevesearch/vellum v1.2.0

--- a/go.sum
+++ b/go.sum
@@ -4,8 +4,8 @@ github.com/bits-and-blooms/bitset v1.24.2 h1:M7/NzVbsytmtfHbumG+K2bremQPMJuqv1JD
 github.com/bits-and-blooms/bitset v1.24.2/go.mod h1:7hO7Gc7Pp1vODcmWvKMRA9BNmbv6a/7QIWpPxHddWR8=
 github.com/blevesearch/bleve_index_api v1.3.9 h1:TLoiBaqcfWGfI1Il0+zzky452uYCPoSMosDSltkCfKs=
 github.com/blevesearch/bleve_index_api v1.3.9/go.mod h1:xvd48t5XMeeioWQ5/jZvgLrV98flT2rdvEJ3l/ki4Ko=
-github.com/blevesearch/go-faiss v1.0.33 h1:7GG3ZGIm6nFRnaJqp6/FylPIQe6W2lki192RJd2E+Zc=
-github.com/blevesearch/go-faiss v1.0.33/go.mod h1:OMGQwOaRRYxrmeNdMrXJPvVx8gBnvE5RYrr0BahNnkk=
+github.com/blevesearch/go-faiss v1.0.34 h1:cFE1jRkjJfk7qMMsqXBqGEivbYQz/tjSf5yyoH50xbY=
+github.com/blevesearch/go-faiss v1.0.34/go.mod h1:OMGQwOaRRYxrmeNdMrXJPvVx8gBnvE5RYrr0BahNnkk=
 github.com/blevesearch/mmap-go v1.2.0 h1:l33nNKPFcBjJUMwem6sAYJPUzhUCABoK9FxZDGiFNBI=
 github.com/blevesearch/mmap-go v1.2.0/go.mod h1:Vd6+20GBhEdwJnU1Xohgt88XCD/CTWcqbCNxkZpyBo0=
 github.com/blevesearch/scorch_segment_api/v2 v2.4.5 h1:Q7Bzpyk86xS22TgTd4VQfSvzZAybDEJ90hNOGqyNqlI=


### PR DESCRIPTION
- Replace the `searchWithSelector` API with a simpler `search` API that takes in two optional search constraints:
    - `selector`: If present, will restrict the search space to include only selected vector IDs.
    -  `params`: If present, will impose user defined search parameters like custom nprobe etc.
- Call go-faiss's `SearchWithOptions` API, which will handle the case if none of the options are provided.