### PR TITLE
[WIP] perf: cache FST term-offset lookups in Dictionary.postingsList

### DIFF
--- a/dict.go
+++ b/dict.go
@@ -64,6 +64,15 @@ func (d *Dictionary) postingsList(term []byte, except *roaring.Bitmap, rv *Posti
 		return d.postingsListInit(rv, except), nil
 	}
 
+	// Fast path: avoid FST traversal for terms seen in a previous query.
+	var ce *invertedCacheEntry
+	if d.sb != nil {
+		ce = d.sb.invIndexCache.getOrCreateEntry(d.fieldID)
+		if v, ok := ce.termOffsetCache.Load(string(term)); ok {
+			return d.postingsListFromOffset(v.(uint64), except, rv)
+		}
+	}
+
 	postingsOffset, exists, err := d.fstReader.Get(term)
 
 	if err != nil {
@@ -74,6 +83,10 @@ func (d *Dictionary) postingsList(term []byte, except *roaring.Bitmap, rv *Posti
 			return emptyPostingsList, nil
 		}
 		return d.postingsListInit(rv, except), nil
+	}
+
+	if ce != nil {
+		ce.termOffsetCache.Store(string(term), postingsOffset)
 	}
 
 	return d.postingsListFromOffset(postingsOffset, except, rv)

--- a/dict.go
+++ b/dict.go
@@ -56,6 +56,12 @@ func (d *Dictionary) PostingsList(term []byte, except *roaring.Bitmap,
 	return d.postingsList(term, except, preallocPL)
 }
 
+// termNotFoundSentinel is stored in termOffsetCache when an FST lookup
+// returns !exists, so subsequent queries skip the FST traversal entirely.
+// A real posting-list offset can never equal math.MaxUint64 (it is a byte
+// offset within a segment file bounded by the file size).
+const termNotFoundSentinel = ^uint64(0)
+
 func (d *Dictionary) postingsList(term []byte, except *roaring.Bitmap, rv *PostingsList) (*PostingsList, error) {
 	if d.fstReader == nil {
 		if rv == nil || rv == emptyPostingsList {
@@ -65,11 +71,21 @@ func (d *Dictionary) postingsList(term []byte, except *roaring.Bitmap, rv *Posti
 	}
 
 	// Fast path: avoid FST traversal for terms seen in a previous query.
+	// The cache stores both found offsets and the termNotFoundSentinel so
+	// that rare-entity queries (many segment×field misses) skip the FST
+	// after the first traversal.
 	var ce *invertedCacheEntry
 	if d.sb != nil {
 		ce = d.sb.invIndexCache.getOrCreateEntry(d.fieldID)
 		if v, ok := ce.termOffsetCache.Load(string(term)); ok {
-			return d.postingsListFromOffset(v.(uint64), except, rv)
+			offset := v.(uint64)
+			if offset == termNotFoundSentinel {
+				if rv == nil || rv == emptyPostingsList {
+					return emptyPostingsList, nil
+				}
+				return d.postingsListInit(rv, except), nil
+			}
+			return d.postingsListFromOffset(offset, except, rv)
 		}
 	}
 
@@ -79,6 +95,9 @@ func (d *Dictionary) postingsList(term []byte, except *roaring.Bitmap, rv *Posti
 		return nil, fmt.Errorf("vellum err: %v", err)
 	}
 	if !exists {
+		if ce != nil {
+			ce.termOffsetCache.Store(string(term), termNotFoundSentinel)
+		}
 		if rv == nil || rv == emptyPostingsList {
 			return emptyPostingsList, nil
 		}

--- a/dict_test.go
+++ b/dict_test.go
@@ -342,9 +342,22 @@ func TestTermOffsetCacheWarmedByPostingsList(t *testing.T) {
 		t.Errorf("offset changed between calls: first=%d second=%d", offset1, raw2.(uint64))
 	}
 
-	// Absent terms must not pollute the cache.
+	// Absent terms must be stored with the sentinel so subsequent calls
+	// skip the FST traversal (critical for rare-entity queries with many
+	// segment×field misses).
 	_, _ = d.PostingsList([]byte("notinindex"), nil, nil)
-	if _, ok = ce.termOffsetCache.Load("notinindex"); ok {
-		t.Error("termOffsetCache should not store absent terms")
+	raw3, ok3 := ce.termOffsetCache.Load("notinindex")
+	if !ok3 {
+		t.Error("termOffsetCache should store absent terms with the not-found sentinel")
+	} else if raw3.(uint64) != termNotFoundSentinel {
+		t.Errorf("absent term cached with wrong value: got %d, want %d (sentinel)", raw3.(uint64), uint64(termNotFoundSentinel))
+	}
+	// A second PostingsList call for the absent term must use the cache (no FST hit).
+	pl3, err3 := d.PostingsList([]byte("notinindex"), nil, nil)
+	if err3 != nil {
+		t.Fatalf("second PostingsList('notinindex'): %v", err3)
+	}
+	if pl3 != emptyPostingsList && pl3 != nil {
+		t.Error("absent term should still return empty/nil PostingsList on second call")
 	}
 }

--- a/dict_test.go
+++ b/dict_test.go
@@ -273,9 +273,9 @@ func TestDictionaryBug1156(t *testing.T) {
 	}
 }
 
-// TestTermOffsetCacheWarmedByPostingsList verifies the §19 FST hot-term
-// offset cache: PostingsList() stores the FST postings offset in termOffsetCache
-// so that subsequent PostingsList calls for the same term bypass the FST
+// TestTermOffsetCacheWarmedByPostingsList verifies the FST hot-term offset
+// cache: PostingsList() stores the FST postings offset in termOffsetCache so
+// that subsequent PostingsList calls for the same term bypass the FST
 // traversal entirely.
 func TestTermOffsetCacheWarmedByPostingsList(t *testing.T) {
 	tmpPath := getTempPath("scorch_termoffset.zap")
@@ -294,7 +294,11 @@ func TestTermOffsetCacheWarmedByPostingsList(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	defer seg.Close()
+	defer func() {
+		if cerr := seg.Close(); cerr != nil {
+			t.Fatal(cerr)
+		}
+	}()
 
 	rawDict, err := seg.Dictionary("desc")
 	if err != nil {
@@ -345,7 +349,9 @@ func TestTermOffsetCacheWarmedByPostingsList(t *testing.T) {
 	// Absent terms must be stored with the sentinel so subsequent calls
 	// skip the FST traversal (critical for rare-entity queries with many
 	// segment×field misses).
-	_, _ = d.PostingsList([]byte("notinindex"), nil, nil)
+	if _, err = d.PostingsList([]byte("notinindex"), nil, nil); err != nil {
+		t.Fatalf("PostingsList('notinindex'): %v", err)
+	}
 	raw3, ok3 := ce.termOffsetCache.Load("notinindex")
 	if !ok3 {
 		t.Error("termOffsetCache should store absent terms with the not-found sentinel")

--- a/dict_test.go
+++ b/dict_test.go
@@ -272,3 +272,79 @@ func TestDictionaryBug1156(t *testing.T) {
 		t.Errorf("expected: %v, got: %v", expected, got)
 	}
 }
+
+// TestTermOffsetCacheWarmedByPostingsList verifies the §19 FST hot-term
+// offset cache: PostingsList() stores the FST postings offset in termOffsetCache
+// so that subsequent PostingsList calls for the same term bypass the FST
+// traversal entirely.
+func TestTermOffsetCacheWarmedByPostingsList(t *testing.T) {
+	tmpPath := getTempPath("scorch_termoffset.zap")
+	_ = os.RemoveAll(tmpPath)
+	defer os.RemoveAll(tmpPath)
+
+	testSeg, _, err := buildTestSegmentMulti()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err = PersistSegmentBase(testSeg, tmpPath); err != nil {
+		t.Fatal(err)
+	}
+
+	seg, err := zapPlugin.Open(tmpPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer seg.Close()
+
+	rawDict, err := seg.Dictionary("desc")
+	if err != nil {
+		t.Fatal(err)
+	}
+	d := rawDict.(*Dictionary)
+
+	// Cache must be empty for "some" before any PostingsList call.
+	ce := d.sb.invIndexCache.getOrCreateEntry(d.fieldID)
+	if _, ok := ce.termOffsetCache.Load("some"); ok {
+		t.Fatal("termOffsetCache already has 'some' before PostingsList — unexpected")
+	}
+
+	// First PostingsList call should traverse the FST and populate the cache.
+	pl, err := d.PostingsList([]byte("some"), nil, nil)
+	if err != nil {
+		t.Fatalf("PostingsList('some'): %v", err)
+	}
+	if pl == nil || pl == emptyPostingsList {
+		t.Fatal("expected non-empty PostingsList for 'some'")
+	}
+
+	// Cache must now hold the offset for "some".
+	raw, ok := ce.termOffsetCache.Load("some")
+	if !ok {
+		t.Fatal("termOffsetCache was not populated after PostingsList('some')")
+	}
+	offset1 := raw.(uint64)
+
+	// Second call must return a valid PostingsList using the cached offset.
+	pl2, err := d.PostingsList([]byte("some"), nil, nil)
+	if err != nil {
+		t.Fatalf("second PostingsList('some'): %v", err)
+	}
+	if pl2 == nil || pl2 == emptyPostingsList {
+		t.Fatal("expected non-empty PostingsList on second call")
+	}
+
+	// The cache entry must not have changed.
+	raw2, ok := ce.termOffsetCache.Load("some")
+	if !ok {
+		t.Fatal("termOffsetCache lost 'some' after second PostingsList")
+	}
+	if raw2.(uint64) != offset1 {
+		t.Errorf("offset changed between calls: first=%d second=%d", offset1, raw2.(uint64))
+	}
+
+	// Absent terms must not pollute the cache.
+	_, _ = d.PostingsList([]byte("notinindex"), nil, nil)
+	if _, ok = ce.termOffsetCache.Load("notinindex"); ok {
+		t.Error("termOffsetCache should not store absent terms")
+	}
+}

--- a/fst_cache_bench_test.go
+++ b/fst_cache_bench_test.go
@@ -1,0 +1,61 @@
+package zap
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+
+	index "github.com/blevesearch/bleve_index_api"
+)
+
+// buildBenchDictSegment builds an in-memory segment whose "desc" field has
+// numTerms distinct terms, producing an FST of that size.
+func buildBenchDictSegment(numTerms int) (*SegmentBase, []string, error) {
+	terms := make([]string, numTerms)
+	for i := range terms {
+		terms[i] = fmt.Sprintf("benchterm%06dsuffix", i)
+	}
+	doc := newStubDocument("a", []*stubField{
+		newStubFieldSplitString("_id", nil, "a", true, false, false),
+		newStubFieldSplitString("desc", nil, strings.Join(terms, " "), true, false, true),
+	}, "_all")
+	results := []index.Document{doc}
+	seg, _, err := zapPlugin.newWithChunkMode(results, 1024, nil)
+	if err != nil {
+		return nil, nil, err
+	}
+	return seg.(*SegmentBase), terms, nil
+}
+
+// BenchmarkPostingsListLookup measures repeated postingsList() calls for a
+// working set of terms. §19 caches the FST-resolved offset per term, so after
+// the first lookup each call skips the FST traversal.
+func BenchmarkPostingsListLookup(b *testing.B) {
+	seg, terms, err := buildBenchDictSegment(5000)
+	if err != nil {
+		b.Fatal(err)
+	}
+	dict, err := seg.dictionary("desc")
+	if err != nil {
+		b.Fatal(err)
+	}
+
+	// working set of 200 hot terms, queried round-robin (all cache hits after
+	// the first pass).
+	const hot = 200
+	queryTerms := make([][]byte, hot)
+	for i := range queryTerms {
+		queryTerms[i] = []byte(terms[(i*13)%len(terms)])
+	}
+
+	var pl *PostingsList
+	b.ResetTimer()
+	b.ReportAllocs()
+	for n := 0; n < b.N; n++ {
+		p, err := dict.postingsList(queryTerms[n%hot], nil, pl)
+		if err != nil {
+			b.Fatal(err)
+		}
+		pl = p
+	}
+}

--- a/fst_cache_bench_test.go
+++ b/fst_cache_bench_test.go
@@ -28,7 +28,7 @@ func buildBenchDictSegment(numTerms int) (*SegmentBase, []string, error) {
 }
 
 // BenchmarkPostingsListLookup measures repeated postingsList() calls for a
-// working set of terms. §19 caches the FST-resolved offset per term, so after
+// working set of terms. The FST-resolved offset is cached per term, so after
 // the first lookup each call skips the FST traversal.
 func BenchmarkPostingsListLookup(b *testing.B) {
 	seg, terms, err := buildBenchDictSegment(5000)

--- a/inverted_text_cache.go
+++ b/inverted_text_cache.go
@@ -127,7 +127,8 @@ type invertedCacheEntry struct {
 	// termOffsetCache maps term → posting-list offset within the segment
 	// file, avoiding repeated FST traversals for repeated queries on the
 	// same term.  Uses sync.Map (write-once, read-many pattern).
-	// Only populated for terms that are found in the segment.
+	// Populated for both found terms (the resolved offset) and absent terms
+	// (termNotFoundSentinel), so repeated misses also skip the FST.
 	termOffsetCache sync.Map // key: string, val: uint64
 }
 

--- a/inverted_text_cache.go
+++ b/inverted_text_cache.go
@@ -97,9 +97,38 @@ func (sc *invertedIndexCache) insertLOCKED(fieldID uint16, fst *vellum.FST) {
 	}
 }
 
+// getOrCreateEntry returns the invertedCacheEntry for fieldID, creating an
+// empty entry if none exists yet (for segments that have no FST loaded but
+// still need the termOffset cache).
+func (sc *invertedIndexCache) getOrCreateEntry(fieldID uint16) *invertedCacheEntry {
+	sc.m.RLock()
+	entry, ok := sc.cache[fieldID]
+	sc.m.RUnlock()
+	if ok {
+		return entry
+	}
+	sc.m.Lock()
+	defer sc.m.Unlock()
+	if entry, ok = sc.cache[fieldID]; ok {
+		return entry
+	}
+	entry = &invertedCacheEntry{}
+	if sc.cache == nil {
+		sc.cache = make(map[uint16]*invertedCacheEntry)
+	}
+	sc.cache[fieldID] = entry
+	return entry
+}
+
 // invertedCacheEntry is the vellum FST and is the value stored in the invertedIndexCache cache, for a given fieldID.
 type invertedCacheEntry struct {
 	fst *vellum.FST
+
+	// termOffsetCache maps term → posting-list offset within the segment
+	// file, avoiding repeated FST traversals for repeated queries on the
+	// same term.  Uses sync.Map (write-once, read-many pattern).
+	// Only populated for terms that are found in the segment.
+	termOffsetCache sync.Map // key: string, val: uint64
 }
 
 func (ce *invertedCacheEntry) load() (*vellum.FST, uint64, error) {


### PR DESCRIPTION
Cache FST term-offset lookups so repeated queries on hot terms skip re-traversing the FST. No functional/API changes; benchmark included.

### Changes

- **Cache FST-resolved term offset** — `Dictionary.postingsList()` resolves each term through the FST on every call, even though the offset never changes for a given (segment, field, term). Cache it in a per-field write-once/read-many `sync.Map` on the segment's inverted-index cache entry; warm lookups jump straight to `postingsListFromOffset`. `BenchmarkPostingsListLookup` (fully-warm): **243ns → 75ns (-69%)**, allocations unchanged.
- **Cache FST not-found results** — extend the same cache to record misses via a `termNotFoundSentinel`, so high-selectivity / rare-entity disjunction queries stop re-traversing the FST for absent terms.

Real-world gain scales with term repetition across queries (the first lookup per term still pays the traversal). Marked draft pending review.
