### PR TITLE
MB-71516: Fix result inconsistencies when exhausting binary indices

### DIFF
--- a/faiss_vector_test.go
+++ b/faiss_vector_test.go
@@ -156,6 +156,18 @@ func newStubFieldVec(name string, vector []float32, d int, metric string, fieldO
 	}
 }
 
+func newStubFieldVecWithOptimization(name string, vector []float32, d int, metric string, fieldOptions index.FieldIndexingOptions, optimizeFor string) index.Field {
+	return &stubVecField{
+		name:        name,
+		value:       vector,
+		dims:        d,
+		similarity:  metric,
+		encodedType: 'v',
+		options:     fieldOptions,
+		optimizeFor: optimizeFor,
+	}
+}
+
 var stubVecData = [][]float32{
 	{1.0, 2.0, 3.0},
 	{12.0, 42.6, 78.65},
@@ -802,4 +814,76 @@ func TestValidVectorMerge(t *testing.T) {
 	defer func() {
 		_ = os.RemoveAll(mergedSegPath1)
 	}()
+}
+
+func TestIndexExhaustion(t *testing.T) {
+	for optim := range index.SupportedVectorIndexOptimizations {
+		t.Run(optim, func(t *testing.T) {
+			// Use 8-dimensional vectors (must be multiple of 8 for binary index)
+			dims := 8
+			numDocs := 5
+			var docs []index.Document
+			for i := 0; i < numDocs; i++ {
+				vec := make([]float32, dims)
+				for j := 0; j < dims; j++ {
+					vec[j] = float32(i*dims + j)
+				}
+				docs = append(docs, newVecStubDocument(string(rune('a'+i)), []index.Field{
+					newStubFieldSplitString("_id", nil, string(rune('a'+i)), true, false, false),
+					newStubFieldVecWithOptimization("vec", vec, dims, index.CosineSimilarity, index.IndexField, optim),
+				}))
+			}
+			vecSegPlugin := &ZapPlugin{}
+			seg, _, err := vecSegPlugin.New(docs)
+			if err != nil {
+				t.Fatal(err)
+			}
+			path := "./test-seg-exhaustion-" + optim
+			if unPersistedSeg, ok := seg.(segment.UnpersistedSegment); ok {
+				err = unPersistedSeg.Persist(path)
+				if err != nil {
+					t.Fatal(err)
+				}
+			}
+			segOnDisk, err := vecSegPlugin.Open(path)
+			if err != nil {
+				t.Fatal(err)
+			}
+			defer func() {
+				cerr := segOnDisk.Close()
+				if cerr != nil {
+					t.Fatalf("error closing segment: %v", cerr)
+				}
+				_ = os.RemoveAll(path)
+			}()
+			if vecSeg, ok := segOnDisk.(segment.VectorSegment); ok {
+				vecIndex, err := vecSeg.InterpretVectorIndex("vec", nil)
+				if err != nil {
+					t.Fatal(err)
+				}
+				defer vecIndex.Close()
+				queryVec := make([]float32, dims)
+				pl, err := vecIndex.Search(queryVec, int64(numDocs*2), nil)
+				if err != nil {
+					t.Fatal(err)
+				}
+
+				itr := pl.Iterator(nil)
+				resultCount := 0
+				for {
+					next, err := itr.Next()
+					if err != nil {
+						t.Fatal(err)
+					}
+					if next == nil {
+						break
+					}
+					resultCount++
+				}
+				if resultCount != numDocs {
+					t.Fatalf("expected %d results, got %d", numDocs, resultCount)
+				}
+			}
+		})
+	}
 }

--- a/faiss_vector_wrapper.go
+++ b/faiss_vector_wrapper.go
@@ -331,13 +331,13 @@ func (v *vectorIndexWrapper) docSearch(k int64, numDocs uint64,
 		}
 		// process the retrieved ids and scores, getting the corresponding docIDs
 		// for each vector id retrieved, and storing the best score for each unique docID
-		// the moment we see a -1 for a vector id, we stop processing further since
-		// it indicates there are no more vectors to be retrieved and break out of the loop
-		// by setting the exhausted flag
 		for i, vecID := range labels {
+			// a vecID of -1 indicates that all valid vectors in the index have been exhausted,
+			// so we set the flag to prevent further iterations. However, the current iteration
+			// may still contain valid results, so we process them before stopping.
 			if vecID == -1 {
 				exhausted = true
-				break
+				continue
 			}
 			docID, exists := v.getDocIDForVectorID(vecID)
 			if !exists {


### PR DESCRIPTION
- When we exhaust a vector index - when `k` > `N` (where `N` represents the number of "valid"
  vectors i.e. those vectors that have not been excluded using the bitmap), FAISS pads the
  output `labels` with `-1` and the corresponding `distances` with `±Inf`, depending on the
  distance metric used.
- We currently process the current iteration's output only until we see the first `-1` and
  perform an early exit, assuming that the rest of the output will be `-1` as well following
  FAISS's padding logic.
- With binary indices in play, due to the inherent nature of the QuickSelect algorithm used to
  pick the top K IDs, the final ordering of the result set output will be random, resulting in
  the previous padding assumption falling through, since we may yet have valid results beyond
  the first `-1`.
- Fix this issue by always processing the complete result set of the current iteration,
  filtering out any `-1` entries regardless of their position, rather than stopping at the
  first `-1` encountered. This ensures all valid results are always captured.