### PR TITLE
fix: reject truncated encoded integers

### DIFF
--- a/memuvarint.go
+++ b/memuvarint.go
@@ -16,6 +16,7 @@ package zap
 
 import (
 	"fmt"
+	"io"
 )
 
 type memUvarintReader struct {
@@ -50,6 +51,10 @@ func (r *memUvarintReader) ReadUvarint() (uint64, error) {
 	var S = r.S
 
 	for {
+		if C >= len(S) {
+			r.C = C
+			return 0, io.ErrUnexpectedEOF
+		}
 		b := S[C]
 		C++
 

--- a/memuvarint_test.go
+++ b/memuvarint_test.go
@@ -17,9 +17,24 @@ package zap
 import (
 	"bytes"
 	"encoding/binary"
+	"errors"
+	"io"
 	"math"
 	"testing"
 )
+
+func TestMemUvarintReaderReturnsUnexpectedEOFForTruncatedValue(t *testing.T) {
+	for _, input := range [][]byte{{0x80}, {0x80, 0x80}, {0xff, 0xff, 0xff}} {
+		reader := newMemUvarintReader(input)
+		_, err := reader.ReadUvarint()
+		if !errors.Is(err, io.ErrUnexpectedEOF) {
+			t.Fatalf("ReadUvarint(%x) error = %v, want %v", input, err, io.ErrUnexpectedEOF)
+		}
+		if reader.C != len(input) {
+			t.Fatalf("ReadUvarint(%x) consumed %d bytes, want %d", input, reader.C, len(input))
+		}
+	}
+}
 
 func BenchmarkUvarint(b *testing.B) {
 	n, buf := generateCommonUvarints(64, 512)


### PR DESCRIPTION
## Summary

Return `io.ErrUnexpectedEOF` when `memUvarintReader` reaches the end of its
input after reading a continuation byte.

The reader previously checked for empty input only before entering its decode
loop. If the final available byte had its continuation bit set, the next loop
iteration indexed beyond the slice and panicked.

## Change

- check the cursor before each in-loop slice access;
- preserve the consumed cursor position on truncation;
- add regression cases containing one and multiple continuation bytes.

## Validation

`go test ./...`

## Additional resources

If you are willing to endure some slop writing, this is how I/the llm encountered the issue: https://parc.yolo.scapegoat.dev/note/projects/2026/07/28/project-report-zapx-defensive-varint-decoding-for-corrupt-bleve-postings