### PR TITLE
Bug Fix: Handle `vectorIndexNotCached` case appropriately

### DIFF
--- a/faiss_vector_posting.go
+++ b/faiss_vector_posting.go
@@ -348,6 +348,9 @@ func (sb *SegmentBase) UpdateVectorFieldStats(stats segment.FieldStats) {
 			stats.Store("num_vector_indexes_in_gpu", fieldName, 1)
 		case vectorIndexInCPU:
 			stats.Store("num_vector_indexes_in_cpu", fieldName, 1)
+		default:
+			stats.Store("num_vector_indexes_in_cpu", fieldName, 0)
+			stats.Store("num_vector_indexes_in_gpu", fieldName, 0)
 		}
 	}
 }


### PR DESCRIPTION
- Currently, when the vector index is not cached in either the GPU or the CPU (memory-mapped),
  we do not update the vector field stat with a 0 value. 
- This results in the stat being omitted entirely from scorch stat, making it hard to 
  diagnose the vector index state.
- Fix this issue by setting the number of vector indexes in CPU and GPU to 0 when the index 
  is not cached.  