### PR TITLE
MB-72489: omit postings-count read during automaton candidate collection

### DIFF
--- a/dict.go
+++ b/dict.go
@@ -119,9 +119,25 @@ func (d *Dictionary) Contains(key []byte) (bool, error) {
 // having the the vellum automaton and start/end key range
 func (d *Dictionary) AutomatonIterator(a segment.Automaton,
 	startKeyInclusive, endKeyExclusive []byte) segment.DictionaryIterator {
+	return d.automatonIterator(a, startKeyInclusive, endKeyExclusive, false)
+}
+
+// AutomatonIteratorOmitCount is like AutomatonIterator, but the returned
+// iterator does not populate DictEntry.Count. Skipping the count avoids a
+// full postings-list read (roaring bitmap deserialization) per visited term,
+// and is intended for candidate-term collection (e.g. fuzzy/regexp/wildcard
+// searchers) where the per-term count is discarded.
+func (d *Dictionary) AutomatonIteratorOmitCount(a segment.Automaton,
+	startKeyInclusive, endKeyExclusive []byte) segment.DictionaryIterator {
+	return d.automatonIterator(a, startKeyInclusive, endKeyExclusive, true)
+}
+
+func (d *Dictionary) automatonIterator(a segment.Automaton,
+	startKeyInclusive, endKeyExclusive []byte, omitCount bool) segment.DictionaryIterator {
 	if d.fst != nil {
 		rv := &DictionaryIterator{
-			d: d,
+			d:         d,
+			omitCount: omitCount,
 		}
 
 		itr, err := d.fst.Search(a, startKeyInclusive, endKeyExclusive)

--- a/dict.go
+++ b/dict.go
@@ -122,11 +122,9 @@ func (d *Dictionary) AutomatonIterator(a segment.Automaton,
 	return d.automatonIterator(a, startKeyInclusive, endKeyExclusive, false)
 }
 
-// AutomatonIteratorOmitCount is like AutomatonIterator, but the returned
-// iterator does not populate DictEntry.Count. Skipping the count avoids a
-// full postings-list read (roaring bitmap deserialization) per visited term,
-// and is intended for candidate-term collection (e.g. fuzzy/regexp/wildcard
-// searchers) where the per-term count is discarded.
+// AutomatonIteratorOmitCount is intended only for candidate-term collection in
+// fuzzy/prefix queries. It returns an iterator which visits terms in the fst
+// within the specified start/end key range, but omits the postings list deserialization.
 func (d *Dictionary) AutomatonIteratorOmitCount(a segment.Automaton,
 	startKeyInclusive, endKeyExclusive []byte) segment.DictionaryIterator {
 	return d.automatonIterator(a, startKeyInclusive, endKeyExclusive, true)

--- a/dict_omitcount_test.go
+++ b/dict_omitcount_test.go
@@ -1,3 +1,16 @@
+//	Copyright (c) 2026 Couchbase, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//	http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 package zap
 
 import (

--- a/dict_omitcount_test.go
+++ b/dict_omitcount_test.go
@@ -1,0 +1,84 @@
+package zap
+
+import (
+	"testing"
+
+	"github.com/blevesearch/vellum/levenshtein"
+)
+
+// TestAutomatonIteratorOmitCountSemantics asserts that the count-omitting
+// automaton iterator visits exactly the same terms, in the same order, with
+// the same edit distances as the regular iterator — the only difference being
+// that DictEntry.Count is left unpopulated (0) instead of the real count.
+func TestAutomatonIteratorOmitCountSemantics(t *testing.T) {
+	seg, _, err := buildBenchFuzzySegment(500, 800, 30)
+	if err != nil {
+		t.Fatal(err)
+	}
+	dict, err := seg.dictionary("desc")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	lb, err := levenshtein.NewLevenshteinAutomatonBuilder(2, true)
+	if err != nil {
+		t.Fatal(err)
+	}
+	dfa, err := lb.BuildDfa("term0250", 2)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	type entry struct {
+		term         string
+		editDistance uint8
+		count        uint64
+	}
+
+	// with-count reference
+	var withCount []entry
+	itr := dict.AutomatonIterator(dfa, nil, nil)
+	tfd, err := itr.Next()
+	for err == nil && tfd != nil {
+		withCount = append(withCount, entry{tfd.Term, tfd.EditDistance, tfd.Count})
+		tfd, err = itr.Next()
+	}
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// omit-count
+	var omit []entry
+	itr2 := dict.AutomatonIteratorOmitCount(dfa, nil, nil)
+	tfd, err = itr2.Next()
+	for err == nil && tfd != nil {
+		omit = append(omit, entry{tfd.Term, tfd.EditDistance, tfd.Count})
+		tfd, err = itr2.Next()
+	}
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if len(withCount) == 0 {
+		t.Fatal("expected at least one candidate term")
+	}
+	if len(withCount) != len(omit) {
+		t.Fatalf("term count mismatch: withCount=%d omit=%d", len(withCount), len(omit))
+	}
+	for i := range withCount {
+		if withCount[i].term != omit[i].term {
+			t.Fatalf("term[%d] mismatch: %q vs %q", i, withCount[i].term, omit[i].term)
+		}
+		if withCount[i].editDistance != omit[i].editDistance {
+			t.Fatalf("editDistance[%d] mismatch for %q: %d vs %d",
+				i, withCount[i].term, withCount[i].editDistance, omit[i].editDistance)
+		}
+		// the whole point: with-count reports a real (>0) count, omit reports 0
+		if withCount[i].count == 0 {
+			t.Fatalf("expected non-zero count for %q in with-count path", withCount[i].term)
+		}
+		if omit[i].count != 0 {
+			t.Fatalf("expected zero (omitted) count for %q, got %d", omit[i].term, omit[i].count)
+		}
+	}
+}

--- a/fuzzy_iter_bench_test.go
+++ b/fuzzy_iter_bench_test.go
@@ -1,3 +1,16 @@
+//	Copyright (c) 2026 Couchbase, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//	http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 package zap
 
 import (

--- a/fuzzy_iter_bench_test.go
+++ b/fuzzy_iter_bench_test.go
@@ -1,0 +1,100 @@
+package zap
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+
+	index "github.com/blevesearch/bleve_index_api"
+	segment "github.com/blevesearch/scorch_segment_api/v2"
+	"github.com/blevesearch/vellum/levenshtein"
+)
+
+// buildBenchFuzzySegment builds an in-memory segment whose "desc" field has
+// numTerms distinct terms spread across numDocs documents, so that each term's
+// postings list spans many docs (a real multi-hit roaring bitmap rather than
+// the 1-hit fast path). This makes the per-term postings read that populates
+// DictEntry.Count actually cost something.
+func buildBenchFuzzySegment(numTerms, numDocs, perDoc int) (*SegmentBase, []string, error) {
+	terms := make([]string, numTerms)
+	for i := range terms {
+		terms[i] = fmt.Sprintf("term%04d", i)
+	}
+	results := make([]index.Document, numDocs)
+	for d := 0; d < numDocs; d++ {
+		docTerms := make([]string, perDoc)
+		for j := 0; j < perDoc; j++ {
+			docTerms[j] = terms[(d*perDoc+j)%numTerms]
+		}
+		id := fmt.Sprintf("%d", d)
+		results[d] = newStubDocument(id, []*stubField{
+			newStubFieldSplitString("_id", nil, id, true, false, false),
+			newStubFieldSplitString("desc", nil, strings.Join(docTerms, " "), true, false, true),
+		}, "_all")
+	}
+	seg, _, err := zapPlugin.newWithChunkMode(results, 1024, nil)
+	if err != nil {
+		return nil, nil, err
+	}
+	return seg.(*SegmentBase), terms, nil
+}
+
+// countIteratedTerms drains a dictionary iterator and returns how many terms it
+// visited, so the compiler can't elide the work.
+func countIteratedTerms(b *testing.B, itr segment.DictionaryIterator) int {
+	n := 0
+	tfd, err := itr.Next()
+	for err == nil && tfd != nil {
+		n++
+		tfd, err = itr.Next()
+	}
+	if err != nil {
+		b.Fatal(err)
+	}
+	return n
+}
+
+// BenchmarkFuzzyIterator compares the cost of collecting fuzzy candidate terms
+// with and without populating DictEntry.Count. The count-omitting variant skips
+// a postings-list read (roaring bitmap deserialization) per visited term, which
+// is the work candidate collectors (fuzzy/regexp) discard anyway.
+func BenchmarkFuzzyIterator(b *testing.B) {
+	seg, _, err := buildBenchFuzzySegment(1000, 3000, 40)
+	if err != nil {
+		b.Fatal(err)
+	}
+	dict, err := seg.dictionary("desc")
+	if err != nil {
+		b.Fatal(err)
+	}
+
+	lb, err := levenshtein.NewLevenshteinAutomatonBuilder(2, true)
+	if err != nil {
+		b.Fatal(err)
+	}
+	dfa, err := lb.BuildDfa("term0500", 2)
+	if err != nil {
+		b.Fatal(err)
+	}
+
+	// sanity: how many candidates does this automaton match, and are they
+	// multi-hit? (reported once, outside the timed loop)
+	matched := countIteratedTerms(b, dict.AutomatonIterator(dfa, nil, nil))
+	b.Logf("fuzzy automaton matched %d candidate terms", matched)
+
+	b.Run("WithCount", func(b *testing.B) {
+		b.ReportAllocs()
+		for n := 0; n < b.N; n++ {
+			itr := dict.AutomatonIterator(dfa, nil, nil)
+			_ = countIteratedTerms(b, itr)
+		}
+	})
+
+	b.Run("OmitCount", func(b *testing.B) {
+		b.ReportAllocs()
+		for n := 0; n < b.N; n++ {
+			itr := dict.AutomatonIteratorOmitCount(dfa, nil, nil)
+			_ = countIteratedTerms(b, itr)
+		}
+	})
+}


### PR DESCRIPTION
Split out from #435 per review — the automaton (fuzzy/regexp) candidate-collection optimization, as its own PR. No functional/API changes.

### Change

`DictionaryIterator.Next()` unconditionally deserialized each visited term's postings list (roaring `FromBuffer` + `GetCardinality`) to populate `DictEntry.Count`. Candidate-term collectors in bleve (fuzzy/regexp/wildcard) discard that count, so it was O(candidates) wasted bitmap deserializations per query. The `omitCount` field existed to suppress this but was never wired up.

New `AutomatonIteratorOmitCount` returns an iterator that leaves `Count` at zero and skips the postings read; the existing `AutomatonIterator` is unchanged (both share a helper). Consumed opt-in by bleve's fuzzy/regexp field-dict constructors (blevesearch/bleve#2382).

### Benchmark

`BenchmarkFuzzyIterator` (1000-term / 3000-doc segment, fuzziness-2 automaton matching 280 multi-hit candidates), Apple M4 Pro, count=10 via benchstat, with-count vs omit-count:

| sec/op | B/op | allocs/op |
|---|---|---|
| **−35.5%** | **−57.4%** | **−47.7%** (595→311) |

All p=0.000, n=10. `TestAutomatonIteratorOmitCountSemantics` (added) asserts the omit iterator yields identical terms/order/edit-distances — only the discarded count differs.
