### PR TITLE
make the `faissIndex` interface and implementation more modular

### DIFF
--- a/centroid_index.go
+++ b/centroid_index.go
@@ -62,7 +62,7 @@ func (sb *SegmentBase) GetCoarseQuantizer(field string) (interface{}, error) {
 	indexSize, n := binary.Uvarint(sb.mem[pos : pos+binary.MaxVarintLen64])
 	pos += n
 
-	faissIndex, err := faiss.ReadIndexFromBuffer(sb.mem[pos:pos+int(indexSize)], faiss.IOFlagReadMmap)
+	faissIndex, err := faiss.ReadIndexFromBuffer(sb.mem[pos:pos+int(indexSize)], faissIOFlags)
 	if err != nil {
 		return nil, err
 	}

--- a/faiss_vector_index.go
+++ b/faiss_vector_index.go
@@ -96,14 +96,6 @@ type faissIndexIVF interface {
 	mergeFrom(other faissIndex, offset int64) error
 }
 
-// Interface for SQ-specific operations on Faiss vector indices.
-type faissIndexSQ interface {
-	// trains the SQ index on the provided training data and adds the vectors to
-	// the trained index. The training step performs quantization of the vector space,
-	// which enables efficient storage and search of high-dimensional vectors.
-	trainAndAdd(trainingData *vectorSet, vecsToAdd *vectorSet) error
-}
-
 // faissIndexGPU is implemented by any index type that can reside in GPU memory.
 type faissIndexGPU interface {
 	// inGPURam reports whether the index is currently loaded in GPU memory.

--- a/faiss_vector_index.go
+++ b/faiss_vector_index.go
@@ -57,9 +57,6 @@ type faissIndex interface {
 	// returns the underlying IVF index if this is an IVF index,
 	// and a boolean indicating whether the cast was successful.
 	castIVF() faissIndexIVF
-	// returns the underlying SQ index if this is an SQ index,
-	// and a boolean indicating whether the cast was successful.
-	castSQ() faissIndexSQ
 }
 
 // Interface for IVF-specific operations on Faiss vector indices.

--- a/faiss_vector_index.go
+++ b/faiss_vector_index.go
@@ -46,9 +46,9 @@ type faissIndex interface {
 	// performs a search on the index using the provided query vector and and retrieves the top K nearest neighbors.
 	// Optional search constraints can be applied using the selector and additional search parameters.
 	search(qVector *vectorSet, k int64, selector faiss.Selector, params json.RawMessage) ([]float32, []int64, error)
-	// serializes the index into a byte slice,
-	// which can be stored or transmitted.
-	serialize() ([]byte, error)
+	// write out the index content into the provide fileWriter using a reusable buffer
+	// returns any error encountered during the write process.
+	write(buf []byte, w *FileWriter) error
 	// returns the size of the index in bytes.
 	size() uint64
 	// -----------------------------------------------------------------

--- a/faiss_vector_index_bivf.go
+++ b/faiss_vector_index_bivf.go
@@ -18,6 +18,7 @@
 package zap
 
 import (
+	"encoding/binary"
 	"encoding/json"
 
 	faiss "github.com/blevesearch/go-faiss"
@@ -33,7 +34,7 @@ type faissBinaryIndex struct {
 
 func newFaissBinaryIndex(binary *faiss.BinaryIndexImpl, backing *faiss.IndexImpl) (index faissIndex, err error) {
 	// the binary index cannot be nil, but the backing index can be nil, depending on the use case.
-	if binary == nil {
+	if binary == nil || backing == nil {
 		return nil, errNilIndex
 	}
 	return &faissBinaryIndex{
@@ -43,15 +44,17 @@ func newFaissBinaryIndex(binary *faiss.BinaryIndexImpl, backing *faiss.IndexImpl
 }
 
 func (b *faissBinaryIndex) add(vecs *vectorSet) error {
-	// add the binaryData from the vectorSet to the binary index
+	// add float data to backing index and the binary data to binary index
+	err := b.backing.Add(vecs.floatData)
+	if err != nil {
+		return err
+	}
 	return b.binary.Add(vecs.binaryData)
 }
 
 func (b *faissBinaryIndex) close() {
 	b.binary.Close()
-	if b.backing != nil {
-		b.backing.Close()
-	}
+	b.backing.Close()
 }
 
 func (b *faissBinaryIndex) dim() int {
@@ -59,10 +62,7 @@ func (b *faissBinaryIndex) dim() int {
 }
 
 func (b *faissBinaryIndex) metricType() int {
-	if b.backing != nil {
-		return b.backing.MetricType()
-	}
-	return b.binary.MetricType()
+	return b.backing.MetricType()
 }
 
 func (b *faissBinaryIndex) ntotal() int64 {
@@ -70,8 +70,8 @@ func (b *faissBinaryIndex) ntotal() int64 {
 }
 
 func (b *faissBinaryIndex) reconstructBatch(vecIDs []int64, prealloc []float32) ([]float32, error) {
-	// binary indexes do not support reconstruction
-	return nil, errNotSupported
+	// reconstruct vectors from backing index
+	return b.backing.ReconstructBatch(vecIDs, prealloc)
 }
 
 func (b *faissBinaryIndex) search(qVector *vectorSet, k int64, selector faiss.Selector, params json.RawMessage) ([]float32, []int64, error) {
@@ -85,36 +85,59 @@ func (b *faissBinaryIndex) search(qVector *vectorSet, k int64, selector faiss.Se
 	if err != nil {
 		return nil, nil, err
 	}
-	var scores []float32
-	var labels []int64
-	// if we have a backing index for re-ranking, compute the distances/scores for the
+
+	// use backing index for re-ranking, compute the distances/scores for the
 	// retrieved binary IDs and then get the top K results based on those distances/scores.
-	if b.backing != nil {
-		distances, err := b.backing.DistCompute(qVector.floatData, binIDs)
-		if err != nil {
-			return nil, nil, err
-		}
-		// quick select algorithm for inplace partial sorting to get top K results
-		// based on distances/scores
-		scores, labels = topNIDsByDistance(distances, binIDs, int(k))
-	} else {
-		// if we don't have a backing index for re-ranking, we return error since we cannot return meaningful
-		// scores without a backing index to compute distances/scores for the retrieved binary IDs.
-		return nil, nil, errNotSupported
+	distances, err := b.backing.DistCompute(qVector.floatData, binIDs)
+	if err != nil {
+		return nil, nil, err
 	}
+	// quick select algorithm for inplace partial sorting to get top K results
+	// based on distances/scores
+	scores, labels := topNIDsByDistance(distances, binIDs, int(k))
 	return scores, labels, nil
 }
 
-func (b *faissBinaryIndex) serialize() ([]byte, error) {
-	return faiss.WriteBinaryIndexIntoBuffer(b.binary)
+func (b *faissBinaryIndex) write(buf []byte, w *FileWriter) error {
+	backingBytes, err := faiss.WriteIndexIntoBuffer(b.backing)
+	if err != nil {
+		return err
+	}
+
+	// write the length of the serialized vector index bytes
+	n := binary.PutUvarint(buf, uint64(len(backingBytes)))
+	_, err = w.Write(buf[:n])
+	if err != nil {
+		return err
+	}
+
+	backingBytes = w.process(backingBytes)
+	_, err = w.Write(backingBytes)
+	if err != nil {
+		return err
+	}
+
+	binaryBytes, err := faiss.WriteBinaryIndexIntoBuffer(b.binary)
+	if err != nil {
+		return err
+	}
+	// write the length of the serialized vector index bytes
+	n = binary.PutUvarint(buf, uint64(len(binaryBytes)))
+	_, err = w.Write(buf[:n])
+	if err != nil {
+		return err
+	}
+
+	binaryBytes = w.process(binaryBytes)
+	_, err = w.Write(binaryBytes)
+	if err != nil {
+		return err
+	}
+	return nil
 }
 
 func (b *faissBinaryIndex) size() uint64 {
-	sizeInBytes := b.binary.Size()
-	if b.backing != nil {
-		sizeInBytes += b.backing.Size()
-	}
-	return sizeInBytes
+	return b.binary.Size() + b.backing.Size()
 }
 
 // -----------------------------------------------------------------
@@ -192,24 +215,17 @@ func (b *faissBinaryIndex) searchClusters(eligibleCentroidIDs []int64, centroidD
 	if err != nil {
 		return nil, nil, err
 	}
-	var scores []float32
-	var labels []int64
-	// if we have a backing index for re-ranking, compute the distances/scores for the
+
+	// use backing index for re-ranking, compute the distances/scores for the
 	// retrieved binary IDs and then get the top K results based on those distances/scores.
-	if b.backing != nil {
-		// reranking is still necessary since hamming distance has a lot of collisions
-		distances, err := b.backing.DistCompute(qVector.floatData, binIDs)
-		if err != nil {
-			return nil, nil, err
-		}
-		// quick select algorithm for inplace partial sorting to get top K results
-		// based on distances/scores
-		scores, labels = topNIDsByDistance(distances, binIDs, int(k))
-	} else {
-		// if we don't have a backing index for re-ranking, we return error since we cannot return meaningful
-		// scores without a backing index to compute distances/scores for the retrieved binary IDs.
-		return nil, nil, errNotSupported
+	// reranking is still necessary since hamming distance has a lot of collisions
+	distances, err := b.backing.DistCompute(qVector.floatData, binIDs)
+	if err != nil {
+		return nil, nil, err
 	}
+	// quick select algorithm for inplace partial sorting to get top K results
+	// based on distances/scores
+	scores, labels := topNIDsByDistance(distances, binIDs, int(k))
 	return scores, labels, nil
 }
 
@@ -222,15 +238,24 @@ func (b *faissBinaryIndex) setNProbe(nprobe int32) {
 }
 
 func (b *faissBinaryIndex) trainAndAdd(trainingData *vectorSet, vecsToAdd *vectorSet) error {
-	err := b.binary.Train(trainingData.binaryData)
+	// train the backing index with the floatData
+	var err error
+	if b.backing != nil && b.backing.IsSQIndex() {
+		err = b.backing.Train(trainingData.floatData)
+		if err != nil {
+			return err
+		}
+	}
+
+	err = b.binary.Train(trainingData.binaryData)
 	if err != nil {
 		return err
 	}
 	return b.add(vecsToAdd)
 }
 
-func (b *faissBinaryIndex) setQuantizers(centroidIndex faissIndexIVF) error {
-	// not supported for binary indexes, return error
+func (b *faissBinaryIndex) setQuantizers(trainedIndex faissIndexIVF) error {
+	// not supported for binary indexes, returns error
 	return errNotSupported
 }
 

--- a/faiss_vector_index_bivf.go
+++ b/faiss_vector_index_bivf.go
@@ -240,7 +240,7 @@ func (b *faissBinaryIndex) setNProbe(nprobe int32) {
 func (b *faissBinaryIndex) trainAndAdd(trainingData *vectorSet, vecsToAdd *vectorSet) error {
 	// train the backing index with the floatData
 	var err error
-	if b.backing != nil && b.backing.IsSQIndex() {
+	if b.backing.IsSQIndex() {
 		err = b.backing.Train(trainingData.floatData)
 		if err != nil {
 			return err

--- a/faiss_vector_index_bivf.go
+++ b/faiss_vector_index_bivf.go
@@ -103,6 +103,7 @@ func (b *faissBinaryIndex) write(buf []byte, w *FileWriter) error {
 	if err != nil {
 		return err
 	}
+	backingBytes = w.process(backingBytes)
 
 	// write the length of the serialized vector index bytes
 	n := binary.PutUvarint(buf, uint64(len(backingBytes)))
@@ -111,7 +112,6 @@ func (b *faissBinaryIndex) write(buf []byte, w *FileWriter) error {
 		return err
 	}
 
-	backingBytes = w.process(backingBytes)
 	_, err = w.Write(backingBytes)
 	if err != nil {
 		return err
@@ -121,6 +121,8 @@ func (b *faissBinaryIndex) write(buf []byte, w *FileWriter) error {
 	if err != nil {
 		return err
 	}
+	binaryBytes = w.process(binaryBytes)
+
 	// write the length of the serialized vector index bytes
 	n = binary.PutUvarint(buf, uint64(len(binaryBytes)))
 	_, err = w.Write(buf[:n])
@@ -128,7 +130,6 @@ func (b *faissBinaryIndex) write(buf []byte, w *FileWriter) error {
 		return err
 	}
 
-	binaryBytes = w.process(binaryBytes)
 	_, err = w.Write(binaryBytes)
 	if err != nil {
 		return err

--- a/faiss_vector_index_bivf.go
+++ b/faiss_vector_index_bivf.go
@@ -33,7 +33,7 @@ type faissBinaryIndex struct {
 }
 
 func newFaissBinaryIndex(binary *faiss.BinaryIndexImpl, backing *faiss.IndexImpl) (index faissIndex, err error) {
-	// the binary index cannot be nil, but the backing index can be nil, depending on the use case.
+	// we always create this object only with valid backing and binary indexes
 	if binary == nil || backing == nil {
 		return nil, errNilIndex
 	}

--- a/faiss_vector_index_bivf.go
+++ b/faiss_vector_index_bivf.go
@@ -153,11 +153,6 @@ func (b *faissBinaryIndex) castIVF() faissIndexIVF {
 	return nil
 }
 
-// Binary indexes don't support SQ, so this always returns nil.
-func (b *faissBinaryIndex) castSQ() faissIndexSQ {
-	return nil
-}
-
 // -----------------------------------------------------------------
 // IVF-Index specific operations
 // -----------------------------------------------------------------

--- a/faiss_vector_index_float32.go
+++ b/faiss_vector_index_float32.go
@@ -73,6 +73,7 @@ func (f *faissFloat32Index) write(buf []byte, w *FileWriter) error {
 	if err != nil {
 		return err
 	}
+	idxBytes = w.process(idxBytes)
 
 	// write the length of the serialized vector index bytes
 	n := binary.PutUvarint(buf, uint64(len(idxBytes)))
@@ -81,7 +82,6 @@ func (f *faissFloat32Index) write(buf []byte, w *FileWriter) error {
 		return err
 	}
 
-	idxBytes = w.process(idxBytes)
 	_, err = w.Write(idxBytes)
 	if err != nil {
 		return err

--- a/faiss_vector_index_float32.go
+++ b/faiss_vector_index_float32.go
@@ -18,6 +18,7 @@
 package zap
 
 import (
+	"encoding/binary"
 	"encoding/json"
 
 	faiss "github.com/blevesearch/go-faiss"
@@ -67,8 +68,25 @@ func (f *faissFloat32Index) search(qVector *vectorSet, k int64, selector faiss.S
 	return f.idx.SearchWithOptions(qVector.floatData, k, selector, params)
 }
 
-func (f *faissFloat32Index) serialize() ([]byte, error) {
-	return faiss.WriteIndexIntoBuffer(f.idx)
+func (f *faissFloat32Index) write(buf []byte, w *FileWriter) error {
+	idxBytes, err := faiss.WriteIndexIntoBuffer(f.idx)
+	if err != nil {
+		return err
+	}
+
+	// write the length of the serialized vector index bytes
+	n := binary.PutUvarint(buf, uint64(len(idxBytes)))
+	_, err = w.Write(buf[:n])
+	if err != nil {
+		return err
+	}
+
+	idxBytes = w.process(idxBytes)
+	_, err = w.Write(idxBytes)
+	if err != nil {
+		return err
+	}
+	return nil
 }
 
 func (f *faissFloat32Index) size() uint64 {

--- a/faiss_vector_index_float32.go
+++ b/faiss_vector_index_float32.go
@@ -106,16 +106,6 @@ func (f *faissFloat32Index) castIVF() faissIndexIVF {
 	return nil
 }
 
-func (f *faissFloat32Index) castSQ() faissIndexSQ {
-	if f.idx.IsSQIndex() {
-		// return f itself, as the SQ interface is implemented by the same
-		// struct as the non-SQ interface in go-faiss.
-		return f
-	}
-	// not an SQ index, return nil.
-	return nil
-}
-
 // -----------------------------------------------------------------
 // IVF-Index specific operations
 // -----------------------------------------------------------------

--- a/faiss_vector_index_gpu_float32.go
+++ b/faiss_vector_index_gpu_float32.go
@@ -166,6 +166,7 @@ func (f *faissGPUFloat32Index) write(buf []byte, w *FileWriter) error {
 	if err != nil {
 		return err
 	}
+	idxBytes = w.process(idxBytes)
 
 	// write the length of the serialized vector index bytes
 	n := binary.PutUvarint(buf, uint64(len(idxBytes)))
@@ -174,7 +175,6 @@ func (f *faissGPUFloat32Index) write(buf []byte, w *FileWriter) error {
 		return err
 	}
 
-	idxBytes = w.process(idxBytes)
 	_, err = w.Write(idxBytes)
 	if err != nil {
 		return err

--- a/faiss_vector_index_gpu_float32.go
+++ b/faiss_vector_index_gpu_float32.go
@@ -18,6 +18,7 @@
 package zap
 
 import (
+	"encoding/binary"
 	"encoding/json"
 	"sync/atomic"
 
@@ -160,8 +161,25 @@ func (f *faissGPUFloat32Index) search(qVector *vectorSet, k int64, selector fais
 	return f.cpuIdx.SearchWithOptions(qVector.floatData, k, selector, params)
 }
 
-func (f *faissGPUFloat32Index) serialize() ([]byte, error) {
-	return faiss.WriteIndexIntoBuffer(f.cpuIdx)
+func (f *faissGPUFloat32Index) write(buf []byte, w *FileWriter) error {
+	idxBytes, err := faiss.WriteIndexIntoBuffer(f.cpuIdx)
+	if err != nil {
+		return err
+	}
+
+	// write the length of the serialized vector index bytes
+	n := binary.PutUvarint(buf, uint64(len(idxBytes)))
+	_, err = w.Write(buf[:n])
+	if err != nil {
+		return err
+	}
+
+	idxBytes = w.process(idxBytes)
+	_, err = w.Write(idxBytes)
+	if err != nil {
+		return err
+	}
+	return nil
 }
 
 func (f *faissGPUFloat32Index) size() uint64 {

--- a/faiss_vector_index_gpu_float32.go
+++ b/faiss_vector_index_gpu_float32.go
@@ -202,13 +202,6 @@ func (f *faissGPUFloat32Index) castIVF() faissIndexIVF {
 	return nil
 }
 
-func (f *faissGPUFloat32Index) castSQ() faissIndexSQ {
-	if f.cpuIdx.IsSQIndex() {
-		return f
-	}
-	return nil
-}
-
 // -----------------------------------------------------------------
 // IVF-Index specific operations (delegate to CPU index)
 // -----------------------------------------------------------------

--- a/section_faiss_vector_index.go
+++ b/section_faiss_vector_index.go
@@ -286,6 +286,7 @@ func (v *vectorIndexOpaque) flushSectionMetadata(fieldID int, w *FileWriter,
 	vecToDocID []uint64, indexes []*vecIndexInfo) error {
 	tempBuf := v.grabBuf(binary.MaxVarintLen64)
 	fieldStart := w.Count()
+
 	// marking the fact that for vector index, doc values are not valid by
 	// storing fieldNotUninverted values.
 	n := binary.PutUvarint(tempBuf, fieldNotUninverted)
@@ -298,6 +299,7 @@ func (v *vectorIndexOpaque) flushSectionMetadata(fieldID int, w *FileWriter,
 	if err != nil {
 		return err
 	}
+
 	// write the index optimization type
 	n = binary.PutUvarint(tempBuf, uint64(index.SupportedVectorIndexOptimizations[indexes[0].indexOptimizedFor]))
 	_, err = w.Write(tempBuf[:n])
@@ -310,6 +312,7 @@ func (v *vectorIndexOpaque) flushSectionMetadata(fieldID int, w *FileWriter,
 	if err != nil {
 		return err
 	}
+
 	buf := make([]byte, binary.MaxVarintLen64*len(vecToDocID))
 	bufPos := 0
 	for _, docID := range vecToDocID {
@@ -329,6 +332,7 @@ func (v *vectorIndexOpaque) flushSectionMetadata(fieldID int, w *FileWriter,
 	if err != nil {
 		return err
 	}
+
 	// record the fieldStart value for this section.
 	v.fieldAddrs[uint16(fieldID)] = fieldStart
 	return nil
@@ -378,6 +382,7 @@ func (v *vectorIndexOpaque) fastMergeIndexes(centroidIndex faissIndexIVF, dims, 
 		}
 		nvecs += vecCount
 	}
+
 	nprobe, nlist := centroidIndex.ivfParams()
 	// set a custom nlist value in the config for the merged index,
 	//  which is same as the centroid index's nlist.
@@ -388,6 +393,7 @@ func (v *vectorIndexOpaque) fastMergeIndexes(centroidIndex faissIndexIVF, dims, 
 		return err
 	}
 	defer faissIndex.close()
+
 	// cast to IVF index to be able to set the quantizer for the fast merge
 	ivfIdx := faissIndex.castIVF()
 	if ivfIdx == nil {
@@ -400,9 +406,6 @@ func (v *vectorIndexOpaque) fastMergeIndexes(centroidIndex faissIndexIVF, dims, 
 	// setting the same nprobe value in the merged index as the centroid
 	// index to ensure that we probe the same number of clusters
 	ivfIdx.setNProbe(int32(nprobe))
-	// reconstruction will be needed for the smaller indexes that are not
-	// eligible for fast merge, so we prepare a buffer for that.
-	reconsVecs := make([]float32, 0, reconsCap)
 	// The centroid index will be an IVFSQ8 index - but with no vectors in it.
 	// The coarse quantizer of that index will be cloned over here
 	err = ivfIdx.setQuantizers(centroidIndex)
@@ -410,6 +413,9 @@ func (v *vectorIndexOpaque) fastMergeIndexes(centroidIndex faissIndexIVF, dims, 
 		return err
 	}
 
+	// reconstruction will be needed for the smaller indexes that are not
+	// eligible for fast merge, so we prepare a buffer for that.
+	reconsVecs := make([]float32, 0, reconsCap)
 	for i := 0; i < len(vecIndexes); i++ {
 		if isClosed(closeCh) {
 			return seg.ErrClosed
@@ -466,6 +472,7 @@ func (v *vectorIndexOpaque) mergeAndWriteVectorIndexes(centroidIndex faissIndexI
 	var indexOptimizedFor string
 	var indexType faissIndexType
 	var validMerge bool
+
 	for segI, segBase := range sbs {
 		// Considering merge operations on vector indexes are expensive, it is
 		// worth including an early exit if the merge is aborted, saving us
@@ -481,6 +488,7 @@ func (v *vectorIndexOpaque) mergeAndWriteVectorIndexes(centroidIndex faissIndexI
 		if currNumVecs == 0 {
 			continue
 		}
+
 		// read the serialized index bytes
 		indexBytes, err := segBase.fileReader.process(segBase.mem[currVecIndex.startOffset : currVecIndex.startOffset+int(currVecIndex.indexSize)])
 		if err != nil {
@@ -497,6 +505,7 @@ func (v *vectorIndexOpaque) mergeAndWriteVectorIndexes(centroidIndex faissIndexI
 			freeReconstructedIndexes(vecIndexes)
 			return err
 		}
+
 		// set the dims and metric values from the constructed index.
 		dims = faissIndex.D()
 		// at least one valid index to be merged, mark the merge as valid.
@@ -510,6 +519,7 @@ func (v *vectorIndexOpaque) mergeAndWriteVectorIndexes(centroidIndex faissIndexI
 			reconsCap = indexReconsLen
 		}
 		indexDataCap += indexReconsLen
+
 		// track the reconstruct index for this vector index, which will be used
 		// to reconstruct the vectors corresponding to the valid vector IDs for this index.
 		fIndex, err := newFaissFloat32Index(faissIndex)
@@ -536,7 +546,6 @@ func (v *vectorIndexOpaque) mergeAndWriteVectorIndexes(centroidIndex faissIndexI
 				freeReconstructedIndexes(vecIndexes)
 				return err
 			}
-
 			vecIndexes[segI].index, err = newFaissBinaryIndex(binaryIndex, faissIndex)
 			if err != nil {
 				freeReconstructedIndexes(vecIndexes)
@@ -545,6 +554,7 @@ func (v *vectorIndexOpaque) mergeAndWriteVectorIndexes(centroidIndex faissIndexI
 		}
 		nvecs += currNumVecs
 	}
+
 	// not a valid merge operation as there are no valid indexes to merge.
 	if !validMerge {
 		return nil
@@ -556,6 +566,7 @@ func (v *vectorIndexOpaque) mergeAndWriteVectorIndexes(centroidIndex faissIndexI
 		freeReconstructedIndexes(vecIndexes)
 		return nil
 	}
+
 	// Fast Merge Path:
 	// fast merge only applicable for:
 	// - IVFSQ8 indexes beyond a certain size threshold.
@@ -572,6 +583,7 @@ func (v *vectorIndexOpaque) mergeAndWriteVectorIndexes(centroidIndex faissIndexI
 		freeReconstructedIndexes(vecIndexes)
 		return nil
 	}
+
 	// Reconstruct Merge Path:
 	// merging of indexes with reconstruction method.
 	// the vecIds in each index contain only the valid vectors,
@@ -600,6 +612,7 @@ func (v *vectorIndexOpaque) mergeAndWriteVectorIndexes(centroidIndex faissIndexI
 			indexData = append(indexData, recons...)
 		}
 	}
+
 	// freeing the reconstructed indexes immediately - waiting till the end
 	// to do the same is not needed because the following operations don't need
 	// the reconstructed ones anymore and doing so will hold up memory which can
@@ -612,14 +625,12 @@ func (v *vectorIndexOpaque) mergeAndWriteVectorIndexes(centroidIndex faissIndexI
 	if err != nil {
 		return err
 	}
-	err = v.writeFaissIndex(vecSet, config, w)
-	if err != nil {
-		return err
-	}
-	return err
+
+	return v.writeFaissIndex(vecSet, config, w)
 }
 
-// returns the serialized faiss index for the given vector data and index config.
+// constructs a faiss on the vectors according to the provided config and writes it out
+// the given writer
 func (v *vectorIndexOpaque) writeFaissIndex(vecs *vectorSet, config *faissIndexConfig, w *FileWriter) error {
 	// create the faiss index based on the provided description string, and the metric type.
 	index, err := faissIndexFactory(config)
@@ -781,11 +792,13 @@ func (vo *vectorIndexOpaque) writeVectorIndexes(w *FileWriter) error {
 			// use the same FAISS metric for inner product and cosine similarity
 			metric = faiss.MetricInnerProduct
 		}
+
 		// create a vector set wrapping the vector data
 		vecSet, err := newVectorSet(content.dimension, content.vectors)
 		if err != nil {
 			return err
 		}
+
 		// record the fieldStart value for this section.
 		fieldStart := w.Count()
 		// writing out two offset values to indicate that the current field's
@@ -800,6 +813,7 @@ func (vo *vectorIndexOpaque) writeVectorIndexes(w *FileWriter) error {
 		if err != nil {
 			return err
 		}
+
 		// write the index optimization type
 		n = binary.PutUvarint(tempBuf, uint64(index.SupportedVectorIndexOptimizations[content.optimizedFor]))
 		_, err = w.Write(tempBuf[:n])
@@ -812,6 +826,7 @@ func (vo *vectorIndexOpaque) writeVectorIndexes(w *FileWriter) error {
 		if err != nil {
 			return err
 		}
+
 		buf := make([]byte, binary.MaxVarintLen64*len(content.vecDocIDs))
 		bufPos := 0
 		for _, docID := range content.vecDocIDs {
@@ -831,16 +846,17 @@ func (vo *vectorIndexOpaque) writeVectorIndexes(w *FileWriter) error {
 		if err != nil {
 			return err
 		}
-		// determine the type of vector index to be created based on the index optimization
-		indexType := determineIndexTypeFromOptimization(content.optimizedFor)
 
-		// create the faiss float32 index for the vectors associated with this field and get the
-		// serialized index bytes to be written out to the segment.
+		// determine the type of vector index to be created based on the index optimization
+		// and create the faiss index for the vectors associated with this field and
+		// write out the index into the segment writer.
+		indexType := determineIndexTypeFromOptimization(content.optimizedFor)
 		config := newFaissIndexConfig(indexType, content.optimizedFor, content.dimension, metric, nvecs, determineCentroids(nvecs), false)
 		err = vo.writeFaissIndex(vecSet, config, w)
 		if err != nil {
 			return err
 		}
+
 		// accounts for whatever data has been written out to the writer.
 		vo.incrementBytesWritten(uint64(w.Count() - fieldStart))
 		vo.fieldAddrs[fieldID] = fieldStart

--- a/section_faiss_vector_index.go
+++ b/section_faiss_vector_index.go
@@ -359,7 +359,9 @@ func (v *vectorIndexOpaque) fastMergeIndexes(centroidIndex faissIndexIVF, dims, 
 		vecCount := len(vecIndexes[i].vecIds)
 		if vecCount == 0 {
 			continue
-		} else if vecIndexes[i].indexOptimizedFor == index.IndexIVFRaBitQ || vecCount >= ivfSq8Threshold {
+		} else if (vecIndexes[i].indexOptimizedFor == index.IndexIVFRaBitQ &&
+			vecIndexes[i].index.castIVF() != nil) ||
+			vecCount >= ivfSq8Threshold {
 			// merging only the large indexes (IVFSQ8 family)
 			// all IVF<same class> indexes are eligible for merging
 			//
@@ -558,7 +560,10 @@ func (v *vectorIndexOpaque) mergeAndWriteVectorIndexes(centroidIndex faissIndexI
 	// fast merge only applicable for:
 	// - IVFSQ8 indexes beyond a certain size threshold.
 	// - the centroid index is available.
-	if nvecs >= ivfSq8Threshold && centroidIndex != nil && indexType == faissFP32Index {
+	// - RabitQ optimization
+	if centroidIndex != nil &&
+		(indexOptimizedFor == index.IndexIVFRaBitQ ||
+			(nvecs >= ivfSq8Threshold && indexType == faissFP32Index)) {
 		err := v.fastMergeIndexes(centroidIndex, dims, metric, indexType, indexOptimizedFor, vecIndexes, w, closeCh)
 		if err != nil {
 			return err

--- a/section_faiss_vector_index.go
+++ b/section_faiss_vector_index.go
@@ -145,24 +145,28 @@ func (v *faissVectorIndexSection) Merge(opaque map[int]resetable, segments []*Se
 			if pos == 0 {
 				continue
 			}
+
 			// loading doc values - adhering to the sections format. never
 			// valid values for vector section
 			_, n := binary.Uvarint(sb.mem[pos : pos+binary.MaxVarintLen64])
 			pos += n
 			_, n = binary.Uvarint(sb.mem[pos : pos+binary.MaxVarintLen64])
 			pos += n
+
 			// read the vector index optimization type represented as an int
 			indexOptimizationTypeInt, n := binary.Uvarint(sb.mem[pos : pos+binary.MaxVarintLen64])
 			pos += n
 			// read the number of vectors
 			numVecs, n := binary.Uvarint(sb.mem[pos : pos+binary.MaxVarintLen64])
 			pos += n
+
 			// track the valid vectors to be reconstructed for this segment
 			// during the merge operation.
 			newIndexInfo := &vecIndexInfo{
 				indexOptimizedFor: index.VectorIndexOptimizationsReverseLookup[int(indexOptimizationTypeInt)],
 				vecIds:            make([]int64, 0, numVecs),
 			}
+
 			// read the length of the docID list
 			listLen, n := binary.Uvarint(sb.mem[pos : pos+binary.MaxVarintLen64])
 			pos += n
@@ -171,6 +175,7 @@ func (v *faissVectorIndexSection) Merge(opaque map[int]resetable, segments []*Se
 				return err
 			}
 			pos += int(listLen)
+
 			bufPos := 0
 			bufLen := len(buf)
 			for vecID := 0; vecID < int(numVecs); vecID++ {
@@ -192,10 +197,12 @@ func (v *faissVectorIndexSection) Merge(opaque map[int]resetable, segments []*Se
 					noDrops = false
 				}
 			}
+
 			if len(newIndexInfo.vecIds) == 0 {
 				// no valid vectors to be merged from this segment
 				continue
 			}
+
 			// read the type of vector index
 			indexType, n := binary.Uvarint(sb.mem[pos : pos+binary.MaxVarintLen64])
 			pos += n
@@ -215,10 +222,12 @@ func (v *faissVectorIndexSection) Merge(opaque map[int]resetable, segments []*Se
 		if len(indexes) == 0 || len(vecToDocID) == 0 {
 			continue
 		}
+
 		err := vo.flushSectionMetadata(fieldID, w, vecToDocID, indexes)
 		if err != nil {
 			return err
 		}
+
 		var centroidIndex faissIndexIVF
 		if noDrops {
 			centroidIndex, err = centroidIndexFromConfig(vo.config, fieldName)
@@ -261,6 +270,7 @@ func centroidIndexFromConfig(config map[string]interface{}, fieldName string) (f
 	if rv == nil {
 		return nil, nil
 	}
+
 	faissIndex, err := newFaissFloat32Index(rv)
 	if err != nil {
 		return nil, err
@@ -349,7 +359,7 @@ func (v *vectorIndexOpaque) fastMergeIndexes(centroidIndex faissIndexIVF, dims, 
 		vecCount := len(vecIndexes[i].vecIds)
 		if vecCount == 0 {
 			continue
-		} else if vecCount >= ivfSq8Threshold {
+		} else if vecIndexes[i].indexOptimizedFor == index.IndexIVFRaBitQ || vecCount >= ivfSq8Threshold {
 			// merging only the large indexes (IVFSQ8 family)
 			// all IVF<same class> indexes are eligible for merging
 			//
@@ -397,6 +407,7 @@ func (v *vectorIndexOpaque) fastMergeIndexes(centroidIndex faissIndexIVF, dims, 
 	if err != nil {
 		return err
 	}
+
 	for i := 0; i < len(vecIndexes); i++ {
 		if isClosed(closeCh) {
 			return seg.ErrClosed
@@ -433,12 +444,7 @@ func (v *vectorIndexOpaque) fastMergeIndexes(centroidIndex faissIndexIVF, dims, 
 			}
 		}
 	}
-	// serialize the merged index into a byte slice, and write it out
-	indexBytes, err := faissIndex.serialize()
-	if err != nil {
-		return err
-	}
-	indexBytes = w.process(indexBytes)
+
 	tempBuf := v.grabBuf(binary.MaxVarintLen64)
 	// write the type of the vector index
 	n := binary.PutUvarint(tempBuf, uint64(indexType))
@@ -446,15 +452,8 @@ func (v *vectorIndexOpaque) fastMergeIndexes(centroidIndex faissIndexIVF, dims, 
 	if err != nil {
 		return err
 	}
-	// write the length of the serialized vector index bytes
-	n = binary.PutUvarint(tempBuf, uint64(len(indexBytes)))
-	_, err = w.Write(tempBuf[:n])
-	if err != nil {
-		return err
-	}
-	// write the vector index data
-	_, err = w.Write(indexBytes)
-	return err
+
+	return faissIndex.write(tempBuf, w)
 }
 
 func (v *vectorIndexOpaque) mergeAndWriteVectorIndexes(centroidIndex faissIndexIVF, sbs []*SegmentBase,
@@ -517,6 +516,31 @@ func (v *vectorIndexOpaque) mergeAndWriteVectorIndexes(centroidIndex faissIndexI
 			return err
 		}
 		vecIndexes[segI].index = fIndex
+
+		// load binary index from disk if present
+		if currVecIndex.indexType == faissBIVFIndex {
+			// get to the bivf part of the vector index section
+			pos := currVecIndex.startOffset + int(currVecIndex.indexSize)
+			binSize, n := binary.Uvarint(segBase.mem[pos : pos+binary.MaxVarintLen64])
+			pos += n
+			indexBytes, err = segBase.fileReader.process(segBase.mem[pos : pos+int(binSize)])
+			if err != nil {
+				freeReconstructedIndexes(vecIndexes)
+				return err
+			}
+
+			binaryIndex, err := faiss.ReadBinaryIndexFromBuffer(indexBytes, ioFlags)
+			if err != nil {
+				freeReconstructedIndexes(vecIndexes)
+				return err
+			}
+
+			vecIndexes[segI].index, err = newFaissBinaryIndex(binaryIndex, faissIndex)
+			if err != nil {
+				freeReconstructedIndexes(vecIndexes)
+				return err
+			}
+		}
 		nvecs += currNumVecs
 	}
 	// not a valid merge operation as there are no valid indexes to merge.
@@ -531,11 +555,9 @@ func (v *vectorIndexOpaque) mergeAndWriteVectorIndexes(centroidIndex faissIndexI
 		return nil
 	}
 	// Fast Merge Path:
-	// hardcoded - refactor later
 	// fast merge only applicable for:
 	// - IVFSQ8 indexes beyond a certain size threshold.
 	// - the centroid index is available.
-	// - the index type is faissFP32Index.
 	if nvecs >= ivfSq8Threshold && centroidIndex != nil && indexType == faissFP32Index {
 		err := v.fastMergeIndexes(centroidIndex, dims, metric, indexType, indexOptimizedFor, vecIndexes, w, closeCh)
 		if err != nil {
@@ -580,68 +602,32 @@ func (v *vectorIndexOpaque) mergeAndWriteVectorIndexes(centroidIndex faissIndexI
 	freeReconstructedIndexes(vecIndexes)
 	// create the faiss index to hold the merged data, and add the
 	// reconstructed vectors into it.
-	config := newFaissIndexConfig(faissFP32Index, indexOptimizedFor, dims, metric, nvecs, determineCentroids(nvecs), useGPU)
+	config := newFaissIndexConfig(indexType, indexOptimizedFor, dims, metric, nvecs, determineCentroids(nvecs), useGPU)
 	vecSet, err := newVectorSet(dims, indexData)
 	if err != nil {
 		return err
 	}
-	fIndexBytes, err := makeFaissIndex(vecSet, config, w)
+	err = v.writeFaissIndex(vecSet, config, w)
 	if err != nil {
 		return err
-	}
-
-	// get a temporary buffer for writing out the index
-	tempBuf := v.grabBuf(binary.MaxVarintLen64)
-	// write the type of the vector index
-	n := binary.PutUvarint(tempBuf, uint64(indexType))
-	_, err = w.Write(tempBuf[:n])
-	if err != nil {
-		return err
-	}
-	// write the length of the serialized vector index bytes
-	n = binary.PutUvarint(tempBuf, uint64(len(fIndexBytes)))
-	_, err = w.Write(tempBuf[:n])
-	if err != nil {
-		return err
-	}
-	// write the vector index data
-	_, err = w.Write(fIndexBytes)
-	if err != nil {
-		return err
-	}
-	if indexType == faissBIVFIndex {
-		// create the binary index to hold the merged data, and
-		// add the reconstructed vectors into it.
-		vecSet.binarize()
-		config := newFaissIndexConfig(faissBIVFIndex, indexOptimizedFor, dims, metric, nvecs, determineCentroids(nvecs), false)
-		bIndexBytes, err := makeFaissIndex(vecSet, config, w)
-		if err != nil {
-			return err
-		}
-		// write the length of the serialized binary vector index bytes
-		n = binary.PutUvarint(tempBuf, uint64(len(bIndexBytes)))
-		_, err = w.Write(tempBuf[:n])
-		if err != nil {
-			return err
-		}
-		// write the binary vector index data
-		_, err = w.Write(bIndexBytes)
-		if err != nil {
-			return err
-		}
 	}
 	return err
 }
 
 // returns the serialized faiss index for the given vector data and index config.
-func makeFaissIndex(vecs *vectorSet, config *faissIndexConfig, w *FileWriter) ([]byte, error) {
+func (v *vectorIndexOpaque) writeFaissIndex(vecs *vectorSet, config *faissIndexConfig, w *FileWriter) error {
 	// create the faiss index based on the provided description string, and the metric type.
 	index, err := faissIndexFactory(config)
 	if err != nil {
-		return nil, err
+		return err
 	}
 	// ensure the faiss index is closed after use
 	defer index.close()
+
+	// binarize the vectors for BIVF indexes
+	if config.indexType == faissBIVFIndex {
+		vecs.binarize()
+	}
 	// if we are using an IVF index, train and add first, then set the direct map
 	// and nprobe. The order matters for GPU indexes: CloneToCPU (done inside
 	// trainAndAdd) clears the direct map and nprobe, so they must be set after.
@@ -651,7 +637,7 @@ func makeFaissIndex(vecs *vectorSet, config *faissIndexConfig, w *FileWriter) ([
 		// search time we probe only a subset of vectors (non-exhaustive search).
 		err = ivfIndex.trainAndAdd(vecs, vecs)
 		if err != nil {
-			return nil, err
+			return err
 		}
 		// the direct map maintained in the IVF index is essential for the
 		// reconstruction of vectors based on the sequential vector IDs in the
@@ -659,30 +645,36 @@ func makeFaissIndex(vecs *vectorSet, config *faissIndexConfig, w *FileWriter) ([
 		// we have sequential vector IDs starting from 0 to N-1.
 		err = ivfIndex.setDirectMap(1)
 		if err != nil {
-			return nil, err
+			return err
 		}
 		// calculate nprobe using a heuristic.
 		nprobe := calculateNprobe(config.nlist, config.optimizationType)
 		ivfIndex.setNProbe(nprobe)
-	} else if sqIndex := index.castSQ(); sqIndex != nil {
-		err = sqIndex.trainAndAdd(vecs, vecs)
-		if err != nil {
-			return nil, err
-		}
 	} else {
+		// add the vectors to the index using sequential vector IDs starting
+		// from 0 to N-1
 		err = index.add(vecs)
 		if err != nil {
-			return nil, err
+			return err
 		}
 	}
-	// serialize the merged index into a byte slice, and write it out
-	indexBytes, err := index.serialize()
+
+	// get a temporary buffer for writing out the index
+	tempBuf := v.grabBuf(binary.MaxVarintLen64)
+	// write the type of the vector index
+	n := binary.PutUvarint(tempBuf, uint64(config.indexType))
+	_, err = w.Write(tempBuf[:n])
 	if err != nil {
-		return nil, err
+		return err
 	}
-	// process the index bytes before writing out
-	indexBytes = w.process(indexBytes)
-	return indexBytes, nil
+
+	// serialize the merged index into a byte slice, and write it out
+	err = index.write(tempBuf, w)
+	if err != nil {
+		return err
+	}
+
+	return nil
 }
 
 // returns the index description string and index type constant for the binary
@@ -789,13 +781,6 @@ func (vo *vectorIndexOpaque) writeVectorIndexes(w *FileWriter) error {
 		if err != nil {
 			return err
 		}
-		// create the faiss float32 index for the vectors associated with this field and get the
-		// serialized index bytes to be written out to the segment.
-		config := newFaissIndexConfig(faissFP32Index, content.optimizedFor, content.dimension, metric, nvecs, determineCentroids(nvecs), content.useGPU)
-		fIndexBytes, err := makeFaissIndex(vecSet, config, w)
-		if err != nil {
-			return err
-		}
 		// record the fieldStart value for this section.
 		fieldStart := w.Count()
 		// writing out two offset values to indicate that the current field's
@@ -843,46 +828,13 @@ func (vo *vectorIndexOpaque) writeVectorIndexes(w *FileWriter) error {
 		}
 		// determine the type of vector index to be created based on the index optimization
 		indexType := determineIndexTypeFromOptimization(content.optimizedFor)
-		// write the type of the vector index
-		n = binary.PutUvarint(tempBuf, uint64(indexType))
-		_, err = w.Write(tempBuf[:n])
-		if err != nil {
-			return err
-		}
 
-		fIndexBytes = w.process(fIndexBytes)
-		// write the length of the serialized vector index bytes
-		n = binary.PutUvarint(tempBuf, uint64(len(fIndexBytes)))
-		_, err = w.Write(tempBuf[:n])
+		// create the faiss float32 index for the vectors associated with this field and get the
+		// serialized index bytes to be written out to the segment.
+		config := newFaissIndexConfig(indexType, content.optimizedFor, content.dimension, metric, nvecs, determineCentroids(nvecs), false)
+		err = vo.writeFaissIndex(vecSet, config, w)
 		if err != nil {
 			return err
-		}
-		// write the vector index data
-		_, err = w.Write(fIndexBytes)
-		if err != nil {
-			return err
-		}
-		if indexType == faissBIVFIndex {
-			// if the index type to be created requires a binary index,
-			// binarize the vector data in the vector set.
-			vecSet.binarize()
-			// bivf config
-			config := newFaissIndexConfig(faissBIVFIndex, content.optimizedFor, content.dimension, metric, nvecs, determineCentroids(nvecs), false)
-			bIndexBytes, err := makeFaissIndex(vecSet, config, w)
-			if err != nil {
-				return err
-			}
-			// write the length of the serialized binary vector index bytes
-			n = binary.PutUvarint(tempBuf, uint64(len(bIndexBytes)))
-			_, err = w.Write(tempBuf[:n])
-			if err != nil {
-				return err
-			}
-			// write the binary vector index data
-			_, err = w.Write(bIndexBytes)
-			if err != nil {
-				return err
-			}
 		}
 		// accounts for whatever data has been written out to the writer.
 		vo.incrementBytesWritten(uint64(w.Count() - fieldStart))
@@ -1057,13 +1009,17 @@ func faissIndexFactory(cfg *faissIndexConfig) (faissIndex, error) {
 		return newFaissFloat32Index(idx)
 	case faissBIVFIndex:
 		description := determineBinaryIndexToUse(cfg.numVecs, cfg.nlist)
-		idx, err := faiss.BinaryIndexFactory(cfg.dimension, description)
+		binaryIdx, err := faiss.BinaryIndexFactory(cfg.dimension, description)
 		if err != nil {
 			return nil, err
 		}
-		// set no backing index on purpose as we use the factory in the
-		// indexing path, where each index is handled independently
-		return newFaissBinaryIndex(idx, nil)
+
+		description = determineFloat32IndexToUse(cfg.numVecs, cfg.nlist, cfg.optimizationType)
+		backingIdx, err := faiss.IndexFactory(cfg.dimension, description, cfg.metricType)
+		if err != nil {
+			return nil, err
+		}
+		return newFaissBinaryIndex(binaryIdx, backingIdx)
 	default:
 		return nil, errNotSupported
 	}


### PR DESCRIPTION
- update the faissBinaryIndex to remove redundant code from the section_faiss_vector_index.go and perform the operations in a more modular manner.
- update the faissIndex interface to have a write API so that along with serialization it'll write out the content to the FileWriter in a format it's designed for
- when RabitQ is enabled, all faiss indexes having vector count > 1000 have the same quantization check. so the fastmerge condition check is updated to account this as well