### PR TITLE
MB-71936: Set the correct ioflags for fastmerge

### DIFF
--- a/centroid_index.go
+++ b/centroid_index.go
@@ -62,7 +62,7 @@ func (sb *SegmentBase) GetCoarseQuantizer(field string) (interface{}, error) {
 	indexSize, n := binary.Uvarint(sb.mem[pos : pos+binary.MaxVarintLen64])
 	pos += uint64(n)
 
-	params := newFaissIndexParams(optStr, int(numVecs))
+	params := newFaissIndexParams(optStr, int(numVecs), faissIOFlagsReadOnly)
 
 	// todo: might wanna use the vector cache here, early tests didn't show a big diff
 	fIndexBytes, err := sb.fileReader.process(sb.mem[pos : pos+indexSize])

--- a/faiss_vector_cache.go
+++ b/faiss_vector_cache.go
@@ -161,7 +161,7 @@ func (vc *vectorIndexCache) createAndCacheLOCKED(fieldID uint16, mem []byte,
 	}
 	pos += int(indexSize)
 
-	params := newFaissIndexParams(optStr, int(numVecs))
+	params := newFaissIndexParams(optStr, int(numVecs), faissIOFlagsReadOnly)
 	if faissIndexType(indexType) == faissBIVFIndex {
 		// read the faiss binary index size
 		binSize, n := binary.Uvarint(mem[pos : pos+binary.MaxVarintLen64])

--- a/faiss_vector_index.go
+++ b/faiss_vector_index.go
@@ -47,14 +47,17 @@ type faissIndexParams struct {
 	// some construction-time decisions (e.g. whether to clone to GPU)
 	// depend on the eventual vector count.
 	numVecs int
+	// ioFlags used to read the index from bytes
+	ioFlags int
 }
 
 // newFaissIndexParams constructs a faissIndexParams with the given optimization
 // type and expected vector count.
-func newFaissIndexParams(optimization string, numVecs int) *faissIndexParams {
+func newFaissIndexParams(optimization string, numVecs, ioFlags int) *faissIndexParams {
 	return &faissIndexParams{
 		optimization: optimization,
 		numVecs:      numVecs,
+		ioFlags:      ioFlags,
 	}
 }
 

--- a/faiss_vector_index_bivf.go
+++ b/faiss_vector_index_bivf.go
@@ -63,12 +63,12 @@ func newFaissBinaryIndexFromBytes(bIndexBytes, fIndexBytes []byte, params *faiss
 		return nil, errNilParams
 	}
 
-	backing, err := faiss.ReadIndexFromBuffer(bIndexBytes, faissIOFlagsReadOnly)
+	backing, err := faiss.ReadIndexFromBuffer(bIndexBytes, params.ioFlags)
 	if err != nil {
 		return nil, err
 	}
 
-	binary, err := faiss.ReadBinaryIndexFromBuffer(fIndexBytes, faissIOFlagsReadOnly)
+	binary, err := faiss.ReadBinaryIndexFromBuffer(fIndexBytes, params.ioFlags)
 	if err != nil {
 		return nil, err
 	}

--- a/faiss_vector_index_float32.go
+++ b/faiss_vector_index_float32.go
@@ -57,7 +57,7 @@ func newFaissFloat32IndexFromBytes(idxBytes []byte, params *faissIndexParams) (f
 		return nil, errNilParams
 	}
 
-	idx, err := faiss.ReadIndexFromBuffer(idxBytes, faissIOFlagsReadOnly)
+	idx, err := faiss.ReadIndexFromBuffer(idxBytes, params.ioFlags)
 	if err != nil {
 		return nil, err
 	}

--- a/faiss_vector_index_gpu_float32.go
+++ b/faiss_vector_index_gpu_float32.go
@@ -90,7 +90,7 @@ func newFaissGPUFloat32IndexFromBytes(idxBytes []byte, params *faissIndexParams)
 		return nil, errNilParams
 	}
 
-	cpuIdx, err := faiss.ReadIndexFromBuffer(idxBytes, faissIOFlagsReadOnly)
+	cpuIdx, err := faiss.ReadIndexFromBuffer(idxBytes, params.ioFlags)
 	if err != nil {
 		return nil, err
 	}

--- a/section_faiss_vector_index.go
+++ b/section_faiss_vector_index.go
@@ -483,7 +483,11 @@ func (v *vectorIndexOpaque) mergeAndWriteVectorIndexes(trainedIndex faissIndexIV
 			return err
 		}
 
-		reconsParams := newFaissIndexParams(currVecIndex.indexOptimizedFor, currVecIndex.nvecs)
+		ioFlags := faissIOFlags
+		if trainedIndex == nil {
+			ioFlags = faissIOFlagsReadOnly
+		}
+		reconsParams := newFaissIndexParams(currVecIndex.indexOptimizedFor, currVecIndex.nvecs, ioFlags)
 
 		// load binary index from disk if present
 		if currVecIndex.indexType == faissBIVFIndex {
@@ -978,7 +982,7 @@ func newFaissIndexConfig(idxType faissIndexType, optimizationType string, dimens
 
 // Factory function to create a faissIndex for the given index config.
 func faissIndexFactory(cfg *faissIndexConfig) (faissIndex, error) {
-	params := newFaissIndexParams(cfg.optimizationType, cfg.numVecs)
+	params := newFaissIndexParams(cfg.optimizationType, cfg.numVecs, faissIOFlags)
 	switch cfg.indexType {
 	case faissFP32Index:
 		description := determineFloat32IndexToUse(cfg.numVecs, cfg.nlist, cfg.optimizationType)


### PR DESCRIPTION
 - FastMerge uses MergeFrom api within faiss which does not work with the ReadOnly io flag