### PR TITLE
MB-72221: Use GPU for `IVF,Flat` index class as well

### DIFF
--- a/faiss_vector_index_gpu_float32.go
+++ b/faiss_vector_index_gpu_float32.go
@@ -385,9 +385,7 @@ func (f *faissGPUFloat32Index) syncGPUToCPU() error {
 
 func (f *faissGPUFloat32Index) canUseGPU() bool {
 	switch f.params.optimization {
-	case index.IndexOptimizedForLatency, index.IndexOptimizedForRecall:
-		return f.params.numVecs >= ivfSq8Threshold
-	case index.IndexOptimizedForMemoryEfficient:
+	case index.IndexOptimizedForLatency, index.IndexOptimizedForRecall, index.IndexOptimizedForMemoryEfficient:
 		return f.params.numVecs >= ivfThreshold
 	default:
 		return false


### PR DESCRIPTION
- Previously we made a decision to omit vector indexes with `0 < NumVecs < 10k` from being cloned to the GPU due to no apparent gain in performance due to GPU usage at a unit scale.
- This however had a detrimental effect to the overall bleve index performance as we end up creating a large number of small sized `IVF_Flat` backed segments and few `IVF,SQ8` vector segments.
- Due to this a lot of performance would be left on the table unnecessarily, so this PR clones IVF,Flat indexes to the GPU as well.