### PR TITLE
MB-71397: Add on CPU index if `Add` OOMs on GPU.

### DIFF
--- a/faiss_vector_index_gpu_float32.go
+++ b/faiss_vector_index_gpu_float32.go
@@ -20,6 +20,7 @@ package zap
 import (
 	"encoding/binary"
 	"encoding/json"
+	"errors"
 	"reflect"
 	"sync/atomic"
 
@@ -177,7 +178,6 @@ func (f *faissGPUFloat32Index) close() {
 	f.waitGPU()
 	f.teardownGPU()
 	f.cpuIdx.Close()
-	f.idxBytes = nil
 }
 
 // teardownGPU stops the batcher first (while gpuIdx is still live so that
@@ -317,8 +317,21 @@ func (f *faissGPUFloat32Index) trainAndAdd(trainingData *vectorSet, vecsToAdd *v
 
 	err = gpuState.idx.Add(vecsToAdd.floatData)
 	if err != nil {
+		// Fallback to full CPU train and add if:
+		// 1. We get a non-OOM error from the GPU index
+		if !errors.Is(err, faiss.ErrGPUOutOfMemory) {
+			f.teardownGPU()
+			return f.trainAndAddCPU(trainingData, vecsToAdd)
+		}
+		// 2. We get an OOM error but syncing GPU to CPU fails.
+		if f.syncGPUToCPU() != nil {
+			f.teardownGPU()
+			return f.trainAndAddCPU(trainingData, vecsToAdd)
+		}
+		// OOM but CPU sync succeeded: both indexes are trained.
+		// Teardown GPU to avoid discrepancy, add to CPU instead.
 		f.teardownGPU()
-		return f.trainAndAddCPU(trainingData, vecsToAdd)
+		return f.cpuIdx.Add(vecsToAdd.floatData)
 	}
 
 	err = f.syncGPUToCPU()
@@ -353,6 +366,7 @@ func (f *faissGPUFloat32Index) mergeFrom(other faissIndex, offset int64) error {
 // syncGPUToCPU clones the current GPU index state back to the CPU index,
 // replacing the old CPU index.
 func (f *faissGPUFloat32Index) syncGPUToCPU() error {
+	f.waitGPU()
 	gpuState := f.gpu.Load()
 	if gpuState == nil {
 		return nil

--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,7 @@ go 1.25.0
 require (
 	github.com/RoaringBitmap/roaring/v2 v2.14.5
 	github.com/blevesearch/bleve_index_api v1.3.11
-	github.com/blevesearch/go-faiss v1.1.2
+	github.com/blevesearch/go-faiss v1.1.3-0.20260525132456-c1cb753e04cd
 	github.com/blevesearch/mmap-go v1.2.0
 	github.com/blevesearch/scorch_segment_api/v2 v2.4.7
 	github.com/blevesearch/vellum v1.2.0

--- a/go.sum
+++ b/go.sum
@@ -4,8 +4,8 @@ github.com/bits-and-blooms/bitset v1.24.2 h1:M7/NzVbsytmtfHbumG+K2bremQPMJuqv1JD
 github.com/bits-and-blooms/bitset v1.24.2/go.mod h1:7hO7Gc7Pp1vODcmWvKMRA9BNmbv6a/7QIWpPxHddWR8=
 github.com/blevesearch/bleve_index_api v1.3.11 h1:x29vbV8OjWfLcrDVd7Lr1q+BkLNS0JWNEig0MCVnKH4=
 github.com/blevesearch/bleve_index_api v1.3.11/go.mod h1:xvd48t5XMeeioWQ5/jZvgLrV98flT2rdvEJ3l/ki4Ko=
-github.com/blevesearch/go-faiss v1.1.2 h1:ojv2S7ot3orbk8wMfJWryq37G4eIL8Y8PLLZYd8ZLHY=
-github.com/blevesearch/go-faiss v1.1.2/go.mod h1:OMGQwOaRRYxrmeNdMrXJPvVx8gBnvE5RYrr0BahNnkk=
+github.com/blevesearch/go-faiss v1.1.3-0.20260525132456-c1cb753e04cd h1:ftEpy+Ma4N/O4zgIRn4pKZOhmi8UnvApcYT6hTf0IYQ=
+github.com/blevesearch/go-faiss v1.1.3-0.20260525132456-c1cb753e04cd/go.mod h1:w3W9AiWsFRGVaMG+/cmJi7iHEAuGyC6blsgO1EzCK/M=
 github.com/blevesearch/mmap-go v1.2.0 h1:l33nNKPFcBjJUMwem6sAYJPUzhUCABoK9FxZDGiFNBI=
 github.com/blevesearch/mmap-go v1.2.0/go.mod h1:Vd6+20GBhEdwJnU1Xohgt88XCD/CTWcqbCNxkZpyBo0=
 github.com/blevesearch/scorch_segment_api/v2 v2.4.7 h1:GlMzW08hcsM3DnLUxhyF/1PcDal1qtvvIuytuph5djw=


### PR DESCRIPTION
- Current behaviour of the `trainAndAdd` is an atomic transaction:
    - Output is always a CPU index which is trained and has vectors added.
    - If either `Train` or `Add` or `CloneToCPU` fails on the GPU index:
         - Destroy GPU index.
         - Train CPU index and Add to it.
    - Else if all three operations succeed:
         - GPU and CPU index are in sync/equivalent.
- With the new memory management code in go-faiss, an `Add` operation may throw an OOM error,
  indicating that the GPU index has rejected vector addition due to lack of memory.
- In this case the GPU index is still a perfectly valid trained index and retraining 
  the CPU index following the old behaviour is wasteful.
- This PR fixes this issue by introducing a new caveat in the atomic operation:
    - If `Add` fails on the GPU index:
        - If error is an OOM exception:
            - Clone the GPU index to the CPU.
            - Teardown the GPU index.
            - Add the vectors to the CPU index (No Train).
        - Else, teardown the GPU index and fall back to training and adding to the CPU index.
- Requires: https://github.com/blevesearch/go-faiss/pull/66