### PR TITLE
Address panic observed while operating with file callbacks

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -14,7 +14,7 @@ jobs:
   test:
     strategy:
       matrix:
-        go-version: [1.23.x, 1.24.x, 1.25.x]
+        go-version: [1.24.x, 1.25.x, 1.26.x]
         platform: [ubuntu-latest, macos-latest, windows-latest]
     runs-on: ${{ matrix.platform }}
     steps:

--- a/build.go
+++ b/build.go
@@ -54,7 +54,9 @@ func PersistSegmentBase(sb *SegmentBase, path string) error {
 		return err
 	}
 	if writer.id != sb.fileReader.id {
-		// rewrite the segment base with the latest writer callback
+		// rewrite the segment base with the latest writer callback;
+		// the rewrite will persist the segment to the given path (upon
+		// success), so we should return early to avoid overwriting again.
 		return rewriteSegmentBase(sb, path)
 	}
 

--- a/build.go
+++ b/build.go
@@ -55,10 +55,7 @@ func PersistSegmentBase(sb *SegmentBase, path string) error {
 	}
 	if writer.id != sb.fileReader.id {
 		// rewrite the segment base with the latest writer callback
-		err = rewriteSegmentBase(sb, path)
-		if err != nil {
-			return err
-		}
+		return rewriteSegmentBase(sb, path)
 	}
 
 	flag := os.O_RDWR | os.O_CREATE

--- a/file_callbacks_test.go
+++ b/file_callbacks_test.go
@@ -12,9 +12,6 @@
 // implied.  See the License for the specific language governing
 // permissions and limitations under the License.
 
-//go:build vectors
-// +build vectors
-
 package zap
 
 import (
@@ -148,11 +145,6 @@ func TestFileCallbacks(t *testing.T) {
 	TestDictionaryBug1156(t)
 
 	TestEnumerator(t)
-
-	TestVecPostingsIterator(t)
-	TestVectorSegment(t)
-	TestPersistedVectorSegment(t)
-	TestValidVectorMerge(t)
 
 	TestChunkIntCoder(t)
 	TestChunkLengthToOffsets(t)

--- a/file_callbacks_vectors_test.go
+++ b/file_callbacks_vectors_test.go
@@ -17,8 +17,8 @@
 
 package zap
 
-import(
-    "testing"
+import (
+	"testing"
 )
 
 // Initializes encryption related file callbacks and

--- a/file_callbacks_vectors_test.go
+++ b/file_callbacks_vectors_test.go
@@ -1,0 +1,33 @@
+//  Copyright (c) 2026 Couchbase, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// 		http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied.  See the License for the specific language governing
+// permissions and limitations under the License.
+
+//go:build vectors
+// +build vectors
+
+package zap
+
+import(
+    "testing"
+)
+
+// Initializes encryption related file callbacks and
+// runs all file I/O related tests
+func TestFileCallbacksVectors(t *testing.T) {
+	initFileCallbacks(t)
+
+	TestVecPostingsIterator(t)
+	TestVectorSegment(t)
+	TestPersistedVectorSegment(t)
+	TestValidVectorMerge(t)
+}

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/blevesearch/zapx/v17
 
-go 1.24.0
+go 1.25.0
 
 require (
 	github.com/RoaringBitmap/roaring/v2 v2.14.5


### PR DESCRIPTION
+ Separating vector tests out of the original file, to run unrelated tests in non-vectors mode.
+ Update github workflows for newer versions of GO.
+ Panic stack trace ..

```
--- FAIL: TestFileCallbacks (0.01s)
panic: runtime error: slice bounds out of range [18446744073709551611:3] [recovered, repanicked]

goroutine 35 [running]:
testing.tRunner.func1.2({0x10041d8c0, 0x14000018780})
	/opt/homebrew/Cellar/go/1.25.6/libexec/src/testing/testing.go:1872 +0x190
testing.tRunner.func1()
	/opt/homebrew/Cellar/go/1.25.6/libexec/src/testing/testing.go:1875 +0x31c
panic({0x10041d8c0?, 0x14000018780?})
	/opt/homebrew/Cellar/go/1.25.6/libexec/src/runtime/panic.go:783 +0x120
github.com/blevesearch/zapx/v17.(*SegmentBase).loadFieldDocValueReader(0x60?, {0x140002fe763?, 0x5?}, 0x5, 0x140000e5ba8?)
	/Users/abhinav.dangeti/Documents/go/src/github.com/blevesearch/zapx/docvalues.go:123 +0x3b0
github.com/blevesearch/zapx/v17.(*SegmentBase).loadDvReaders(0x14000000140)
	/Users/abhinav.dangeti/Documents/go/src/github.com/blevesearch/zapx/segment.go:835 +0x2d0
github.com/blevesearch/zapx/v17.(*ZapPlugin).open(0x1400015e100?, {0x14000404a40, 0x3b}, 0x0)
	/Users/abhinav.dangeti/Documents/go/src/github.com/blevesearch/zapx/segment.go:94 +0x26c
github.com/blevesearch/zapx/v17.(*ZapPlugin).Open(...)
	/Users/abhinav.dangeti/Documents/go/src/github.com/blevesearch/zapx/segment.go:49
github.com/blevesearch/zapx/v17.TestOpen(0x14000161a40)
	/Users/abhinav.dangeti/Documents/go/src/github.com/blevesearch/zapx/segment_test.go:40 +0xac
github.com/blevesearch/zapx/v17.TestFileCallbacks(0x14000161a40)
	/Users/abhinav.dangeti/Documents/go/src/github.com/blevesearch/zapx/file_callbacks_test.go:133 +0x28
testing.tRunner(0x14000161a40, 0x100434ea8)
	/opt/homebrew/Cellar/go/1.25.6/libexec/src/testing/testing.go:1934 +0xc8
created by testing.(*T).Run in goroutine 1
	/opt/homebrew/Cellar/go/1.25.6/libexec/src/testing/testing.go:1997 +0x364
```