### PR TITLE
MB-71788: Use the training params for fast merge

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.25.0
 
 require (
 	github.com/RoaringBitmap/roaring/v2 v2.14.5
-	github.com/blevesearch/bleve_index_api v1.3.11
+	github.com/blevesearch/bleve_index_api v1.3.12
 	github.com/blevesearch/go-faiss v1.1.3-0.20260525132456-c1cb753e04cd
 	github.com/blevesearch/mmap-go v1.2.0
 	github.com/blevesearch/scorch_segment_api/v2 v2.4.7

--- a/go.sum
+++ b/go.sum
@@ -2,8 +2,8 @@ github.com/RoaringBitmap/roaring/v2 v2.14.5 h1:ckd0o545JqDPeVJDgeFoaM21eBixUnlWf
 github.com/RoaringBitmap/roaring/v2 v2.14.5/go.mod h1:eq4wdNXxtJIS/oikeCzdX1rBzek7ANzbth041hrU8Q4=
 github.com/bits-and-blooms/bitset v1.24.2 h1:M7/NzVbsytmtfHbumG+K2bremQPMJuqv1JD3vOaFxp0=
 github.com/bits-and-blooms/bitset v1.24.2/go.mod h1:7hO7Gc7Pp1vODcmWvKMRA9BNmbv6a/7QIWpPxHddWR8=
-github.com/blevesearch/bleve_index_api v1.3.11 h1:x29vbV8OjWfLcrDVd7Lr1q+BkLNS0JWNEig0MCVnKH4=
-github.com/blevesearch/bleve_index_api v1.3.11/go.mod h1:xvd48t5XMeeioWQ5/jZvgLrV98flT2rdvEJ3l/ki4Ko=
+github.com/blevesearch/bleve_index_api v1.3.12 h1:MirVNltwGq8z0PhOgiQp+bKL5qq8OvCxEwOOC7NnHNE=
+github.com/blevesearch/bleve_index_api v1.3.12/go.mod h1:xvd48t5XMeeioWQ5/jZvgLrV98flT2rdvEJ3l/ki4Ko=
 github.com/blevesearch/go-faiss v1.1.3-0.20260525132456-c1cb753e04cd h1:ftEpy+Ma4N/O4zgIRn4pKZOhmi8UnvApcYT6hTf0IYQ=
 github.com/blevesearch/go-faiss v1.1.3-0.20260525132456-c1cb753e04cd/go.mod h1:w3W9AiWsFRGVaMG+/cmJi7iHEAuGyC6blsgO1EzCK/M=
 github.com/blevesearch/mmap-go v1.2.0 h1:l33nNKPFcBjJUMwem6sAYJPUzhUCABoK9FxZDGiFNBI=

--- a/section_faiss_vector_index.go
+++ b/section_faiss_vector_index.go
@@ -540,16 +540,8 @@ func (v *vectorIndexOpaque) mergeAndWriteVectorIndexes(trainedIndex faissIndexIV
 		return nil
 	}
 
-	// create the faiss index to hold the merged data, either via fast merge or reconstruction
-	nlist := determineCentroids(nvecs)
-	if trainedIndex == nil {
-		// when the training for fast merge is ongoing, we use the nlist value set in the
-		// config for the train process
-		if tp, ok := v.config[index.TrainingKey]; ok {
-			trainingParams := tp.(*index.TrainingParams)
-			nlist = trainingParams.NumCentroids
-		}
-	}
+	// create the faiss index config to hold the merged data, either via fast merge or reconstruction
+	nlist := v.numCentroids(nvecs)
 	config := newFaissIndexConfig(indexType, indexOptimizedFor, dims, metric, nvecs, nlist, useGPU)
 	// we perform fast merge if we're not using the GPU and if the trained index
 	// is compatible to be used for fast merge
@@ -724,6 +716,16 @@ func determineCentroids(nvecs int) int {
 	return nlist
 }
 
+func (vo *vectorIndexOpaque) numCentroids(nvecs int) int {
+	nlist := determineCentroids(nvecs)
+	// training key is associated with some addtional params such as num centroids
+	// that might be specific to the fast merge path
+	if tp, ok := vo.config[index.TrainingKey].(*index.TrainingParams); ok {
+		nlist = tp.NumCentroids
+	}
+	return nlist
+}
+
 // determineFloat32IndexToUse returns a description string for the float32
 // index and quantizer type, and an index type constant.
 func determineFloat32IndexToUse(nvecs, nlist int, optimizationType string) string {
@@ -823,14 +825,7 @@ func (vo *vectorIndexOpaque) writeVectorIndexes(w *FileWriter) error {
 			return err
 		}
 
-		// training key is associated with some addtional params that might be specific to
-		// the fast merge path
-		nlist := determineCentroids(nvecs)
-		if tp, ok := vo.config[index.TrainingKey]; ok {
-			trainingParams := tp.(*index.TrainingParams)
-			nlist = trainingParams.NumCentroids
-		}
-
+		nlist := vo.numCentroids(nvecs)
 		// determine the type of vector index to be created based on the index optimization
 		// and create the faiss index for the vectors associated with this field and
 		// write out the index into the segment writer.

--- a/section_faiss_vector_index.go
+++ b/section_faiss_vector_index.go
@@ -256,8 +256,8 @@ func trainedIndexFromConfig(config map[string]interface{}, fieldName string) (fa
 	if cb, ok := config[index.TrainedIndexCallback]; ok {
 		trainedIndexFor = cb.(index.TrainedIndexCallbackFn)
 	}
-	if tf, ok := config[index.TrainingKey]; ok {
-		trainingParams = tf.(*index.TrainingParams)
+	if tp, ok := config[index.TrainingKey]; ok {
+		trainingParams = tp.(*index.TrainingParams)
 	}
 	// if we have a callback registered AND if the training params are not set:
 	//  - fastmerge is supported for this index
@@ -542,7 +542,7 @@ func (v *vectorIndexOpaque) mergeAndWriteVectorIndexes(trainedIndex faissIndexIV
 
 	// create the faiss index to hold the merged data, either via fast merge or reconstruction
 	nlist := determineCentroids(nvecs)
-	if tf, ok := v.config[index.TrainingKey]; ok && tf.(bool) {
+	if trainedIndex == nil {
 		// when the training for fast merge is ongoing, we use the nlist value set in the
 		// config for the train process
 		if tp, ok := v.config[index.TrainingKey]; ok {

--- a/section_faiss_vector_index.go
+++ b/section_faiss_vector_index.go
@@ -251,19 +251,19 @@ func (v *faissVectorIndexSection) Merge(opaque map[int]resetable, segments []*Se
 
 func trainedIndexFromConfig(config map[string]interface{}, fieldName string) (faissIndexIVF, error) {
 	var trainedIndexFor index.TrainedIndexCallbackFn
-	var training bool
+	var trainingParams *index.TrainingParams
 	var rv faissIndex
 	if cb, ok := config[index.TrainedIndexCallback]; ok {
 		trainedIndexFor = cb.(index.TrainedIndexCallbackFn)
 	}
 	if tf, ok := config[index.TrainingKey]; ok {
-		training = tf.(bool)
+		trainingParams = tf.(*index.TrainingParams)
 	}
-	// if we have a callback registered AND if the training flag is not set:
+	// if we have a callback registered AND if the training params are not set:
 	//  - fastmerge is supported for this index
 	// 	- we're not in the training phase of index creation where you want to be
 	//    able to reconstruct the vectors for training
-	if trainedIndexFor != nil && !training {
+	if trainedIndexFor != nil && trainingParams == nil {
 		trainedIndex, err := trainedIndexFor(fieldName)
 		if err != nil {
 			return nil, err
@@ -541,7 +541,16 @@ func (v *vectorIndexOpaque) mergeAndWriteVectorIndexes(trainedIndex faissIndexIV
 	}
 
 	// create the faiss index to hold the merged data, either via fast merge or reconstruction
-	config := newFaissIndexConfig(indexType, indexOptimizedFor, dims, metric, nvecs, determineCentroids(nvecs), useGPU)
+	nlist := determineCentroids(nvecs)
+	if tf, ok := v.config[index.TrainingKey]; ok && tf.(bool) {
+		// when the training for fast merge is ongoing, we use the nlist value set in the
+		// config for the train process
+		if tp, ok := v.config[index.TrainingKey]; ok {
+			trainingParams := tp.(*index.TrainingParams)
+			nlist = trainingParams.NumCentroids
+		}
+	}
+	config := newFaissIndexConfig(indexType, indexOptimizedFor, dims, metric, nvecs, nlist, useGPU)
 	// we perform fast merge if we're not using the GPU and if the trained index
 	// is compatible to be used for fast merge
 	if !useGPU && canFastMerge(trainedIndex, indexOptimizedFor, nvecs) {
@@ -814,11 +823,19 @@ func (vo *vectorIndexOpaque) writeVectorIndexes(w *FileWriter) error {
 			return err
 		}
 
+		// training key is associated with some addtional params that might be specific to
+		// the fast merge path
+		nlist := determineCentroids(nvecs)
+		if tp, ok := vo.config[index.TrainingKey]; ok {
+			trainingParams := tp.(*index.TrainingParams)
+			nlist = trainingParams.NumCentroids
+		}
+
 		// determine the type of vector index to be created based on the index optimization
 		// and create the faiss index for the vectors associated with this field and
 		// write out the index into the segment writer.
 		indexType := determineIndexTypeFromOptimization(content.optimizedFor)
-		config := newFaissIndexConfig(indexType, content.optimizedFor, content.dimension, metric, nvecs, determineCentroids(nvecs), false)
+		config := newFaissIndexConfig(indexType, content.optimizedFor, content.dimension, metric, nvecs, nlist, false)
 		err = vo.writeFaissIndex(vecSet, config, w)
 		if err != nil {
 			return err


### PR DESCRIPTION
- fast merge works by performing a training process prior to data ingestion and that means that the training parameters are controllable by the application layer such as cbft in couchbase. 
- so when a new vector index is being created as part of training, the config is provided with the training params that's used in the fast merge path