### PR TITLE
Regression fix: Compute `Size()` on the fly

### DIFF
--- a/faiss_vector_cache.go
+++ b/faiss_vector_cache.go
@@ -206,15 +206,6 @@ func (vc *vectorIndexCache) insertLOCKED(fieldID uint16,
 	vc.cache[fieldID] = createCacheEntry(index, mapping, 0.4)
 }
 
-func (vc *vectorIndexCache) incHit(fieldID uint16) {
-	vc.m.RLock()
-	entry, ok := vc.cache[fieldID]
-	if ok {
-		entry.incHit()
-	}
-	vc.m.RUnlock()
-}
-
 func (vc *vectorIndexCache) decRef(fieldID uint16) {
 	vc.m.RLock()
 	entry, ok := vc.cache[fieldID]

--- a/faiss_vector_posting.go
+++ b/faiss_vector_posting.go
@@ -309,11 +309,6 @@ func (sb *SegmentBase) InterpretVectorIndex(field string, except *roaring.Bitmap
 	if err != nil {
 		return nil, err
 	}
-	// update the size of the wrapper if we have successfully loaded the vector index
-	if rv.index != nil {
-		rv.updateSize()
-	}
-
 	// get the number of nested documents in this segment, if any
 	// to determine if the wrapper needs to handle nested documents
 	rv.nestedMode = sb.countNested() > 0

--- a/faiss_vector_wrapper.go
+++ b/faiss_vector_wrapper.go
@@ -68,7 +68,6 @@ type vectorIndexWrapper struct {
 	mapping *idMapping
 	exclude *bitmap
 	fieldID uint16
-	size    uint64
 
 	// nestedMode indicates if the vector index is operating in nested document mode.
 	// if so we have a reusable ancestry slice to help with docID lookups
@@ -288,10 +287,6 @@ func (v *vectorIndexWrapper) Close() {
 }
 
 func (v *vectorIndexWrapper) Size() uint64 {
-	return v.size
-}
-
-func (v *vectorIndexWrapper) updateSize() {
 	sizeInBytes := reflectStaticSizeIndexWrapper
 	if v.index != nil {
 		sizeInBytes += v.index.size()
@@ -302,7 +297,7 @@ func (v *vectorIndexWrapper) updateSize() {
 	if v.exclude != nil {
 		sizeInBytes += v.exclude.size()
 	}
-	v.size = sizeInBytes
+	return sizeInBytes
 }
 
 func (v *vectorIndexWrapper) ObtainKCentroidCardinalitiesFromIVFIndex(limit int, descending bool) (


### PR DESCRIPTION
- With a previous change, the `Size()` API was fixed to report the correct vector index size.
  However this computation was always done everytime a vector index snapshot was created using
  the `InterpretVectorIndex` API.
- This added unnecessary overhead which resulted in perf degradation, this pattern 
  worked in the old `Size` API as it was just a simple operation and no computation was done.
- Fix this issue by computing the size when the `Size` API is called on a snapshot rather than at the time of snapshot creation.