### PR TITLE
Bug Fix: Add a guard for config

### DIFF
--- a/merge.go
+++ b/merge.go
@@ -205,7 +205,9 @@ func mergeToWriter(segments []*SegmentBase, drops []*roaring.Bitmap,
 		"fieldsMap":     fieldsMap,
 		"numDocs":       numDocs,
 		"fieldsOptions": fieldsOptions,
-		"config":        config,
+	}
+	if config != nil {
+		args["config"] = config
 	}
 
 	if numDocs > 0 {

--- a/new.go
+++ b/new.go
@@ -224,8 +224,10 @@ func (s *interim) convert() (uint64, uint64, error) {
 		"chunkMode":     s.chunkMode,
 		"fieldsMap":     s.FieldsMap,
 		"fieldsInv":     s.FieldsInv,
-		"config":        s.config,
 		"fieldsOptions": s.FieldsOptions,
+	}
+	if s.config != nil {
+		args["config"] = s.config
 	}
 	if s.opaque == nil {
 		s.opaque = map[int]resetable{}

--- a/section_faiss_vector_index.go
+++ b/section_faiss_vector_index.go
@@ -722,7 +722,7 @@ func determineCentroids(nvecs int) int {
 func (vo *vectorIndexOpaque) numCentroids(nvecs int) int {
 	nlist := determineCentroids(nvecs)
 	if vo.config != nil {
-		// training key is associated with some addtional params such as num centroids
+		// training key is associated with some additional parameters such as num centroids
 		// that might be specific to the fast merge path
 		if tp, ok := vo.config[index.TrainingKey].(*index.TrainingParams); ok {
 			nlist = tp.NumCentroids

--- a/section_faiss_vector_index.go
+++ b/section_faiss_vector_index.go
@@ -250,6 +250,9 @@ func (v *faissVectorIndexSection) Merge(opaque map[int]resetable, segments []*Se
 }
 
 func trainedIndexFromConfig(config map[string]interface{}, fieldName string) (faissIndexIVF, error) {
+	if config == nil {
+		return nil, nil
+	}
 	var trainedIndexFor index.TrainedIndexCallbackFn
 	var trainingParams *index.TrainingParams
 	var rv faissIndex
@@ -718,10 +721,12 @@ func determineCentroids(nvecs int) int {
 
 func (vo *vectorIndexOpaque) numCentroids(nvecs int) int {
 	nlist := determineCentroids(nvecs)
-	// training key is associated with some addtional params such as num centroids
-	// that might be specific to the fast merge path
-	if tp, ok := vo.config[index.TrainingKey].(*index.TrainingParams); ok {
-		nlist = tp.NumCentroids
+	if vo.config != nil {
+		// training key is associated with some addtional params such as num centroids
+		// that might be specific to the fast merge path
+		if tp, ok := vo.config[index.TrainingKey].(*index.TrainingParams); ok {
+			nlist = tp.NumCentroids
+		}
 	}
 	return nlist
 }


### PR DESCRIPTION
- `config` maybe `nil` when using the legacy `New` and `Open` APIs.
- Add a guard to always fallback to naive merge if `config` is nil in the fastmerge codepath.