### PR TITLE
MB-71954: Add gpu memory estimate

### DIFF
--- a/faiss_vector_index_gpu_float32.go
+++ b/faiss_vector_index_gpu_float32.go
@@ -140,13 +140,64 @@ func (f *faissGPUFloat32Index) initGPU() {
 	if !f.canUseGPU() {
 		return
 	}
-	gpuIdx, err := faiss.CloneToGPU(f.cpuIdx)
+	gpuIdx, err := faiss.CloneToGPU(f.cpuIdx, f.estimateGPUMemSize())
 	if err != nil || gpuIdx == nil {
 		return
 	}
 	gs := &gpuState{idx: gpuIdx}
 	gs.batcher = newRequestBatcher(gs)
 	f.gpu.Store(gs)
+}
+
+// gpuInterleavedWarpSize is the warp size used by the faiss GPU IVF
+// interleaved layout to pack vectors of an inverted list. Each list's
+// code storage is padded to a multiple of this many vectors. Matches
+// kWarpSize in faiss/gpu/utils/DeviceDefs.cuh for the CUDA / RDNA-32
+// case (the most common deployment). The per-list id storage is NOT
+// padded (see IVFBase::addIndicesFromCpu_), so only codes contribute.
+const gpuInterleavedWarpSize = 32
+
+// estimateGPUMemSize estimates the GPU memory footprint of the index in
+// bytes, used to reserve memory before cloning. For an index loaded from
+// a serialized form, the on-disk byte length is a good baseline for the
+// CPU footprint; the GPU IVF interleaved layout then adds per-list
+// code padding because each inverted list's code storage is rounded up
+// to a multiple of gpuInterleavedWarpSize vectors. The padding is
+// computed exactly by reading the actual size of each inverted list.
+func (f *faissGPUFloat32Index) estimateGPUMemSize() uint64 {
+	size := uint64(len(f.idxBytes))
+	if !f.cpuIdx.IsIVFIndex() {
+		return size
+	}
+	ntotal := f.cpuIdx.Ntotal()
+	if ntotal <= 0 {
+		// No vectors yet (e.g., the from-scratch path before training);
+		// nothing to pad.
+		return size
+	}
+	codeSize, err := f.cpuIdx.CodeSize()
+	if err != nil {
+		return size
+	}
+	_, nlist := f.cpuIdx.IVFParams()
+	// Passing nil selector to ObtainClusterVectorCountsFromIVFIndex includes
+	// all vectors (no ID filtering), which is exactly what we need here.
+	listCounts, err := f.cpuIdx.ObtainClusterVectorCountsFromIVFIndex(nil, nlist)
+	if err != nil {
+		return size
+	}
+	// Each list of n vectors uses ceil(n/gpuInterleavedWarpSize) *
+	// gpuInterleavedWarpSize slots for codes on the GPU, wasting
+	// (-n) mod gpuInterleavedWarpSize slots; each wasted slot costs
+	// one code.
+	var paddingVecs uint64
+	for _, n := range listCounts {
+		if rem := uint64(n) % gpuInterleavedWarpSize; rem != 0 {
+			paddingVecs += gpuInterleavedWarpSize - rem
+		}
+	}
+	size += paddingVecs * codeSize
+	return size
 }
 
 // attempt to add the vectors to the GPU index. If it fails,

--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,7 @@ go 1.25.0
 require (
 	github.com/RoaringBitmap/roaring/v2 v2.14.5
 	github.com/blevesearch/bleve_index_api v1.3.11
-	github.com/blevesearch/go-faiss v1.1.2
+	github.com/blevesearch/go-faiss v1.1.3-0.20260521215433-a4b54ee73db5
 	github.com/blevesearch/mmap-go v1.2.0
 	github.com/blevesearch/scorch_segment_api/v2 v2.4.7
 	github.com/blevesearch/vellum v1.2.0

--- a/go.sum
+++ b/go.sum
@@ -4,8 +4,8 @@ github.com/bits-and-blooms/bitset v1.24.2 h1:M7/NzVbsytmtfHbumG+K2bremQPMJuqv1JD
 github.com/bits-and-blooms/bitset v1.24.2/go.mod h1:7hO7Gc7Pp1vODcmWvKMRA9BNmbv6a/7QIWpPxHddWR8=
 github.com/blevesearch/bleve_index_api v1.3.11 h1:x29vbV8OjWfLcrDVd7Lr1q+BkLNS0JWNEig0MCVnKH4=
 github.com/blevesearch/bleve_index_api v1.3.11/go.mod h1:xvd48t5XMeeioWQ5/jZvgLrV98flT2rdvEJ3l/ki4Ko=
-github.com/blevesearch/go-faiss v1.1.2 h1:ojv2S7ot3orbk8wMfJWryq37G4eIL8Y8PLLZYd8ZLHY=
-github.com/blevesearch/go-faiss v1.1.2/go.mod h1:OMGQwOaRRYxrmeNdMrXJPvVx8gBnvE5RYrr0BahNnkk=
+github.com/blevesearch/go-faiss v1.1.3-0.20260521215433-a4b54ee73db5 h1:O450JE1fjDAnhj2oJXWfA5D9dM7xqT3zgbPt95vbDIk=
+github.com/blevesearch/go-faiss v1.1.3-0.20260521215433-a4b54ee73db5/go.mod h1:OMGQwOaRRYxrmeNdMrXJPvVx8gBnvE5RYrr0BahNnkk=
 github.com/blevesearch/mmap-go v1.2.0 h1:l33nNKPFcBjJUMwem6sAYJPUzhUCABoK9FxZDGiFNBI=
 github.com/blevesearch/mmap-go v1.2.0/go.mod h1:Vd6+20GBhEdwJnU1Xohgt88XCD/CTWcqbCNxkZpyBo0=
 github.com/blevesearch/scorch_segment_api/v2 v2.4.7 h1:GlMzW08hcsM3DnLUxhyF/1PcDal1qtvvIuytuph5djw=


### PR DESCRIPTION
Add new `estimateGPUMemSize` which is used to get a more accurate estimate of the memory occupied on GPU by an index.