### PR TITLE
MB-71796: Fix crash when using GPU Index Class

### DIFF
--- a/centroid_index.go
+++ b/centroid_index.go
@@ -21,6 +21,7 @@ import (
 	"encoding/binary"
 	"fmt"
 
+	index "github.com/blevesearch/bleve_index_api"
 	faiss "github.com/blevesearch/go-faiss"
 )
 
@@ -36,47 +37,52 @@ func (sb *SegmentBase) GetCoarseQuantizer(field string) (interface{}, error) {
 		return nil, fmt.Errorf("field %s does not have a vector section in the segment", field)
 	}
 
-	pos := int(vectorSection)
-	// doc values and vector optimization type
-	for i := 0; i < 3; i++ {
+	pos := vectorSection
+	// doc values
+	for i := 0; i < 2; i++ {
 		_, n := binary.Uvarint(sb.mem[pos : pos+binary.MaxVarintLen64])
-		pos += n
+		pos += uint64(n)
 	}
+	// read the index optimization type
+	opt, n := binary.Uvarint(sb.mem[pos : pos+binary.MaxVarintLen64])
+	pos += uint64(n)
+	// get the optimization type string from the reverse lookup map
+	optStr := index.VectorIndexOptimizationsReverseLookup[int(opt)]
 
 	numVecs, n := binary.Uvarint(sb.mem[pos : pos+binary.MaxVarintLen64])
-	pos += n
+	pos += uint64(n)
 
 	// length of the vector to docID map
 	_, n = binary.Uvarint(sb.mem[pos : pos+binary.MaxVarintLen64])
-	pos += n
+	pos += uint64(n)
 
 	// vector to docID mapping
 	for i := 0; i < int(numVecs); i++ {
 		_, n = binary.Uvarint(sb.mem[pos : pos+binary.MaxVarintLen64])
-		pos += n
+		pos += uint64(n)
 	}
 
 	// type of index
 	indexType, n := binary.Uvarint(sb.mem[pos : pos+binary.MaxVarintLen64])
-	pos += n
+	pos += uint64(n)
 	indexSize, n := binary.Uvarint(sb.mem[pos : pos+binary.MaxVarintLen64])
-	pos += n
+	pos += uint64(n)
 
 	// todo: might wanna use the vector cache here, early tests didn't show a big diff
-	faissIndex, err := faiss.ReadIndexFromBuffer(sb.mem[pos:pos+int(indexSize)], faissIOFlags)
+	faissIndex, err := faiss.ReadIndexFromBuffer(sb.mem[pos:pos+indexSize], faissIOFlags)
 	if err != nil {
 		return nil, err
 	}
-	pos += int(indexSize)
+	pos += indexSize
 
 	if faissIndexType(indexType) == faissBIVFIndex {
 		binaryIndexSize, n := binary.Uvarint(sb.mem[pos : pos+binary.MaxVarintLen64])
-		pos += n
-		binaryIndex, err := faiss.ReadBinaryIndexFromBuffer(sb.mem[pos:pos+int(binaryIndexSize)], faissIOFlags)
+		pos += uint64(n)
+		binaryIndex, err := faiss.ReadBinaryIndexFromBuffer(sb.mem[pos:pos+binaryIndexSize], faissIOFlags)
 		if err != nil {
 			return nil, err
 		}
-		return newFaissBinaryIndex(binaryIndex, faissIndex)
+		return newFaissBinaryIndex(binaryIndex, faissIndex, optStr)
 	}
-	return newFaissFloat32Index(faissIndex)
+	return newFaissFloat32Index(faissIndex, optStr)
 }

--- a/centroid_index.go
+++ b/centroid_index.go
@@ -75,6 +75,7 @@ func (sb *SegmentBase) GetCoarseQuantizer(field string) (interface{}, error) {
 	}
 	pos += indexSize
 
+	cfg := newFaissIndexParams(optStr, int(numVecs))
 	if faissIndexType(indexType) == faissBIVFIndex {
 		binaryIndexSize, n := binary.Uvarint(sb.mem[pos : pos+binary.MaxVarintLen64])
 		pos += uint64(n)
@@ -82,7 +83,7 @@ func (sb *SegmentBase) GetCoarseQuantizer(field string) (interface{}, error) {
 		if err != nil {
 			return nil, err
 		}
-		return newFaissBinaryIndex(binaryIndex, faissIndex, optStr)
+		return newFaissBinaryIndex(binaryIndex, faissIndex, cfg)
 	}
-	return newFaissFloat32Index(faissIndex, optStr)
+	return newFaissFloat32Index(faissIndex, cfg)
 }

--- a/centroid_index.go
+++ b/centroid_index.go
@@ -75,7 +75,7 @@ func (sb *SegmentBase) GetCoarseQuantizer(field string) (interface{}, error) {
 	}
 	pos += indexSize
 
-	cfg := newFaissIndexParams(optStr, int(numVecs))
+	params := newFaissIndexParams(optStr, int(numVecs))
 	if faissIndexType(indexType) == faissBIVFIndex {
 		binaryIndexSize, n := binary.Uvarint(sb.mem[pos : pos+binary.MaxVarintLen64])
 		pos += uint64(n)
@@ -83,7 +83,7 @@ func (sb *SegmentBase) GetCoarseQuantizer(field string) (interface{}, error) {
 		if err != nil {
 			return nil, err
 		}
-		return newFaissBinaryIndex(binaryIndex, faissIndex, cfg)
+		return newFaissBinaryIndex(binaryIndex, faissIndex, params)
 	}
-	return newFaissFloat32Index(faissIndex, cfg)
+	return newFaissFloat32Index(faissIndex, params)
 }

--- a/faiss_vector_cache.go
+++ b/faiss_vector_cache.go
@@ -65,7 +65,7 @@ func (vc *vectorIndexCache) Clear() {
 
 // loadOrCreate obtains the vector index from the cache or creates it if it's not present.
 // useGPU indicates whether the field mapping requires GPU acceleration for this index.
-func (vc *vectorIndexCache) loadOrCreate(fieldID uint16, mem []byte, numDocs uint32, except *roaring.Bitmap, useGPU bool, r *FileReader) (
+func (vc *vectorIndexCache) loadOrCreate(fieldID uint16, mem []byte, numDocs uint32, except *roaring.Bitmap, useGPU bool, r *FileReader, optStr string) (
 	index faissIndex, mapping *idMapping, exclude *bitmap, err error) {
 	// first try to read from the cache with a read lock
 	vc.m.RLock()
@@ -93,12 +93,12 @@ func (vc *vectorIndexCache) loadOrCreate(fieldID uint16, mem []byte, numDocs uin
 		return entry.load(except)
 	}
 	// still not present, create and cache it
-	return vc.createAndCacheLOCKED(fieldID, mem, numDocs, except, useGPU, r)
+	return vc.createAndCacheLOCKED(fieldID, mem, numDocs, except, useGPU, r, optStr)
 }
 
 // Rebuilding the cache on a miss.
 func (vc *vectorIndexCache) createAndCacheLOCKED(fieldID uint16, mem []byte,
-	numDocs uint32, except *roaring.Bitmap, useGPU bool, r *FileReader) (index faissIndex,
+	numDocs uint32, except *roaring.Bitmap, useGPU bool, r *FileReader, optStr string) (index faissIndex,
 	mapping *idMapping, exclude *bitmap, err error) {
 	// if the cache doesn't have the entry, construct the vector to doc id map and
 	// the vector index out of the mem bytes and update the cache under lock.
@@ -176,15 +176,15 @@ func (vc *vectorIndexCache) createAndCacheLOCKED(fieldID uint16, mem []byte,
 			return nil, nil, nil, fmt.Errorf("faiss binary index load error: %v", err)
 		}
 		pos += int(binSize)
-		index, err = newFaissBinaryIndex(bIndex, fIndex)
+		index, err = newFaissBinaryIndex(bIndex, fIndex, optStr)
 		if err != nil {
 			return nil, nil, nil, fmt.Errorf("faiss binary index creation error: %v", err)
 		}
 	} else {
 		if useGPU {
-			index, err = newFaissGPUFloat32Index(fIndex)
+			index, err = newFaissGPUFloat32Index(fIndex, optStr)
 		} else {
-			index, err = newFaissFloat32Index(fIndex)
+			index, err = newFaissFloat32Index(fIndex, optStr)
 		}
 		if err != nil {
 			return nil, nil, nil, fmt.Errorf("faiss float32 index creation error: %v", err)

--- a/faiss_vector_cache.go
+++ b/faiss_vector_cache.go
@@ -182,7 +182,7 @@ func (vc *vectorIndexCache) createAndCacheLOCKED(fieldID uint16, mem []byte,
 		}
 	} else {
 		if useGPU {
-			index, err = newFaissGPUFloat32Index(fIndex, optStr)
+			index, err = newFaissGPUFloat32Index(fIndex, optStr, int(numVecs))
 		} else {
 			index, err = newFaissFloat32Index(fIndex, optStr)
 		}

--- a/faiss_vector_cache.go
+++ b/faiss_vector_cache.go
@@ -107,17 +107,20 @@ func (vc *vectorIndexCache) createAndCacheLOCKED(fieldID uint16, mem []byte,
 	if n <= 0 {
 		return nil, nil, nil, fmt.Errorf("could not read numVecs")
 	}
+	pos += n
+
 	// if no vectors or no documents, return empty cache entry
 	if numVecs == 0 || numDocs == 0 {
 		return nil, nil, nil, nil
 	}
-	pos += n
+
 	// read the length of the docID list
 	listLen, n := binary.Uvarint(mem[pos : pos+binary.MaxVarintLen64])
 	if n <= 0 {
 		return nil, nil, nil, fmt.Errorf("could not read docID list length")
 	}
 	pos += n
+
 	// read the entierity of the docID list through the file reader
 	buf, err := r.process(mem[pos : pos+int(listLen)])
 	if err != nil {
@@ -126,6 +129,7 @@ func (vc *vectorIndexCache) createAndCacheLOCKED(fieldID uint16, mem []byte,
 	pos += int(listLen)
 	bufPos := 0
 	bufLen := len(buf)
+
 	// create a mapping using the numVecs and numDocs
 	mapping = newIDMapping(uint32(numVecs), numDocs)
 	for vecID := uint32(0); vecID < uint32(numVecs); vecID++ {
@@ -136,12 +140,14 @@ func (vc *vectorIndexCache) createAndCacheLOCKED(fieldID uint16, mem []byte,
 		bufPos += n
 		mapping.add(vecID, uint32(docID))
 	}
+
 	// read the type of the vector index
 	indexType, n := binary.Uvarint(mem[pos : pos+binary.MaxVarintLen64])
 	if n <= 0 {
 		return nil, nil, nil, fmt.Errorf("could not read faiss index type")
 	}
 	pos += n
+
 	// read the faiss index size
 	indexSize, n := binary.Uvarint(mem[pos : pos+binary.MaxVarintLen64])
 	if n <= 0 {
@@ -161,6 +167,8 @@ func (vc *vectorIndexCache) createAndCacheLOCKED(fieldID uint16, mem []byte,
 		return nil, nil, nil, fmt.Errorf("faiss index load error: %v", err)
 	}
 	pos += int(indexSize)
+
+	params := newFaissIndexParams(optStr, int(numVecs))
 	if faissIndexType(indexType) == faissBIVFIndex {
 		// read the faiss binary index size
 		binSize, n := binary.Uvarint(mem[pos : pos+binary.MaxVarintLen64])
@@ -176,15 +184,15 @@ func (vc *vectorIndexCache) createAndCacheLOCKED(fieldID uint16, mem []byte,
 			return nil, nil, nil, fmt.Errorf("faiss binary index load error: %v", err)
 		}
 		pos += int(binSize)
-		index, err = newFaissBinaryIndex(bIndex, fIndex, optStr)
+		index, err = newFaissBinaryIndex(bIndex, fIndex, params)
 		if err != nil {
 			return nil, nil, nil, fmt.Errorf("faiss binary index creation error: %v", err)
 		}
 	} else {
 		if useGPU {
-			index, err = newFaissGPUFloat32Index(fIndex, optStr, int(numVecs))
+			index, err = newFaissGPUFloat32Index(fIndex, params)
 		} else {
-			index, err = newFaissFloat32Index(fIndex, optStr)
+			index, err = newFaissFloat32Index(fIndex, params)
 		}
 		if err != nil {
 			return nil, nil, nil, fmt.Errorf("faiss float32 index creation error: %v", err)

--- a/faiss_vector_index.go
+++ b/faiss_vector_index.go
@@ -25,9 +25,9 @@ import (
 )
 
 var (
-	errNilConfig    error = errors.New("faiss index config is nil")
-	errNilIndex     error = errors.New("faiss index is nil")
-	errNotSupported error = errors.New("operation not supported")
+	errInvalidOptimizationString error = errors.New("faiss index optimization string is invalid")
+	errNilIndex                  error = errors.New("faiss index is nil")
+	errNotSupported              error = errors.New("operation not supported")
 )
 
 // Abstract interface for Faiss vector indices, which are returned by the go-faiss library.

--- a/faiss_vector_index.go
+++ b/faiss_vector_index.go
@@ -25,10 +25,38 @@ import (
 )
 
 var (
-	errInvalidOptimizationString error = errors.New("faiss index optimization string is invalid")
-	errNilIndex                  error = errors.New("faiss index is nil")
-	errNotSupported              error = errors.New("operation not supported")
+	errNilIndex     error = errors.New("faiss index is nil")
+	errNilParams    error = errors.New("faiss index params is nil")
+	errNotSupported error = errors.New("operation not supported")
 )
+
+// -------------------------------------------
+// Parameters for constructing a Faiss index
+// -------------------------------------------
+// faissIndexParams holds the construction-time parameters required by a
+// faissIndex implementation that cannot be derived from the underlying
+// faiss index objects themselves (e.g. dimension and metric type are
+// already available on the faiss index).
+type faissIndexParams struct {
+	// optimization is the index optimization type string (e.g. latency,
+	// recall, memory-efficient, BIVF flavours).
+	optimization string
+	// numVecs is the number of vectors expected to populate the index.
+	// It is needed at construction time because the underlying faiss
+	// index reports zero vectors until trainAndAdd/add is called, but
+	// some construction-time decisions (e.g. whether to clone to GPU)
+	// depend on the eventual vector count.
+	numVecs int
+}
+
+// newFaissIndexParams constructs a faissIndexParams with the given optimization
+// type and expected vector count.
+func newFaissIndexParams(optimization string, numVecs int) *faissIndexParams {
+	return &faissIndexParams{
+		optimization: optimization,
+		numVecs:      numVecs,
+	}
+}
 
 // Abstract interface for Faiss vector indices, which are returned by the go-faiss library.
 type faissIndex interface {

--- a/faiss_vector_index_bivf.go
+++ b/faiss_vector_index_bivf.go
@@ -29,34 +29,23 @@ import (
 // Faiss Binary IVF Index
 // ---------------------------------
 type faissBinaryIndex struct {
-	cfg     *faissIndexConfig
-	backing *faiss.IndexImpl
-	binary  *faiss.BinaryIndexImpl
+	backing      *faiss.IndexImpl
+	binary       *faiss.BinaryIndexImpl
+	optimization string
 }
 
-func newFaissBinaryIndex(binary *faiss.BinaryIndexImpl, backing *faiss.IndexImpl) (index faissIndex, err error) {
+func newFaissBinaryIndex(binary *faiss.BinaryIndexImpl, backing *faiss.IndexImpl, optimization string) (faissIndex, error) {
 	// we always create this object only with valid backing and binary indexes
 	if binary == nil || backing == nil {
 		return nil, errNilIndex
 	}
-	return &faissBinaryIndex{
-		backing: backing,
-		binary:  binary,
-	}, nil
-}
-
-func newFaissBinaryIndexWithConfig(binary *faiss.BinaryIndexImpl, backing *faiss.IndexImpl, cfg *faissIndexConfig) (index faissIndex, err error) {
-	if binary == nil || backing == nil {
-		return nil, errNilIndex
+	if _, ok := index.SupportedVectorIndexOptimizations[optimization]; !ok {
+		return nil, errInvalidOptimizationString
 	}
-	if cfg == nil {
-		return nil, errNilConfig
-	}
-
 	return &faissBinaryIndex{
-		cfg:     cfg,
-		backing: backing,
-		binary:  binary,
+		backing:      backing,
+		binary:       binary,
+		optimization: optimization,
 	}, nil
 }
 
@@ -287,16 +276,15 @@ func (b *faissBinaryIndex) setQuantizers(trainedIndex faissIndexIVF) error {
 }
 
 func (b *faissBinaryIndex) isMergeable() bool {
-	if b.cfg != nil {
-		switch b.cfg.optimizationType {
-		case index.IndexBIVFWithBackingFlat:
-			// the flat backing index currently doesn't support merge_from
-			return false
-		case index.IndexBIVFWithBackingSQ8:
-			return b.backing.Ntotal() > ivfThreshold
-		}
+	switch b.optimization {
+	case index.IndexBIVFWithBackingFlat:
+		// the flat backing index currently doesn't support merge_from
+		return false
+	case index.IndexBIVFWithBackingSQ8:
+		return b.ntotal() > ivfThreshold
+	default:
+		return false
 	}
-	return false
 }
 
 func (b *faissBinaryIndex) mergeFrom(other faissIndex, offset int64) error {

--- a/faiss_vector_index_bivf.go
+++ b/faiss_vector_index_bivf.go
@@ -281,7 +281,7 @@ func (b *faissBinaryIndex) isMergeable() bool {
 		// the flat backing index currently doesn't support merge_from
 		return false
 	case index.IndexBIVFWithBackingSQ8:
-		return b.ntotal() > ivfThreshold
+		return b.ntotal() >= ivfThreshold
 	default:
 		return false
 	}

--- a/faiss_vector_index_bivf.go
+++ b/faiss_vector_index_bivf.go
@@ -29,23 +29,23 @@ import (
 // Faiss Binary IVF Index
 // ---------------------------------
 type faissBinaryIndex struct {
-	backing      *faiss.IndexImpl
-	binary       *faiss.BinaryIndexImpl
-	optimization string
+	backing *faiss.IndexImpl
+	binary  *faiss.BinaryIndexImpl
+	params  *faissIndexParams
 }
 
-func newFaissBinaryIndex(binary *faiss.BinaryIndexImpl, backing *faiss.IndexImpl, optimization string) (faissIndex, error) {
+func newFaissBinaryIndex(binary *faiss.BinaryIndexImpl, backing *faiss.IndexImpl, params *faissIndexParams) (faissIndex, error) {
 	// we always create this object only with valid backing and binary indexes
 	if binary == nil || backing == nil {
 		return nil, errNilIndex
 	}
-	if _, ok := index.SupportedVectorIndexOptimizations[optimization]; !ok {
-		return nil, errInvalidOptimizationString
+	if params == nil {
+		return nil, errNilParams
 	}
 	return &faissBinaryIndex{
-		backing:      backing,
-		binary:       binary,
-		optimization: optimization,
+		backing: backing,
+		binary:  binary,
+		params:  params,
 	}, nil
 }
 
@@ -276,12 +276,12 @@ func (b *faissBinaryIndex) setQuantizers(trainedIndex faissIndexIVF) error {
 }
 
 func (b *faissBinaryIndex) isMergeable() bool {
-	switch b.optimization {
+	switch b.params.optimization {
 	case index.IndexBIVFWithBackingFlat:
 		// the flat backing index currently doesn't support merge_from
 		return false
 	case index.IndexBIVFWithBackingSQ8:
-		return b.ntotal() >= ivfThreshold
+		return b.params.numVecs >= ivfThreshold
 	default:
 		return false
 	}

--- a/faiss_vector_index_float32.go
+++ b/faiss_vector_index_float32.go
@@ -29,30 +29,20 @@ import (
 // Faiss Float32 Index
 // ---------------------------------
 type faissFloat32Index struct {
-	cfg *faissIndexConfig
-	idx *faiss.IndexImpl
+	idx          *faiss.IndexImpl
+	optimization string
 }
 
-func newFaissFloat32Index(idx *faiss.IndexImpl) (index faissIndex, err error) {
+func newFaissFloat32Index(idx *faiss.IndexImpl, optStr string) (faissIndex, error) {
 	if idx == nil {
 		return nil, errNilIndex
 	}
-	return &faissFloat32Index{
-		idx: idx,
-	}, nil
-}
-
-func newFaissFloat32IndexWithConfig(idx *faiss.IndexImpl, cfg *faissIndexConfig) (index faissIndex, err error) {
-	if idx == nil {
-		return nil, errNilIndex
+	if _, ok := index.SupportedVectorIndexOptimizations[optStr]; !ok {
+		return nil, errInvalidOptimizationString
 	}
-	if cfg == nil {
-		return nil, errNilConfig
-	}
-
 	return &faissFloat32Index{
-		idx: idx,
-		cfg: cfg,
+		idx:          idx,
+		optimization: optStr,
 	}, nil
 }
 
@@ -173,17 +163,14 @@ func (f *faissFloat32Index) setQuantizers(trainedIndex faissIndexIVF) error {
 }
 
 func (f *faissFloat32Index) isMergeable() bool {
-	if f.cfg != nil {
-		switch f.cfg.optimizationType {
-		case index.IndexOptimizedForLatency, index.IndexOptimizedForRecall:
-			return f.ntotal() > ivfSq8Threshold
-		case index.IndexOptimizedForMemoryEfficient, index.IndexIVFRaBitQ:
-			return f.ntotal() > ivfThreshold
-		default:
-			return false
-		}
+	switch f.optimization {
+	case index.IndexOptimizedForLatency, index.IndexOptimizedForRecall:
+		return f.ntotal() > ivfSq8Threshold
+	case index.IndexOptimizedForMemoryEfficient, index.IndexIVFRaBitQ:
+		return f.ntotal() > ivfThreshold
+	default:
+		return false
 	}
-	return false
 }
 
 func (f *faissFloat32Index) mergeFrom(other faissIndex, offset int64) error {

--- a/faiss_vector_index_float32.go
+++ b/faiss_vector_index_float32.go
@@ -29,20 +29,20 @@ import (
 // Faiss Float32 Index
 // ---------------------------------
 type faissFloat32Index struct {
-	idx          *faiss.IndexImpl
-	optimization string
+	idx    *faiss.IndexImpl
+	params *faissIndexParams
 }
 
-func newFaissFloat32Index(idx *faiss.IndexImpl, optStr string) (faissIndex, error) {
+func newFaissFloat32Index(idx *faiss.IndexImpl, params *faissIndexParams) (faissIndex, error) {
 	if idx == nil {
 		return nil, errNilIndex
 	}
-	if _, ok := index.SupportedVectorIndexOptimizations[optStr]; !ok {
-		return nil, errInvalidOptimizationString
+	if params == nil {
+		return nil, errNilParams
 	}
 	return &faissFloat32Index{
-		idx:          idx,
-		optimization: optStr,
+		idx:    idx,
+		params: params,
 	}, nil
 }
 
@@ -163,11 +163,11 @@ func (f *faissFloat32Index) setQuantizers(trainedIndex faissIndexIVF) error {
 }
 
 func (f *faissFloat32Index) isMergeable() bool {
-	switch f.optimization {
+	switch f.params.optimization {
 	case index.IndexOptimizedForLatency, index.IndexOptimizedForRecall:
-		return f.ntotal() >= ivfSq8Threshold
+		return f.params.numVecs >= ivfSq8Threshold
 	case index.IndexOptimizedForMemoryEfficient, index.IndexIVFRaBitQ:
-		return f.ntotal() >= ivfThreshold
+		return f.params.numVecs >= ivfThreshold
 	default:
 		return false
 	}

--- a/faiss_vector_index_float32.go
+++ b/faiss_vector_index_float32.go
@@ -165,9 +165,9 @@ func (f *faissFloat32Index) setQuantizers(trainedIndex faissIndexIVF) error {
 func (f *faissFloat32Index) isMergeable() bool {
 	switch f.optimization {
 	case index.IndexOptimizedForLatency, index.IndexOptimizedForRecall:
-		return f.ntotal() > ivfSq8Threshold
+		return f.ntotal() >= ivfSq8Threshold
 	case index.IndexOptimizedForMemoryEfficient, index.IndexIVFRaBitQ:
-		return f.ntotal() > ivfThreshold
+		return f.ntotal() >= ivfThreshold
 	default:
 		return false
 	}

--- a/faiss_vector_index_gpu_float32.go
+++ b/faiss_vector_index_gpu_float32.go
@@ -48,9 +48,7 @@ func (gs *gpuState) batchSearch(qVector *vectorSet, k int64) ([]float32, []int64
 // operations, serialization, etc.) are delegated to the CPU index.
 type faissGPUFloat32Index struct {
 	cpuIdx *faiss.IndexImpl
-
-	optimization string
-	nvecs        int
+	params *faissIndexParams
 
 	// doneCh is closed when initGPU completes.
 	doneCh chan struct{}
@@ -64,18 +62,17 @@ type faissGPUFloat32Index struct {
 // newFaissGPUFloat32Index creates a GPU-backed float32 index. The GPU clone is
 // always performed asynchronously; search falls back to CPU until it
 // completes. All other GPU-operating methods block on doneCh before proceeding.
-func newFaissGPUFloat32Index(cpuIdx *faiss.IndexImpl, optimization string, nvecs int) (faissIndex, error) {
+func newFaissGPUFloat32Index(cpuIdx *faiss.IndexImpl, params *faissIndexParams) (faissIndex, error) {
 	if cpuIdx == nil {
 		return nil, errNilIndex
 	}
-	if _, ok := index.SupportedVectorIndexOptimizations[optimization]; !ok {
-		return nil, errInvalidOptimizationString
+	if params == nil {
+		return nil, errNilParams
 	}
 	f := &faissGPUFloat32Index{
-		cpuIdx:       cpuIdx,
-		doneCh:       make(chan struct{}),
-		optimization: optimization,
-		nvecs:        nvecs,
+		cpuIdx: cpuIdx,
+		params: params,
+		doneCh: make(chan struct{}),
 	}
 	go f.initGPU()
 	return f, nil
@@ -319,11 +316,11 @@ func (f *faissGPUFloat32Index) syncGPUToCPU() error {
 }
 
 func (f *faissGPUFloat32Index) canUseGPU() bool {
-	switch f.optimization {
+	switch f.params.optimization {
 	case index.IndexOptimizedForLatency, index.IndexOptimizedForRecall:
-		return f.nvecs >= ivfSq8Threshold
+		return f.params.numVecs >= ivfSq8Threshold
 	case index.IndexOptimizedForMemoryEfficient:
-		return f.nvecs >= ivfThreshold
+		return f.params.numVecs >= ivfThreshold
 	default:
 		return false
 	}

--- a/faiss_vector_index_gpu_float32.go
+++ b/faiss_vector_index_gpu_float32.go
@@ -50,6 +50,7 @@ type faissGPUFloat32Index struct {
 	cpuIdx *faiss.IndexImpl
 
 	optimization string
+	nvecs        int
 
 	// doneCh is closed when initGPU completes.
 	doneCh chan struct{}
@@ -63,7 +64,7 @@ type faissGPUFloat32Index struct {
 // newFaissGPUFloat32Index creates a GPU-backed float32 index. The GPU clone is
 // always performed asynchronously; search falls back to CPU until it
 // completes. All other GPU-operating methods block on doneCh before proceeding.
-func newFaissGPUFloat32Index(cpuIdx *faiss.IndexImpl, optimization string) (faissIndex, error) {
+func newFaissGPUFloat32Index(cpuIdx *faiss.IndexImpl, optimization string, nvecs int) (faissIndex, error) {
 	if cpuIdx == nil {
 		return nil, errNilIndex
 	}
@@ -74,6 +75,7 @@ func newFaissGPUFloat32Index(cpuIdx *faiss.IndexImpl, optimization string) (fais
 		cpuIdx:       cpuIdx,
 		doneCh:       make(chan struct{}),
 		optimization: optimization,
+		nvecs:        nvecs,
 	}
 	go f.initGPU()
 	return f, nil
@@ -317,12 +319,11 @@ func (f *faissGPUFloat32Index) syncGPUToCPU() error {
 }
 
 func (f *faissGPUFloat32Index) canUseGPU() bool {
-	nvecs := f.ntotal()
 	switch f.optimization {
 	case index.IndexOptimizedForLatency, index.IndexOptimizedForRecall:
-		return nvecs >= ivfSq8Threshold
+		return f.nvecs >= ivfSq8Threshold
 	case index.IndexOptimizedForMemoryEfficient:
-		return nvecs >= ivfThreshold
+		return f.nvecs >= ivfThreshold
 	default:
 		return false
 	}

--- a/faiss_vector_index_gpu_float32.go
+++ b/faiss_vector_index_gpu_float32.go
@@ -22,6 +22,7 @@ import (
 	"encoding/json"
 	"sync/atomic"
 
+	index "github.com/blevesearch/bleve_index_api"
 	faiss "github.com/blevesearch/go-faiss"
 )
 
@@ -48,6 +49,8 @@ func (gs *gpuState) batchSearch(qVector *vectorSet, k int64) ([]float32, []int64
 type faissGPUFloat32Index struct {
 	cpuIdx *faiss.IndexImpl
 
+	optimization string
+
 	// doneCh is closed when initGPU completes.
 	doneCh chan struct{}
 
@@ -60,13 +63,14 @@ type faissGPUFloat32Index struct {
 // newFaissGPUFloat32Index creates a GPU-backed float32 index. The GPU clone is
 // always performed asynchronously; search falls back to CPU until it
 // completes. All other GPU-operating methods block on doneCh before proceeding.
-func newFaissGPUFloat32Index(cpuIdx *faiss.IndexImpl) (faissIndex, error) {
+func newFaissGPUFloat32Index(cpuIdx *faiss.IndexImpl, optimization string) (faissIndex, error) {
 	if cpuIdx == nil {
 		return nil, errNilIndex
 	}
 	f := &faissGPUFloat32Index{
-		cpuIdx: cpuIdx,
-		doneCh: make(chan struct{}),
+		cpuIdx:       cpuIdx,
+		doneCh:       make(chan struct{}),
+		optimization: optimization,
 	}
 	go f.initGPU()
 	return f, nil
@@ -80,7 +84,13 @@ func (f *faissGPUFloat32Index) waitGPU() {
 // initGPU clones the CPU index to the GPU and sets up the request batcher.
 // It always closes doneCh when it returns, signalling completion to waiters.
 func (f *faissGPUFloat32Index) initGPU() {
+	// ensure doneCh is closed on exit, even if the GPU clone/setup fails.
 	defer close(f.doneCh)
+	// Check if we can use the GPU before attempting the clone,
+	// to avoid unnecessary overhead when the GPU is not expected to help.
+	if !f.canUseGPU() {
+		return
+	}
 	gpuIdx, err := faiss.CloneToGPU(f.cpuIdx)
 	if err != nil || gpuIdx == nil {
 		return
@@ -301,4 +311,16 @@ func (f *faissGPUFloat32Index) syncGPUToCPU() error {
 	f.cpuIdx = cpuIdx
 	oldCPUIdx.Close()
 	return nil
+}
+
+func (f *faissGPUFloat32Index) canUseGPU() bool {
+	nvecs := f.ntotal()
+	switch f.optimization {
+	case index.IndexOptimizedForLatency, index.IndexOptimizedForRecall:
+		return nvecs > ivfSq8Threshold
+	case index.IndexOptimizedForMemoryEfficient:
+		return nvecs > ivfThreshold
+	default:
+		return false
+	}
 }

--- a/faiss_vector_index_gpu_float32.go
+++ b/faiss_vector_index_gpu_float32.go
@@ -67,6 +67,9 @@ func newFaissGPUFloat32Index(cpuIdx *faiss.IndexImpl, optimization string) (fais
 	if cpuIdx == nil {
 		return nil, errNilIndex
 	}
+	if _, ok := index.SupportedVectorIndexOptimizations[optimization]; !ok {
+		return nil, errInvalidOptimizationString
+	}
 	f := &faissGPUFloat32Index{
 		cpuIdx:       cpuIdx,
 		doneCh:       make(chan struct{}),
@@ -317,9 +320,9 @@ func (f *faissGPUFloat32Index) canUseGPU() bool {
 	nvecs := f.ntotal()
 	switch f.optimization {
 	case index.IndexOptimizedForLatency, index.IndexOptimizedForRecall:
-		return nvecs > ivfSq8Threshold
+		return nvecs >= ivfSq8Threshold
 	case index.IndexOptimizedForMemoryEfficient:
-		return nvecs > ivfThreshold
+		return nvecs >= ivfThreshold
 	default:
 		return false
 	}

--- a/faiss_vector_posting.go
+++ b/faiss_vector_posting.go
@@ -24,6 +24,7 @@ import (
 
 	"github.com/RoaringBitmap/roaring/v2"
 	"github.com/RoaringBitmap/roaring/v2/roaring64"
+	index "github.com/blevesearch/bleve_index_api"
 	segment "github.com/blevesearch/scorch_segment_api/v2"
 )
 
@@ -289,20 +290,22 @@ func (sb *SegmentBase) InterpretVectorIndex(field string, except *roaring.Bitmap
 	if pos <= 0 {
 		return rv, nil
 	}
-	// the below loop loads the following:
-	// 1. doc values(first 2 iterations) - adhering to the sections format. never
-	// valid values for vector section
-	// 2. index optimization type.
-	for i := 0; i < 3; i++ {
+	// skip the docvalue offsets as they are not required for the
+	// vector index section.
+	for i := 0; i < 2; i++ {
 		_, n := binary.Uvarint(sb.mem[pos : pos+binary.MaxVarintLen64])
 		pos += uint64(n)
 	}
-
+	// read the index optimization type
+	opt, n := binary.Uvarint(sb.mem[pos : pos+binary.MaxVarintLen64])
+	pos += uint64(n)
+	// get the optimization type string from the reverse lookup map
+	optStr := index.VectorIndexOptimizationsReverseLookup[int(opt)]
 	// create the vector index wrapper by loading (or creating) the vector index
 	// and the vector to docID mapping
 	useGPU := sb.fieldsOptions[field].UseGPU()
 	var err error
-	rv.index, rv.mapping, rv.exclude, err = sb.vecIndexCache.loadOrCreate(fieldID, sb.mem[pos:], uint32(sb.numDocs), except, useGPU, sb.fileReader)
+	rv.index, rv.mapping, rv.exclude, err = sb.vecIndexCache.loadOrCreate(fieldID, sb.mem[pos:], uint32(sb.numDocs), except, useGPU, sb.fileReader, optStr)
 	if err != nil {
 		return nil, err
 	}

--- a/section_faiss_vector_index.go
+++ b/section_faiss_vector_index.go
@@ -46,10 +46,10 @@ const (
 	// Divide the estimated nprobe with this value to optimize
 	// for latency.
 	nprobeLatencyOptimization = 2
-	// The threshold for number of vectors beyond which we start building
+	// The threshold for number of vectors at or beyond which we start building
 	// the IVF class of indexes.
 	ivfThreshold = 1000
-	// The threshold for number of vectors beyond which we start building
+	// The threshold for number of vectors at or beyond which we start building
 	// the IVF class of indexes with SQ8 quantization for memory efficiency.
 	ivfSq8Threshold = 10000
 )
@@ -1042,5 +1042,5 @@ func canFastMerge(trainedIndex faissIndexIVF, opt string, totalVecs int) bool {
 	default:
 		minVecsForFastMerge = ivfSq8Threshold
 	}
-	return trainedIndex.ntotal() > int64(minVecsForFastMerge) && totalVecs > minVecsForFastMerge
+	return trainedIndex.ntotal() >= int64(minVecsForFastMerge) && totalVecs >= minVecsForFastMerge
 }

--- a/section_faiss_vector_index.go
+++ b/section_faiss_vector_index.go
@@ -46,12 +46,11 @@ const (
 	// Divide the estimated nprobe with this value to optimize
 	// for latency.
 	nprobeLatencyOptimization = 2
-	// The threshold for number of vectors beyond which we start building the ivf class
-	// of indexes
+	// The threshold for number of vectors beyond which we start building
+	// the IVF class of indexes.
 	ivfThreshold = 1000
-	// The threshold for number of vectors beyond which we consider fast merging
-	// using faiss's native merge capabilities, instead of reconstructing and adding
-	// vectors one by one
+	// The threshold for number of vectors beyond which we start building
+	// the IVF class of indexes with SQ8 quantization for memory efficiency.
 	ivfSq8Threshold = 10000
 )
 
@@ -505,17 +504,14 @@ func (v *vectorIndexOpaque) mergeAndWriteVectorIndexes(trainedIndex faissIndexIV
 			reconsCap = indexReconsLen
 		}
 		indexDataCap += indexReconsLen
-
 		// track the reconstruct index for this vector index, which will be used
 		// to reconstruct the vectors corresponding to the valid vector IDs for this index.
-		config := newFaissIndexConfig(indexType, indexOptimizedFor, dims, metric, currNumVecs, determineCentroids(currNumVecs), useGPU)
-		fIndex, err := newFaissFloat32IndexWithConfig(faissIndex, config)
+		fIndex, err := newFaissFloat32Index(faissIndex, indexOptimizedFor)
 		if err != nil {
 			freeReconstructedIndexes(vecIndexes)
 			return err
 		}
 		vecIndexes[segI].index = fIndex
-
 		// load binary index from disk if present
 		if currVecIndex.indexType == faissBIVFIndex {
 			// get to the bivf part of the vector index section
@@ -533,7 +529,7 @@ func (v *vectorIndexOpaque) mergeAndWriteVectorIndexes(trainedIndex faissIndexIV
 				freeReconstructedIndexes(vecIndexes)
 				return err
 			}
-			vecIndexes[segI].index, err = newFaissBinaryIndexWithConfig(binaryIndex, faissIndex, config)
+			vecIndexes[segI].index, err = newFaissBinaryIndex(binaryIndex, faissIndex, indexOptimizedFor)
 			if err != nil {
 				freeReconstructedIndexes(vecIndexes)
 				return err
@@ -1003,12 +999,10 @@ func faissIndexFactory(cfg *faissIndexConfig) (faissIndex, error) {
 		if err != nil {
 			return nil, err
 		}
-		// we restrict GPU to IVF indexes only; flat and SQ indexes do not get a noticeable speedup
-		// when run on GPU, and the GPU overhead can actually make them slower than CPU.
-		if cfg.useGPU && idx.IsIVFIndex() {
-			return newFaissGPUFloat32Index(idx)
+		if cfg.useGPU {
+			return newFaissGPUFloat32Index(idx, cfg.optimizationType)
 		}
-		return newFaissFloat32Index(idx)
+		return newFaissFloat32Index(idx, cfg.optimizationType)
 	case faissBIVFIndex:
 		description := determineBinaryIndexToUse(cfg.numVecs, cfg.nlist)
 		binaryIdx, err := faiss.BinaryIndexFactory(cfg.dimension, description)
@@ -1021,7 +1015,7 @@ func faissIndexFactory(cfg *faissIndexConfig) (faissIndex, error) {
 		if err != nil {
 			return nil, err
 		}
-		return newFaissBinaryIndex(binaryIdx, backingIdx)
+		return newFaissBinaryIndex(binaryIdx, backingIdx, cfg.optimizationType)
 	default:
 		return nil, errNotSupported
 	}

--- a/section_faiss_vector_index.go
+++ b/section_faiss_vector_index.go
@@ -506,7 +506,8 @@ func (v *vectorIndexOpaque) mergeAndWriteVectorIndexes(trainedIndex faissIndexIV
 		indexDataCap += indexReconsLen
 		// track the reconstruct index for this vector index, which will be used
 		// to reconstruct the vectors corresponding to the valid vector IDs for this index.
-		fIndex, err := newFaissFloat32Index(faissIndex, indexOptimizedFor)
+		reconParams := newFaissIndexParams(indexOptimizedFor, currNumVecs)
+		fIndex, err := newFaissFloat32Index(faissIndex, reconParams)
 		if err != nil {
 			freeReconstructedIndexes(vecIndexes)
 			return err
@@ -529,7 +530,7 @@ func (v *vectorIndexOpaque) mergeAndWriteVectorIndexes(trainedIndex faissIndexIV
 				freeReconstructedIndexes(vecIndexes)
 				return err
 			}
-			vecIndexes[segI].index, err = newFaissBinaryIndex(binaryIndex, faissIndex, indexOptimizedFor)
+			vecIndexes[segI].index, err = newFaissBinaryIndex(binaryIndex, faissIndex, reconParams)
 			if err != nil {
 				freeReconstructedIndexes(vecIndexes)
 				return err
@@ -992,6 +993,7 @@ func newFaissIndexConfig(idxType faissIndexType, optimizationType string, dimens
 
 // Factory function to create a faissIndex for the given index config.
 func faissIndexFactory(cfg *faissIndexConfig) (faissIndex, error) {
+	params := newFaissIndexParams(cfg.optimizationType, cfg.numVecs)
 	switch cfg.indexType {
 	case faissFP32Index:
 		description := determineFloat32IndexToUse(cfg.numVecs, cfg.nlist, cfg.optimizationType)
@@ -1000,9 +1002,9 @@ func faissIndexFactory(cfg *faissIndexConfig) (faissIndex, error) {
 			return nil, err
 		}
 		if cfg.useGPU {
-			return newFaissGPUFloat32Index(idx, cfg.optimizationType, cfg.numVecs)
+			return newFaissGPUFloat32Index(idx, params)
 		}
-		return newFaissFloat32Index(idx, cfg.optimizationType)
+		return newFaissFloat32Index(idx, params)
 	case faissBIVFIndex:
 		description := determineBinaryIndexToUse(cfg.numVecs, cfg.nlist)
 		binaryIdx, err := faiss.BinaryIndexFactory(cfg.dimension, description)
@@ -1015,7 +1017,7 @@ func faissIndexFactory(cfg *faissIndexConfig) (faissIndex, error) {
 		if err != nil {
 			return nil, err
 		}
-		return newFaissBinaryIndex(binaryIdx, backingIdx, cfg.optimizationType)
+		return newFaissBinaryIndex(binaryIdx, backingIdx, params)
 	default:
 		return nil, errNotSupported
 	}

--- a/section_faiss_vector_index.go
+++ b/section_faiss_vector_index.go
@@ -506,7 +506,11 @@ func (v *vectorIndexOpaque) mergeAndWriteVectorIndexes(trainedIndex faissIndexIV
 		indexDataCap += indexReconsLen
 		// track the reconstruct index for this vector index, which will be used
 		// to reconstruct the vectors corresponding to the valid vector IDs for this index.
-		reconParams := newFaissIndexParams(indexOptimizedFor, currNumVecs)
+
+		// Here currNumVecs is the count of valid vectors for this index, so we pass in ntotal
+		// as the vector count in the index for the params because the underlying faiss index still has all the vectors.
+		totCurrVecs := int(faissIndex.Ntotal())
+		reconParams := newFaissIndexParams(indexOptimizedFor, totCurrVecs)
 		fIndex, err := newFaissFloat32Index(faissIndex, reconParams)
 		if err != nil {
 			freeReconstructedIndexes(vecIndexes)

--- a/section_faiss_vector_index.go
+++ b/section_faiss_vector_index.go
@@ -1000,7 +1000,7 @@ func faissIndexFactory(cfg *faissIndexConfig) (faissIndex, error) {
 			return nil, err
 		}
 		if cfg.useGPU {
-			return newFaissGPUFloat32Index(idx, cfg.optimizationType)
+			return newFaissGPUFloat32Index(idx, cfg.optimizationType, cfg.numVecs)
 		}
 		return newFaissFloat32Index(idx, cfg.optimizationType)
 	case faissBIVFIndex:


### PR DESCRIPTION
- Add a check to prevent unsupported vector index classes from being cloned to the GPU.
  Earlier we could clone to GPU for the `IVF,RaBitQ` class and crash the process.
- Add a check to prevent `IVF,Flat` indexes from being cloned to GPU as we do not expect
  to have much speedup from this vector classes as we create them for <10000 vectors.
- Fix bug where we invalidate fast merge operations due to boundary condition mismatch.
- Cleanup code.