### PR TITLE
MB-73783: Bit-packed postings list with SIMD encode/decode

### DIFF
--- a/build.go
+++ b/build.go
@@ -27,7 +27,7 @@ import (
 	segment "github.com/blevesearch/scorch_segment_api/v2"
 )
 
-const Version uint32 = 17
+const Version uint32 = 18
 
 const Type string = "zap"
 

--- a/cmd/zap/cmd/dict.go
+++ b/cmd/zap/cmd/dict.go
@@ -17,11 +17,9 @@ package cmd
 import (
 	"encoding/binary"
 	"fmt"
-	"math"
 
-	"github.com/RoaringBitmap/roaring/v2"
 	"github.com/blevesearch/vellum"
-	zap "github.com/blevesearch/zapx/v17"
+	zap "github.com/blevesearch/zapx/v18"
 	"github.com/spf13/cobra"
 )
 
@@ -59,17 +57,19 @@ var dictCmd = &cobra.Command{
 			for err == nil {
 				currTerm, currVal := itr.Current()
 				extra := ""
-				if currVal&zap.FSTValEncodingMask == zap.FSTValEncoding1Hit {
-					docNum, normBits := zap.FSTValDecode1Hit(currVal)
-					norm := math.Float32frombits(uint32(normBits))
-					extra = fmt.Sprintf("-- docNum: %d, norm: %f", docNum, norm)
+				info, err := zap.DescribeTermPostings(data, currVal)
+				if err != nil {
+					return err
+				}
+				if info.OneHit {
+					extra = fmt.Sprintf("-- docNum: %d", info.DocNum)
 					fmt.Printf(" %s - %d (%x) %s\n", currTerm, currVal, currVal, extra)
 					hit1Count++
 				} else {
-					// fetch the postings size, cardinality in case of non 1 hits
-					l, c := readPostingCardinality(currVal, data)
-					fmt.Printf(" %s - %d (%x) posting byteSize: %d cardinality: %d\n",
-						currTerm, currVal, currVal, l, c)
+					fmt.Printf(" %s - %d (%x) docFreq: %d blocks: %d tail: %d "+
+						"payload: %d skip: %d locs: %d\n",
+						currTerm, currVal, currVal, info.DocFreq, info.NumBlocks,
+						info.TailLen, info.PayloadLen, info.SkipLen, info.LocsLen)
 				}
 				termsCount++
 				err = itr.Next()
@@ -86,31 +86,4 @@ var dictCmd = &cobra.Command{
 
 func init() {
 	RootCmd.AddCommand(dictCmd)
-}
-
-func readPostingCardinality(postingsOffset uint64, data []byte) (int, uint64) {
-	// read the location of the freq/norm details
-	var n uint64
-	var read int
-
-	_, read = binary.Uvarint(data[postingsOffset+n : postingsOffset+binary.MaxVarintLen64])
-	n += uint64(read)
-
-	_, read = binary.Uvarint(data[postingsOffset+n : postingsOffset+n+binary.MaxVarintLen64])
-	n += uint64(read)
-
-	var postingsLen uint64
-	postingsLen, read = binary.Uvarint(data[postingsOffset+n : postingsOffset+n+binary.MaxVarintLen64])
-	n += uint64(read)
-
-	roaringBytes := data[postingsOffset+n : postingsOffset+n+postingsLen]
-
-	r := roaring.NewBitmap()
-
-	_, err := r.FromBuffer(roaringBytes)
-	if err != nil {
-		fmt.Printf("error loading roaring bitmap: %v", err)
-	}
-
-	return len(roaringBytes), r.GetCardinality()
 }

--- a/cmd/zap/cmd/docvalue.go
+++ b/cmd/zap/cmd/docvalue.go
@@ -24,7 +24,7 @@ import (
 	"strconv"
 
 	index "github.com/blevesearch/bleve_index_api"
-	zap "github.com/blevesearch/zapx/v17"
+	zap "github.com/blevesearch/zapx/v18"
 	"github.com/golang/snappy"
 	"github.com/spf13/cobra"
 )

--- a/cmd/zap/cmd/explore.go
+++ b/cmd/zap/cmd/explore.go
@@ -17,11 +17,9 @@ package cmd
 import (
 	"encoding/binary"
 	"fmt"
-	"math"
 
-	"github.com/RoaringBitmap/roaring/v2"
 	"github.com/blevesearch/vellum"
-	zap "github.com/blevesearch/zapx/v17"
+	zap "github.com/blevesearch/zapx/v18"
 	"github.com/spf13/cobra"
 )
 
@@ -63,58 +61,29 @@ var exploreCmd = &cobra.Command{
 				if exists {
 					fmt.Printf("FST val is %d (%x)\n", postingsAddr, postingsAddr)
 
-					if postingsAddr&zap.FSTValEncodingMask == zap.FSTValEncoding1Hit {
-						docNum, normBits := zap.FSTValDecode1Hit(postingsAddr)
-						norm := math.Float32frombits(uint32(normBits))
-						fmt.Printf("Posting List is 1-hit encoded, docNum: %d, norm: %f\n",
-							docNum, norm)
-						return nil
-					}
-
-					if postingsAddr&zap.FSTValEncodingMask != zap.FSTValEncodingGeneral {
-						return fmt.Errorf("unknown fst val encoding")
-					}
-
-					var n uint64
-					freqAddr, read := binary.Uvarint(data[postingsAddr : postingsAddr+binary.MaxVarintLen64])
-					n += uint64(read)
-
-					var locAddr uint64
-					locAddr, read = binary.Uvarint(data[postingsAddr+n : postingsAddr+n+binary.MaxVarintLen64])
-					n += uint64(read)
-
-					var postingListLen uint64
-					postingListLen, read = binary.Uvarint(data[postingsAddr+n : postingsAddr+n+binary.MaxVarintLen64])
-					n += uint64(read)
-
-					fmt.Printf("Posting List Length: %d\n", postingListLen)
-					bitmap := roaring.New()
-					_, err = bitmap.FromBuffer(data[postingsAddr+n : postingsAddr+n+postingListLen])
+					info, err := zap.DescribeTermPostings(data, postingsAddr)
 					if err != nil {
 						return err
 					}
-					fmt.Printf("Posting List: %v\n", bitmap)
-
-					fmt.Printf("Freq details at: %d (%x)\n", freqAddr, freqAddr)
-					numChunks, r2 := binary.Uvarint(data[freqAddr : freqAddr+binary.MaxVarintLen64])
-					n = uint64(r2)
-
-					var freqOffsets []uint64
-					for j := uint64(0); j < numChunks; j++ {
-						chunkLen, r3 := binary.Uvarint(data[freqAddr+n : freqAddr+n+binary.MaxVarintLen64])
-						n += uint64(r3)
-						freqOffsets = append(freqOffsets, chunkLen)
-					}
-					running := freqAddr + n
-					for k, offset := range freqOffsets {
-						fmt.Printf("freq chunk: %d, len %d, start at %d (%x) end %d (%x)\n", k, offset, running, running, running+offset, running+offset)
-						running += offset
+					if info.OneHit {
+						fmt.Printf("Posting List is 1-hit encoded, docNum: %d\n", info.DocNum)
+						return nil
 					}
 
-					if locAddr != termNotEncoded {
-						fmt.Printf("Loc details at: %d (%x)\n", locAddr, locAddr)
+					fmt.Printf("docFreq: %d hasFreqs: %v hasLocs: %v\n",
+						info.DocFreq, info.HasFreqs, info.HasLocs)
+					fmt.Printf("payload: %d bytes at %d (%x), %d full blocks + %d tail docs\n",
+						info.PayloadLen, info.PayloadStart, info.PayloadStart,
+						info.NumBlocks, info.TailLen)
+					fmt.Printf("skip: %d bytes at %d (%x)\n",
+						info.SkipLen, info.SkipStart, info.SkipStart)
+
+					if info.LocsLen > 0 {
+						locAddr := info.LocsStart
+						fmt.Printf("Loc details at: %d (%x), %d bytes, chunk size %d\n",
+							locAddr, locAddr, info.LocsLen, info.LocChunkSize)
 						numLChunks, r4 := binary.Uvarint(data[locAddr : locAddr+binary.MaxVarintLen64])
-						n = uint64(r4)
+						n := uint64(r4)
 						fmt.Printf("there are %d loc chunks\n", numLChunks)
 
 						var locOffsets []uint64

--- a/cmd/zap/cmd/fields.go
+++ b/cmd/zap/cmd/fields.go
@@ -17,7 +17,7 @@ package cmd
 import (
 	"fmt"
 
-	zap "github.com/blevesearch/zapx/v17"
+	zap "github.com/blevesearch/zapx/v18"
 	"github.com/spf13/cobra"
 )
 

--- a/cmd/zap/cmd/root.go
+++ b/cmd/zap/cmd/root.go
@@ -18,7 +18,7 @@ import (
 	"fmt"
 	"os"
 
-	zap "github.com/blevesearch/zapx/v17"
+	zap "github.com/blevesearch/zapx/v18"
 	"github.com/spf13/cobra"
 )
 

--- a/cmd/zap/main.go
+++ b/cmd/zap/main.go
@@ -15,7 +15,7 @@
 package main
 
 import (
-	"github.com/blevesearch/zapx/v17/cmd/zap/cmd"
+	"github.com/blevesearch/zapx/v18/cmd/zap/cmd"
 )
 
 func main() {

--- a/dict.go
+++ b/dict.go
@@ -30,6 +30,10 @@ type Dictionary struct {
 	fieldID uint16
 	fst     *vellum.FST
 
+	// norms is the field's quantized field-length column, shared by every term
+	// in the field and cached alongside the FST
+	norms *normsColumn
+
 	fstReader *vellum.Reader
 
 	bytesRead uint64
@@ -94,16 +98,10 @@ func (d *Dictionary) postingsListInit(rv *PostingsList, except *roaring.Bitmap) 
 	if rv == nil || rv == emptyPostingsList {
 		rv = &PostingsList{}
 	} else {
-		postings := rv.postings
-		if postings != nil {
-			postings.Clear()
-		}
-
 		*rv = PostingsList{} // clear the struct
-
-		rv.postings = postings
 	}
 	rv.sb = d.sb
+	rv.norms = d.norms
 	rv.except = except
 	return rv
 }

--- a/fieldnorm.go
+++ b/fieldnorm.go
@@ -1,0 +1,98 @@
+//  Copyright (c) 2026 Couchbase, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// 		http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package zap
+
+import (
+	"math"
+	"sort"
+)
+
+// A field norm is the number of tokens the analyzer emitted for one field of
+// one document -- the "dl" term in BM25.  It is stored as a single quantized
+// byte per document per field, in a dense column shared by every term of the
+// field, rather than being repeated alongside every posting.
+//
+// The quantization is the scheme Lucene and tantivy both use: a 3-bit mantissa
+// with an implicit leading 1 and a 5-bit exponent, biased so that the first 41
+// lengths are represented exactly.  Properties worth knowing:
+//
+//   - lengths 0..=40 represented exactly, so short fields (titles, names, tags),
+//     where length normalization matters most, lose nothing;
+//   - the mapping is monotonic and rounds *down*, so a stored length is never
+//     larger than the true one;
+//   - relative error above 40 is bounded by 1/8;
+//   - it saturates at fieldNormTable[255].
+
+// identityPart is the number of leading ids that decode to themselves before
+// the exponential part takes over.
+const identityPart = 24
+
+// fieldNormTable maps a norm id to the field length it represents.  It is
+// strictly increasing, which is what lets fieldNormToID binary-search it.
+var fieldNormTable [256]uint32
+
+// fieldNormFactor maps a norm id to 1/sqrt(length), the value the scorer wants.
+// fieldNormFactor[0] is +Inf, matching the behaviour of a zero-length field in
+// earlier zap versions.
+var fieldNormFactor [256]float32
+
+func init() {
+	for id := 0; id < 256; id++ {
+		fieldNormTable[id] = decodeFieldNormID(uint8(id))
+		fieldNormFactor[id] = float32(1.0 / math.Sqrt(float64(fieldNormTable[id])))
+	}
+}
+
+// decodeExpPart decodes the exponential portion of a norm id: the low 3 bits
+// are the mantissa, the high 5 are the exponent.  A zero exponent means the
+// mantissa is the value verbatim; otherwise the implicit leading 1 is restored
+// and the result shifted.
+func decodeExpPart(b uint8) uint32 {
+	bits := uint32(b & 0x07)
+	shift := b >> 3
+	if shift == 0 {
+		return bits
+	}
+	return (bits | 8) << (shift - 1)
+}
+
+func decodeFieldNormID(id uint8) uint32 {
+	if id < identityPart {
+		return uint32(id)
+	}
+	return identityPart + decodeExpPart(id-identityPart)
+}
+
+// idToFieldNorm returns the field length a norm id stands for.
+func idToFieldNorm(id uint8) uint32 {
+	return fieldNormTable[id]
+}
+
+// fieldNormToID quantizes a field length to the largest norm id whose length is
+// less than or equal to it, saturating at 255.
+func fieldNormToID(fieldNorm uint32) uint8 {
+	// sort.Search gives the first index whose value exceeds fieldNorm; the id
+	// we want is the one before it.  Index 0 holds length 0, so the result of
+	// the search is always at least 1 and the subtraction is safe.
+	return uint8(sort.Search(256, func(i int) bool {
+		return fieldNormTable[i] > fieldNorm
+	}) - 1)
+}
+
+// normFactorFromID returns the normalization factor 1/sqrt(fieldLength) for a
+// norm id, as one L1-resident table lookup.
+func normFactorFromID(id uint8) float64 {
+	return float64(fieldNormFactor[id])
+}

--- a/fieldnorm_test.go
+++ b/fieldnorm_test.go
@@ -1,0 +1,91 @@
+//  Copyright (c) 2026 Couchbase, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// 		http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package zap
+
+import (
+	"math"
+	"testing"
+)
+
+func TestFieldNormTableStrictlyIncreasing(t *testing.T) {
+	for id := 1; id < 256; id++ {
+		if fieldNormTable[id] <= fieldNormTable[id-1] {
+			t.Fatalf("fieldNormTable not strictly increasing at id %d: %d <= %d",
+				id, fieldNormTable[id], fieldNormTable[id-1])
+		}
+	}
+}
+
+func TestFieldNormTableKnownValues(t *testing.T) {
+	// These pin the quantization to tantivy's, so a segment written here and a
+	// segment written there agree on what a norm id means.
+	tests := []struct {
+		id   uint8
+		want uint32
+	}{
+		{0, 0}, {1, 1}, {23, 23}, {24, 24}, {31, 31}, {32, 32},
+		{39, 39}, {40, 40}, {41, 42}, {255, 2013265944},
+	}
+	for _, tt := range tests {
+		if got := idToFieldNorm(tt.id); got != tt.want {
+			t.Errorf("idToFieldNorm(%d) = %d, want %d", tt.id, got, tt.want)
+		}
+	}
+}
+
+func TestFieldNormExactBelow41(t *testing.T) {
+	for l := uint32(0); l <= 40; l++ {
+		id := fieldNormToID(l)
+		if got := idToFieldNorm(id); got != l {
+			t.Errorf("length %d round-tripped to %d (id %d), want exact", l, got, id)
+		}
+	}
+}
+
+func TestFieldNormRoundsDown(t *testing.T) {
+	for l := uint32(0); l < 100000; l++ {
+		id := fieldNormToID(l)
+		stored := idToFieldNorm(id)
+		if stored > l {
+			t.Fatalf("length %d quantized up to %d", l, stored)
+		}
+		if id < 255 && idToFieldNorm(id+1) <= l {
+			t.Fatalf("length %d quantized to id %d, but id %d also fits", l, id, id+1)
+		}
+		// Relative error above the identity range is bounded by the 3-bit
+		// mantissa.
+		if l > 40 && float64(l-stored)/float64(l) > 1.0/8.0 {
+			t.Fatalf("length %d quantized to %d, relative error exceeds 1/8", l, stored)
+		}
+	}
+}
+
+func TestFieldNormSaturates(t *testing.T) {
+	if got := fieldNormToID(math.MaxUint32); got != 255 {
+		t.Errorf("fieldNormToID(MaxUint32) = %d, want 255", got)
+	}
+}
+
+func TestNormFactorFromID(t *testing.T) {
+	if !math.IsInf(normFactorFromID(0), 1) {
+		t.Errorf("normFactorFromID(0) = %v, want +Inf", normFactorFromID(0))
+	}
+	for id := 1; id < 256; id++ {
+		want := float64(float32(1.0 / math.Sqrt(float64(fieldNormTable[id]))))
+		if got := normFactorFromID(uint8(id)); got != want {
+			t.Errorf("normFactorFromID(%d) = %v, want %v", id, got, want)
+		}
+	}
+}

--- a/file_callbacks_test.go
+++ b/file_callbacks_test.go
@@ -369,4 +369,21 @@ func TestFileCallbacks(t *testing.T) {
 
 	TestGeoIndexSectionRoundTrip(t)
 	TestGeoIndexMerge(t)
+
+	// The block postings format is the reason each block is run through the
+	// hook on its own rather than as one blob per term. An encrypting callback
+	// changes a block's length, so the skip list records where each block
+	// actually landed instead of deriving it from the bit widths; these are the
+	// tests that would notice if that stopped being true.
+	TestBlockPostingsRoundTrip(t)
+	TestBlockPostingsCount(t)
+	TestBlockPostingsAdvance(t)
+	TestBlockPostingsWithDeletions(t)
+	TestBlockPostingsLocations(t)
+	TestBlockPostingsLocationsWithAdvance(t)
+	TestBlockPostingsNormsRoundTrip(t)
+	TestNormsColumnConstantEncoding(t)
+	TestBlockPostingsMerge(t)
+	TestTailSeekPastRangeSkipsDecode(t)
+	TestOneHitEncoding(t)
 }

--- a/go.mod
+++ b/go.mod
@@ -1,10 +1,11 @@
-module github.com/blevesearch/zapx/v17
+module github.com/blevesearch/zapx/v18
 
 go 1.25.0
 
 require (
 	github.com/RoaringBitmap/roaring/v2 v2.14.5
 	github.com/blevesearch/bleve_index_api v1.4.1
+	github.com/blevesearch/freeway v0.0.0
 	github.com/blevesearch/go-faiss v1.1.5
 	github.com/blevesearch/mmap-go v1.2.0
 	github.com/blevesearch/scorch_segment_api/v2 v2.4.10
@@ -12,6 +13,8 @@ require (
 	github.com/golang/snappy v1.0.0
 	github.com/spf13/cobra v1.10.2
 )
+
+replace github.com/blevesearch/freeway => ../freeway
 
 require (
 	github.com/bits-and-blooms/bitset v1.24.2 // indirect

--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,7 @@ go 1.25.0
 require (
 	github.com/RoaringBitmap/roaring/v2 v2.14.5
 	github.com/blevesearch/bleve_index_api v1.4.1
-	github.com/blevesearch/freeway v0.0.0
+	github.com/blevesearch/freeway v0.0.0-20260910051309-0770e11c32cd
 	github.com/blevesearch/go-faiss v1.1.5
 	github.com/blevesearch/mmap-go v1.2.0
 	github.com/blevesearch/scorch_segment_api/v2 v2.4.10
@@ -13,8 +13,6 @@ require (
 	github.com/golang/snappy v1.0.0
 	github.com/spf13/cobra v1.10.2
 )
-
-replace github.com/blevesearch/freeway => ../freeway
 
 require (
 	github.com/bits-and-blooms/bitset v1.24.2 // indirect

--- a/go.sum
+++ b/go.sum
@@ -4,6 +4,8 @@ github.com/bits-and-blooms/bitset v1.24.2 h1:M7/NzVbsytmtfHbumG+K2bremQPMJuqv1JD
 github.com/bits-and-blooms/bitset v1.24.2/go.mod h1:7hO7Gc7Pp1vODcmWvKMRA9BNmbv6a/7QIWpPxHddWR8=
 github.com/blevesearch/bleve_index_api v1.4.1 h1:CYIyecFlI+/RYjzUm+NmDjYbSvk870Bb7f+Vl4b12q8=
 github.com/blevesearch/bleve_index_api v1.4.1/go.mod h1:xvd48t5XMeeioWQ5/jZvgLrV98flT2rdvEJ3l/ki4Ko=
+github.com/blevesearch/freeway v0.0.0-20260910051309-0770e11c32cd h1:LOQjtgGUFbLlHbw/Ue+SE4nFSWUPMkyTZcCiRLWlF6E=
+github.com/blevesearch/freeway v0.0.0-20260910051309-0770e11c32cd/go.mod h1:KguWkuJ1aPhrMS4svPyA9rz2zrgkNybj546cXgxGrCI=
 github.com/blevesearch/go-faiss v1.1.5 h1:/IU5lkOahH9Ghfk9n3F6N0XD7PYVXZJWmNDc9TtXuco=
 github.com/blevesearch/go-faiss v1.1.5/go.mod h1:w3W9AiWsFRGVaMG+/cmJi7iHEAuGyC6blsgO1EzCK/M=
 github.com/blevesearch/mmap-go v1.2.0 h1:l33nNKPFcBjJUMwem6sAYJPUzhUCABoK9FxZDGiFNBI=

--- a/inverted_text_cache.go
+++ b/inverted_text_cache.go
@@ -40,12 +40,23 @@ func (sc *invertedIndexCache) Clear() {
 	sc.m.Unlock()
 }
 
+// dictLocation names the two regions of a field's inverted index section that
+// the cache materialises: the term dictionary and the field-norm column.
+type dictLocation struct {
+	dictOffset  uint64
+	normsOffset uint64
+	normsLen    uint64
+	numDocs     uint64
+}
+
 // loadOrCreate loads the inverted index cache for the specified fieldID if it is already present,
-// or creates it if not. The inverted index cache for a fieldID consists of an FST (Finite State Transducer):
+// or creates it if not. The inverted index cache for a fieldID consists of:
 // - A Vellum FST (Finite State Transducer) representing the TermDictionary.
-// This function returns the loaded or newly created FST, and the number of bytes read from the provided memory slice,
-// if the cache was created.
-func (sc *invertedIndexCache) loadOrCreate(fieldID uint16, mem []byte, fr *FileReader) (*vellum.FST, uint64, error) {
+// - The field's quantized field-norm column, which every term of the field reads.
+// This function returns the loaded or newly created entries, and the number of bytes read from
+// the provided memory slice, if the cache was created.
+func (sc *invertedIndexCache) loadOrCreate(fieldID uint16, mem []byte, loc dictLocation,
+	fr *FileReader) (*vellum.FST, *normsColumn, uint64, error) {
 	sc.m.RLock()
 	entry, ok := sc.cache[fieldID]
 	if ok {
@@ -63,45 +74,66 @@ func (sc *invertedIndexCache) loadOrCreate(fieldID uint16, mem []byte, fr *FileR
 		return entry.load()
 	}
 
-	return sc.createAndCacheLOCKED(fieldID, mem, fr)
+	return sc.createAndCacheLOCKED(fieldID, mem, loc, fr)
 }
 
 // createAndCacheLOCKED creates the inverted index cache for the specified fieldID and caches it.
-func (sc *invertedIndexCache) createAndCacheLOCKED(fieldID uint16, mem []byte, fr *FileReader) (*vellum.FST, uint64, error) {
-	var pos uint64
-	vellumLen, read := binary.Uvarint(mem[pos : pos+binary.MaxVarintLen64])
+func (sc *invertedIndexCache) createAndCacheLOCKED(fieldID uint16, mem []byte, loc dictLocation,
+	fr *FileReader) (*vellum.FST, *normsColumn, uint64, error) {
+	pos := loc.dictOffset
+	vellumLen, read := binary.Uvarint(memAt(mem, pos, binary.MaxVarintLen64))
 	if vellumLen == 0 || read <= 0 {
-		return nil, 0, fmt.Errorf("vellum length is 0")
+		return nil, nil, 0, fmt.Errorf("vellum length is 0")
 	}
 	pos += uint64(read)
 	fstBytes, err := fr.process(mem[pos : pos+vellumLen])
 	if err != nil {
-		return nil, 0, fmt.Errorf("error processing vellum bytes: %v", err)
+		return nil, nil, 0, fmt.Errorf("error processing vellum bytes: %v", err)
 	}
 	fst, err := vellum.Load(fstBytes)
 	if err != nil {
-		return nil, 0, fmt.Errorf("vellum err: %v", err)
+		return nil, nil, 0, fmt.Errorf("vellum err: %v", err)
 	}
 	pos += vellumLen
-	sc.insertLOCKED(fieldID, fst)
-	return fst, pos, nil
+	bytesRead := pos - loc.dictOffset
+
+	// The norm column is decoded once per field rather than per term, which is
+	// the point of it living here: a term lookup then costs a single byte load.
+	norms := normsAbsent
+	if loc.normsLen > 0 {
+		normBytes, err := fr.process(mem[loc.normsOffset : loc.normsOffset+loc.normsLen])
+		if err != nil {
+			return nil, nil, 0, fmt.Errorf("error processing norms bytes: %v", err)
+		}
+		norms, err = decodeNormsColumn(normBytes, loc.numDocs)
+		if err != nil {
+			return nil, nil, 0, err
+		}
+		bytesRead += loc.normsLen
+	}
+
+	sc.insertLOCKED(fieldID, fst, norms)
+	return fst, norms, bytesRead, nil
 }
 
-// insertLOCKED inserts the vellum FST into the cache for the specified fieldID.
-func (sc *invertedIndexCache) insertLOCKED(fieldID uint16, fst *vellum.FST) {
+// insertLOCKED inserts the vellum FST and norm column into the cache for the specified fieldID.
+func (sc *invertedIndexCache) insertLOCKED(fieldID uint16, fst *vellum.FST, norms *normsColumn) {
 	_, ok := sc.cache[fieldID]
 	if !ok {
 		sc.cache[fieldID] = &invertedCacheEntry{
-			fst: fst,
+			fst:   fst,
+			norms: norms,
 		}
 	}
 }
 
-// invertedCacheEntry is the vellum FST and is the value stored in the invertedIndexCache cache, for a given fieldID.
+// invertedCacheEntry is the per-field inverted index state stored in the
+// invertedIndexCache: the vellum FST and the field-norm column.
 type invertedCacheEntry struct {
-	fst *vellum.FST
+	fst   *vellum.FST
+	norms *normsColumn
 }
 
-func (ce *invertedCacheEntry) load() (*vellum.FST, uint64, error) {
-	return ce.fst, 0, nil
+func (ce *invertedCacheEntry) load() (*vellum.FST, *normsColumn, uint64, error) {
+	return ce.fst, ce.norms, 0, nil
 }

--- a/merge.go
+++ b/merge.go
@@ -292,78 +292,73 @@ func computeNewDocCount(segments []*SegmentBase, drops []*roaring.Bitmap) (uint6
 	return newDocCount, droppedCount
 }
 
-func mergeTermFreqNormLocsByCopying(term []byte, postItr *PostingsIterator,
-	newDocNums []uint64, newRoaring *roaring.Bitmap,
-	tfEncoder *chunkedIntCoder, locEncoder *chunkedIntCoder) (
-	lastDocNum uint64, lastFreq uint64, lastNorm uint64, err error) {
-	nextDocNum, nextFreq, nextNorm, nextFreqNormBytes, nextLocBytes, err :=
-		postItr.nextBytes()
-	for err == nil && len(nextFreqNormBytes) > 0 {
-		hitNewDocNum := newDocNums[nextDocNum]
-		if hitNewDocNum == docDropped {
-			return 0, 0, 0, fmt.Errorf("see hit with dropped doc num")
-		}
-
-		newRoaring.Add(uint32(hitNewDocNum))
-
-		err = tfEncoder.AddBytes(hitNewDocNum, nextFreqNormBytes)
+// mergeTermPostingsByCopying moves one source segment's postings for a term
+// into the serializer, carrying each document's location bytes across verbatim
+// rather than decoding and re-encoding them.
+//
+// Only the locations can be copied. Doc numbers are renumbered by the merge, so
+// the bitpacked blocks have to be rebuilt against the new numbering, and norms
+// are not in the postings at all -- they travel as a column, merged once per
+// field rather than once per posting.
+func mergeTermPostingsByCopying(postItr *PostingsIterator, newDocNums []uint64,
+	termHasLocs bool, ser *postingsSerializer,
+	locEncoder *chunkedIntCoder) error {
+	for {
+		docNum, freq, locBytes, exists, err := postItr.nextWithLocBytes()
 		if err != nil {
-			return 0, 0, 0, err
+			return err
+		}
+		if !exists {
+			return nil
 		}
 
-		if len(nextLocBytes) > 0 {
-			err = locEncoder.AddBytes(hitNewDocNum, nextLocBytes)
+		hitNewDocNum := newDocNums[docNum]
+		if hitNewDocNum == docDropped {
+			return fmt.Errorf("see hit with dropped doc num")
+		}
+
+		if err := ser.AddDoc(uint32(hitNewDocNum), uint32(freq)); err != nil {
+			return err
+		}
+
+		if termHasLocs {
+			if len(locBytes) > 0 {
+				err = locEncoder.AddBytes(hitNewDocNum, locBytes)
+			} else {
+				// A term that records locations carries a group for every one
+				// of its postings, so that a reader walking the location stream
+				// stays aligned without needing a per-document flag. This
+				// source segment had none for this term, so the group is empty.
+				err = locEncoder.Add(hitNewDocNum, 0)
+			}
 			if err != nil {
-				return 0, 0, 0, err
+				return err
 			}
 		}
-
-		lastDocNum = hitNewDocNum
-		lastFreq = nextFreq
-		lastNorm = nextNorm
-
-		nextDocNum, nextFreq, nextNorm, nextFreqNormBytes, nextLocBytes, err =
-			postItr.nextBytes()
 	}
-
-	return lastDocNum, lastFreq, lastNorm, err
 }
 
-func mergeTermFreqNormLocs(fieldsMap map[string]uint16, term []byte, postItr *PostingsIterator,
-	newDocNums []uint64, newRoaring *roaring.Bitmap,
-	tfEncoder *chunkedIntCoder, locEncoder *chunkedIntCoder, bufLoc []uint64) (
-	lastDocNum uint64, lastFreq uint64, lastNorm uint64, bufLocOut []uint64, err error) {
+// mergeTermPostings is the general form: it decodes each posting and re-encodes
+// its locations, remapping their field ids into the merged field space. That
+// remapping is why the copying variant above requires the segments to agree on
+// their fields.
+func mergeTermPostings(fieldsMap map[string]uint16, postItr *PostingsIterator,
+	newDocNums []uint64, termHasLocs bool, ser *postingsSerializer,
+	locEncoder *chunkedIntCoder, bufLoc []uint64) (bufLocOut []uint64, err error) {
 	next, err := postItr.Next()
 	for next != nil && err == nil {
 		hitNewDocNum := newDocNums[next.Number()]
 		if hitNewDocNum == docDropped {
-			return 0, 0, 0, nil, fmt.Errorf("see hit with dropped docNum")
+			return nil, fmt.Errorf("see hit with dropped docNum")
 		}
 
-		newRoaring.Add(uint32(hitNewDocNum))
-
-		nextFreq := next.Frequency()
-		var nextNorm uint64
-		if pi, ok := next.(*Posting); ok {
-			nextNorm = pi.NormUint64()
-		} else {
-			return 0, 0, 0, nil, fmt.Errorf("unexpected posting type %T", next)
+		if err = ser.AddDoc(uint32(hitNewDocNum), uint32(next.Frequency())); err != nil {
+			return nil, err
 		}
 
-		locs := next.Locations()
+		if termHasLocs {
+			locs := next.Locations()
 
-		if nextFreq > 0 {
-			err = tfEncoder.Add(hitNewDocNum,
-				encodeFreqHasLocs(nextFreq, len(locs) > 0), nextNorm)
-		} else {
-			err = tfEncoder.Add(hitNewDocNum,
-				encodeFreqHasLocs(nextFreq, len(locs) > 0))
-		}
-		if err != nil {
-			return 0, 0, 0, nil, err
-		}
-
-		if len(locs) > 0 {
 			numBytesLocs := 0
 			for _, loc := range locs {
 				ap := loc.ArrayPositions()
@@ -371,9 +366,8 @@ func mergeTermFreqNormLocs(fieldsMap map[string]uint16, term []byte, postItr *Po
 					loc.Pos(), loc.Start(), loc.End(), uint64(len(ap)), ap)
 			}
 
-			err = locEncoder.Add(hitNewDocNum, uint64(numBytesLocs))
-			if err != nil {
-				return 0, 0, 0, nil, err
+			if err = locEncoder.Add(hitNewDocNum, uint64(numBytesLocs)); err != nil {
+				return nil, err
 			}
 
 			for _, loc := range locs {
@@ -388,75 +382,16 @@ func mergeTermFreqNormLocs(fieldsMap map[string]uint16, term []byte, postItr *Po
 				args[3] = loc.End()
 				args[4] = uint64(len(ap))
 				args = append(args, ap...)
-				err = locEncoder.Add(hitNewDocNum, args...)
-				if err != nil {
-					return 0, 0, 0, nil, err
+				if err = locEncoder.Add(hitNewDocNum, args...); err != nil {
+					return nil, err
 				}
 			}
 		}
 
-		lastDocNum = hitNewDocNum
-		lastFreq = nextFreq
-		lastNorm = nextNorm
-
 		next, err = postItr.Next()
 	}
 
-	return lastDocNum, lastFreq, lastNorm, bufLoc, err
-}
-
-func writePostings(postings *roaring.Bitmap, tfEncoder, locEncoder *chunkedIntCoder,
-	use1HitEncoding func(uint64) (bool, uint64, uint64),
-	w *FileWriter, bufMaxVarintLen64 []byte) (
-	offset uint64, err error) {
-	if postings == nil {
-		return 0, nil
-	}
-
-	termCardinality := postings.GetCardinality()
-	if termCardinality <= 0 {
-		return 0, nil
-	}
-
-	if use1HitEncoding != nil {
-		encodeAs1Hit, docNum1Hit, normBits1Hit := use1HitEncoding(termCardinality)
-		if encodeAs1Hit {
-			return FSTValEncode1Hit(docNum1Hit, normBits1Hit), nil
-		}
-	}
-
-	var tfOffset uint64
-	tfOffset, _, err = tfEncoder.writeAt(w)
-	if err != nil {
-		return 0, err
-	}
-
-	var locOffset uint64
-	locOffset, _, err = locEncoder.writeAt(w)
-	if err != nil {
-		return 0, err
-	}
-
-	postingsOffset := uint64(w.Count())
-
-	n := binary.PutUvarint(bufMaxVarintLen64, tfOffset)
-	_, err = w.Write(bufMaxVarintLen64[:n])
-	if err != nil {
-		return 0, err
-	}
-
-	n = binary.PutUvarint(bufMaxVarintLen64, locOffset)
-	_, err = w.Write(bufMaxVarintLen64[:n])
-	if err != nil {
-		return 0, err
-	}
-
-	_, err = writeRoaringWithLen(postings, w, bufMaxVarintLen64)
-	if err != nil {
-		return 0, err
-	}
-
-	return postingsOffset, nil
+	return bufLoc, err
 }
 
 type varintEncoder func(uint64) (int, error)

--- a/new.go
+++ b/new.go
@@ -180,12 +180,6 @@ type interimStoredField struct {
 	arrayposs [][]uint64 // array positions
 }
 
-type interimFreqNorm struct {
-	freq    uint64
-	norm    float32
-	numLocs int
-}
-
 type interimLoc struct {
 	fieldID   uint16
 	pos       uint64

--- a/posting.go
+++ b/posting.go
@@ -15,7 +15,6 @@
 package zap
 
 import (
-	"encoding/binary"
 	"fmt"
 	"math"
 	"reflect"
@@ -43,44 +42,39 @@ func init() {
 // FST or vellum value (uint64) encoding is determined by the top two
 // highest-order or most significant bits...
 //
-//  encoding  : MSB
-//  name      : 63  62  61...to...bit #0 (LSB)
-//  ----------+---+---+---------------------------------------------------
-//   general  : 0 | 0 | 62-bits of postingsOffset.
-//   ~        : 0 | 1 | reserved for future.
-//   1-hit    : 1 | 0 | 31-bits of positive float31 norm | 31-bits docNum.
-//   ~        : 1 | 1 | reserved for future.
+//	encoding  : MSB
+//	name      : 63  62  61...to...bit #0 (LSB)
+//	----------+---+---+---------------------------------------------------
+//	 general  : 0 | 0 | 62-bits offset of the term footer.
+//	 ~        : 0 | 1 | reserved for future.
+//	 1-hit    : 1 | 0 | 31 unused bits | 31-bits docNum.
+//	 ~        : 1 | 1 | reserved for future.
 //
-// Encoding "general" is able to handle all cases, where the
-// postingsOffset points to more information about the postings for
-// the term.
+// Encoding "general" is able to handle all cases, where the offset points at
+// the term footer described in postings_format.go.
 //
-// Encoding "1-hit" is used to optimize a commonly seen case when a
-// term has only a single hit.  For example, a term in the _id field
-// will have only 1 hit.  The "1-hit" encoding is used for a term
-// in a field when...
+// Encoding "1-hit" optimizes the very common case of a term with a single hit
+// -- a term in the _id field, or the long tail of any real dictionary. It
+// applies when:
 //
-// - term vector info is disabled for that field;
-// - and, the term appears in only a single doc for that field;
-// - and, the term's freq is exactly 1 in that single doc for that field;
-// - and, the docNum must fit into 31-bits;
+//   - the term appears in only a single doc for that field;
+//   - and, the term's freq is exactly 1 in that doc;
+//   - and, term vectors are not recorded for the term;
+//   - and, the docNum fits into 31-bits.
 //
-// Otherwise, the "general" encoding is used instead.
-//
-// In the "1-hit" encoding, the field in that single doc may have
-// other terms, which is supported in the "1-hit" encoding by the
-// positive float31 norm.
-
+// Earlier zap versions also had to pack the norm into this value. That is no
+// longer necessary: the norm lives in the field's norm column, keyed by doc
+// number, so a 1-hit term needs nothing but the doc number itself.
 const FSTValEncodingMask = uint64(0xc000000000000000)
 const FSTValEncodingGeneral = uint64(0x0000000000000000)
 const FSTValEncoding1Hit = uint64(0x8000000000000000)
 
-func FSTValEncode1Hit(docNum uint64, normBits uint64) uint64 {
-	return FSTValEncoding1Hit | ((mask31Bits & normBits) << 31) | (mask31Bits & docNum)
+func FSTValEncode1Hit(docNum uint64) uint64 {
+	return FSTValEncoding1Hit | (mask31Bits & docNum)
 }
 
-func FSTValDecode1Hit(v uint64) (docNum uint64, normBits uint64) {
-	return (mask31Bits & v), (mask31Bits & (v >> 31))
+func FSTValDecode1Hit(v uint64) (docNum uint64) {
+	return mask31Bits & v
 }
 
 const mask31Bits = uint64(0x000000007fffffff)
@@ -91,22 +85,32 @@ func under32Bits(x uint64) bool {
 
 const DocNum1HitFinished = math.MaxUint64
 
-var NormBits1Hit = uint64(1)
-
 // PostingsList is an in-memory representation of a postings list
 type PostingsList struct {
-	sb             *SegmentBase
-	postingsOffset uint64
-	freqOffset     uint64
-	locOffset      uint64
-	postings       *roaring.Bitmap
-	except         *roaring.Bitmap
+	sb    *SegmentBase
+	norms *normsColumn
 
-	// when normBits1Hit != 0, then this postings list came from a
-	// 1-hit encoding, and only the docNum1Hit & normBits1Hit apply
-	docNum1Hit   uint64
-	normBits1Hit uint64
+	footer       termFooter
+	payloadStart uint64
+	locsStart    uint64
+	skipStart    uint64
 
+	except *roaring.Bitmap
+
+	// when is1Hit, the whole list is the single docNum1Hit and none of the
+	// region offsets above are meaningful
+	is1Hit     bool
+	docNum1Hit uint64
+
+	// docBM is the postings list as a roaring bitmap, created on demand and
+	// cached.
+	// It's needed for resolving external _id strings to internal doc
+	// numbers, not on the scan path, so will not impact search latency
+	// TODO: will it blow up memory footprint?
+	docBM *roaring.Bitmap
+
+	// chunkSize governs the location blob, which keeps the chunked encoding of
+	// earlier zap versions
 	chunkSize uint64
 
 	bytesRead uint64
@@ -121,25 +125,70 @@ func (p *PostingsList) Size() int {
 	if p.except != nil {
 		sizeInBytes += int(p.except.GetSizeInBytes())
 	}
+	if p.docBM != nil {
+		sizeInBytes += int(p.docBM.GetSizeInBytes())
+	}
 
 	return sizeInBytes
 }
 
 func (p *PostingsList) OrInto(receiver *roaring.Bitmap) {
-	if p.normBits1Hit != 0 {
+	if p.is1Hit {
 		receiver.Add(uint32(p.docNum1Hit))
 		return
 	}
-
-	if p.postings != nil {
-		receiver.Or(p.postings)
+	bm, err := p.docBitmap()
+	if err != nil || bm == nil {
+		return
 	}
+	receiver.Or(bm)
+}
+
+// docBitmap materialises the postings list as a roaring bitmap, minus any
+// deletions, and caches it. See the note on PostingsList.docBM.
+func (p *PostingsList) docBitmap() (*roaring.Bitmap, error) {
+	if p.docBM != nil {
+		return p.docBM, nil
+	}
+	if p.is1Hit {
+		bm := roaring.New()
+		if p.docNum1Hit != DocNum1HitFinished &&
+			(p.except == nil || !p.except.Contains(uint32(p.docNum1Hit))) {
+			bm.Add(uint32(p.docNum1Hit))
+		}
+		p.docBM = bm
+		return bm, nil
+	}
+	if p.sb == nil || p.footer.docFreq == 0 {
+		p.docBM = roaring.New()
+		return p.docBM, nil
+	}
+
+	var c blockCursor
+	if err := c.init(p.sb, &p.footer, p.payloadStart, p.skipStart, false); err != nil {
+		return nil, err
+	}
+	docNums := make([]uint32, 0, p.footer.docFreq)
+	for !c.exhausted {
+		if err := c.loadBlock(); err != nil {
+			return nil, err
+		}
+		docNums = append(docNums, c.buf.docs[:c.nDocs]...)
+		c.nextBlock()
+	}
+	bm := roaring.New()
+	bm.AddMany(docNums)
+	if p.except != nil && !p.except.IsEmpty() {
+		bm.AndNot(p.except)
+	}
+	p.docBM = bm
+	return bm, nil
 }
 
 // Iterator returns an iterator for this postings list
 func (p *PostingsList) Iterator(includeFreq, includeNorm, includeLocs bool,
 	prealloc segment.PostingsIterator) segment.PostingsIterator {
-	if p.normBits1Hit == 0 && p.postings == nil {
+	if !p.is1Hit && p.sb == nil {
 		return emptyPostingsIterator
 	}
 
@@ -152,100 +201,119 @@ func (p *PostingsList) Iterator(includeFreq, includeNorm, includeLocs bool,
 		preallocPI = nil
 	}
 
-	return p.iterator(includeFreq, includeNorm, includeLocs, preallocPI)
+	rv, err := p.iterator(includeFreq, includeNorm, includeLocs, preallocPI)
+	if err != nil {
+		// The segment.PostingsIterator contract has no way to report a failure
+		// here; surface it on the first Next()/Advance() instead.
+		rv.err = err
+	}
+	return rv
 }
 
 func (p *PostingsList) iterator(includeFreq, includeNorm, includeLocs bool,
-	rv *PostingsIterator) *PostingsIterator {
+	rv *PostingsIterator) (*PostingsIterator, error) {
 	if rv == nil {
 		rv = &PostingsIterator{}
 	} else {
-		freqNormReader := rv.freqNormReader
-		if freqNormReader != nil {
-			freqNormReader.reset()
-		}
-
 		locReader := rv.locReader
 		if locReader != nil {
 			locReader.reset()
 		}
-
 		nextLocs := rv.nextLocs[:0]
 		nextSegmentLocs := rv.nextSegmentLocs[:0]
-
 		buf := rv.buf
+		blockBuf := rv.cursor.buf
 
 		*rv = PostingsIterator{} // clear the struct
 
-		rv.freqNormReader = freqNormReader
 		rv.locReader = locReader
-
 		rv.nextLocs = nextLocs
 		rv.nextSegmentLocs = nextSegmentLocs
-
 		rv.buf = buf
+		rv.cursor.buf = blockBuf
 	}
 
 	rv.postings = p
 	rv.includeFreqNorm = includeFreq || includeNorm || includeLocs
 	rv.includeLocs = includeLocs
+	rv.docNum1Hit = DocNum1HitFinished
 
-	if p.normBits1Hit != 0 {
-		// "1-hit" encoding
+	if p.except != nil && !p.except.IsEmpty() {
+		// Deletions are walked in lockstep with the postings rather than
+		// pre-ANDed into a new bitmap: both sequences are ascending, so a merge
+		// scan costs nothing per document and, unlike roaring.AndNot, allocates
+		// nothing per term.
+		rv.exceptItr = p.except.Iterator()
+	}
+
+	if p.is1Hit {
+		rv.is1Hit = true
+		rv.cursor.exhausted = true
 		rv.docNum1Hit = p.docNum1Hit
-		rv.normBits1Hit = p.normBits1Hit
-
-		if p.except != nil && p.except.Contains(uint32(rv.docNum1Hit)) {
+		if rv.exceptItr != nil && p.except.Contains(uint32(rv.docNum1Hit)) {
 			rv.docNum1Hit = DocNum1HitFinished
 		}
-
-		return rv
+		return rv, nil
 	}
 
-	// "general" encoding, check if empty
-	if p.postings == nil {
-		return rv
+	if p.footer.docFreq == 0 {
+		rv.cursor.exhausted = true
+		return rv, nil
 	}
 
-	// initialize freq chunk reader
-	if rv.includeFreqNorm {
-		rv.freqNormReader = newChunkedIntDecoder(p.sb.mem, p.freqOffset, rv.freqNormReader, p.sb.fileReader)
-		rv.incrementBytesRead(rv.freqNormReader.getBytesRead())
+	rv.normIsDense = p.norms.kind == normsKindDense
+	rv.normDense = p.norms.dense
+	rv.normConst = normFactorFromID(p.norms.constant)
+	if p.norms.kind == normsKindAbsent {
+		rv.normConst = normFactorFromID(0)
+	}
+	rv.fastScan = rv.exceptItr == nil && !includeLocs
+
+	err := rv.cursor.init(p.sb, &p.footer, p.payloadStart, p.skipStart, rv.includeFreqNorm)
+	if err != nil {
+		return rv, err
 	}
 
-	// initialize the loc chunk reader
-	if rv.includeLocs {
-		rv.locReader = newChunkedIntDecoder(p.sb.mem, p.locOffset, rv.locReader, p.sb.fileReader)
-		rv.incrementBytesRead(rv.locReader.getBytesRead())
+	if rv.includeLocs && p.footer.hasLocs() {
+		rv.locReader = newChunkedIntDecoder(p.sb.mem, p.locsStart, rv.locReader, p.sb.fileReader)
+		rv.hasLocs = true
+		rv.locChunk = -1
 	}
 
-	rv.all = p.postings.Iterator()
-	if p.except != nil {
-		rv.ActualBM = roaring.AndNot(p.postings, p.except)
-		rv.Actual = rv.ActualBM.Iterator()
-	} else {
-		rv.ActualBM = p.postings
-		rv.Actual = rv.all // Optimize to use same iterator for all & Actual.
-	}
+	return rv, nil
+}
 
-	return rv
+// rawDocFreq is the number of postings recorded on disk, before any deletions
+// are taken into account.
+func (p *PostingsList) rawDocFreq() uint64 {
+	if p.is1Hit {
+		return 1
+	}
+	return uint64(p.footer.docFreq)
 }
 
 // Count returns the number of items on this postings list
 func (p *PostingsList) Count() uint64 {
-	var n, e uint64
-	if p.normBits1Hit != 0 {
-		n = 1
+	if p.is1Hit {
+		if p.docNum1Hit == DocNum1HitFinished {
+			return 0
+		}
 		if p.except != nil && p.except.Contains(uint32(p.docNum1Hit)) {
-			e = 1
+			return 0
 		}
-	} else if p.postings != nil {
-		n = p.postings.GetCardinality()
-		if p.except != nil {
-			e = p.postings.AndCardinality(p.except)
-		}
+		return 1
 	}
-	return n - e
+	// Without deletions the answer is on the term footer, so the common case
+	// costs nothing. With deletions it needs the doc set, which is materialised
+	// once and cached.
+	if p.except == nil || p.except.IsEmpty() {
+		return uint64(p.footer.docFreq)
+	}
+	bm, err := p.docBitmap()
+	if err != nil {
+		return 0
+	}
+	return bm.GetCardinality()
 }
 
 // Implements the segment.DiskStatsReporter interface
@@ -269,58 +337,36 @@ func (p *PostingsList) BytesWritten() uint64 {
 }
 
 func (rv *PostingsList) read(postingsOffset uint64, d *Dictionary) error {
-	rv.postingsOffset = postingsOffset
-
-	// handle "1-hit" encoding special case
-	if rv.postingsOffset&FSTValEncodingMask == FSTValEncoding1Hit {
-		return rv.init1Hit(postingsOffset)
+	rv.sb = d.sb
+	rv.norms = d.norms
+	if rv.norms == nil {
+		rv.norms = normsAbsent
 	}
 
-	// read the location of the freq/norm details
-	var n uint64
-	var read int
+	// handle "1-hit" encoding special case
+	if postingsOffset&FSTValEncodingMask == FSTValEncoding1Hit {
+		rv.is1Hit = true
+		rv.docNum1Hit = FSTValDecode1Hit(postingsOffset)
+		return nil
+	}
 
-	rv.freqOffset, read = binary.Uvarint(d.sb.mem[postingsOffset+n : postingsOffset+binary.MaxVarintLen64])
-	n += uint64(read)
-
-	rv.locOffset, read = binary.Uvarint(d.sb.mem[postingsOffset+n : postingsOffset+n+binary.MaxVarintLen64])
-	n += uint64(read)
-
-	var postingsLen uint64
-	postingsLen, read = binary.Uvarint(d.sb.mem[postingsOffset+n : postingsOffset+n+binary.MaxVarintLen64])
-	n += uint64(read)
-
-	roaringBytes, err := d.sb.fileReader.process(d.sb.mem[postingsOffset+n : postingsOffset+n+postingsLen])
+	payloadStart, locsStart, skipStart, err := rv.footer.decode(d.sb.mem, postingsOffset)
 	if err != nil {
 		return err
 	}
+	rv.payloadStart = payloadStart
+	rv.locsStart = locsStart
+	rv.skipStart = skipStart
+	// Only the footer has actually been read. The payload is charged block by
+	// block as the cursor decodes it, which is the point of the format: a query
+	// that skips most of a long postings list should not be billed for it.
+	rv.incrementBytesRead(uint64(maxTermFooterLen))
 
-	rv.incrementBytesRead(n + postingsLen)
-
-	if rv.postings == nil {
-		rv.postings = roaring.NewBitmap()
-	}
-	_, err = rv.postings.FromBuffer(roaringBytes)
-	if err != nil {
-		return fmt.Errorf("error loading roaring bitmap: %v", err)
-	}
-
-	chunkSize, err := getChunkSize(d.sb.chunkMode,
-		rv.postings.GetCardinality(), d.sb.numDocs)
-	if err != nil {
-		return fmt.Errorf("failed to get chunk size: %v", err)
-	}
-
-	rv.chunkSize = chunkSize
-
-	return nil
-}
-
-func (rv *PostingsList) init1Hit(fstVal uint64) error {
-	docNum, normBits := FSTValDecode1Hit(fstVal)
-
-	rv.docNum1Hit = docNum
-	rv.normBits1Hit = normBits
+	// The location blob keeps the chunked encoding of earlier zap versions, but
+	// its chunk size is read from the footer instead of being re-derived from a
+	// cardinality the reader has to recompute. Reader and writer cannot
+	// disagree about a number that was written down.
+	rv.chunkSize = rv.footer.locChunkSize
 
 	return nil
 }
@@ -328,35 +374,61 @@ func (rv *PostingsList) init1Hit(fstVal uint64) error {
 // PostingsIterator provides a way to iterate through the postings list
 type PostingsIterator struct {
 	postings *PostingsList
-	all      roaring.IntPeekable
-	Actual   roaring.IntPeekable
-	ActualBM *roaring.Bitmap
 
-	currChunk      uint32
-	freqNormReader *chunkedIntDecoder
-	locReader      *chunkedIntDecoder
+	cursor     blockCursor
+	cur        int // index of the current posting within the decoded block
+	positioned bool
+
+	// nextAllowed is the lowest doc number the next call may return: one past
+	// whatever was returned last.
+	nextAllowed uint32
+
+	// exceptItr walks the deleted-doc bitmap in lockstep with the postings.
+	exceptItr roaring.IntPeekable
+
+	locReader *chunkedIntDecoder
+	locChunk  int
+	hasLocs   bool
+
+	// is1Hit marks a list whose single posting is encoded inline in the FST
+	// value. There is no block cursor behind it, so iteration must stop as soon
+	// as that one doc number has been handed out.
+	is1Hit bool
+
+	// fastScan records that this iterator is a plain block-backed scan: no
+	// inline encoding, no replacement bitmap, no deletions, no locations. That
+	// combination is the overwhelming majority of term scans, and it lets a
+	// forward step inside an already-decoded block skip every check the general
+	// path has to make.
+	fastScan bool
+
+	// The field's norm column, flattened onto the iterator so the hot loop does
+	// not re-decide its shape per document.
+	normDense   []uint8
+	normConst   float64
+	normIsDense bool
 
 	next            Posting            // reused across Next() calls
 	nextLocs        []Location         // reused across Next() calls
 	nextSegmentLocs []segment.Location // reused across Next() calls
 
-	docNum1Hit   uint64
-	normBits1Hit uint64
+	docNum1Hit uint64
 
 	buf []byte
 
 	includeFreqNorm bool
 	includeLocs     bool
 
+	err error
+
 	bytesRead uint64
 }
 
-var emptyPostingsIterator = &PostingsIterator{}
+var emptyPostingsIterator = &PostingsIterator{docNum1Hit: DocNum1HitFinished}
 
 func (i *PostingsIterator) Size() int {
 	sizeInBytes := reflectStaticSizePostingsIterator + SizeOfPtr +
 		i.next.Size()
-	// account for freqNormReader, locReader if we start using this.
 	for _, entry := range i.nextLocs {
 		sizeInBytes += entry.Size()
 	}
@@ -364,108 +436,281 @@ func (i *PostingsIterator) Size() int {
 	return sizeInBytes
 }
 
-// Implements the segment.DiskStatsReporter interface
-// The purpose of this implementation is to get
-// the bytes read from the disk which includes
-// the freqNorm and location specific information
-// of a hit
+// Implements the segment.DiskStatsReporter interface.
+//
+// The count is assembled from the three readers that actually touch the
+// mapping -- the block cursor, the location decoder, and whatever the iterator
+// itself charged at setup -- rather than being overwritten by whichever one
+// reported last. Callers take deltas of this across a query, so it has to be
+// cumulative and monotonic between resets.
 func (i *PostingsIterator) ResetBytesRead(val uint64) {
 	i.bytesRead = val
+	i.cursor.bytesRead = 0
+	if i.locReader != nil {
+		i.locReader.bytesRead = 0
+	}
 }
 
 func (i *PostingsIterator) BytesRead() uint64 {
-	return i.bytesRead
-}
-
-func (i *PostingsIterator) incrementBytesRead(val uint64) {
-	i.bytesRead += val
+	rv := i.bytesRead + i.cursor.bytesRead
+	if i.locReader != nil {
+		rv += i.locReader.getBytesRead()
+	}
+	return rv
 }
 
 func (i *PostingsIterator) BytesWritten() uint64 {
 	return 0
 }
 
-func (i *PostingsIterator) loadChunk(chunk int) error {
-	if i.includeFreqNorm {
-		err := i.freqNormReader.loadChunk(chunk)
-		if err != nil {
-			return err
-		}
+// isDeleted reports whether a doc number has been deleted. The bitmap and the
+// postings are both ascending, so advancing the peekable cursor is amortised
+// constant work.
+func (i *PostingsIterator) isDeleted(docNum uint32) bool {
+	if i.exceptItr == nil {
+		return false
+	}
+	i.exceptItr.AdvanceIfNeeded(docNum)
+	return i.exceptItr.HasNext() && i.exceptItr.PeekNext() == docNum
+}
 
-		// assign the bytes read at this point, since
-		// the postingsIterator is tracking only the chunk loaded
-		// and the cumulation is tracked correctly in the downstream
-		// intDecoder
-		i.ResetBytesRead(i.freqNormReader.getBytesRead())
+// positionAt moves the cursor onto the first posting at or after lo, reporting
+// false once the list runs out.
+func (i *PostingsIterator) positionAt(lo uint32) (bool, error) {
+	c := &i.cursor
+
+	if i.positioned {
+		// Already there. Happens when a caller advances to a doc it has just
+		// been handed.
+		if i.cur < c.nDocs && c.buf.docs[i.cur] >= lo {
+			return true, nil
+		}
+		// The overwhelmingly common case: the answer is the very next slot.
+		i.cur++
+		if i.cur < c.nDocs && c.buf.docs[i.cur] >= lo {
+			return true, nil
+		}
+		// Still inside this block, but further along.
+		if i.cur < c.nDocs && c.blockLastDoc >= lo {
+			i.cur = searchBlock(&c.buf.docs, lo)
+			return i.cur < c.nDocs, nil
+		}
 	}
 
-	if i.includeLocs {
-		err := i.locReader.loadChunk(chunk)
-		if err != nil {
-			return err
+	// Walk the skip list to the block that could hold lo, then decode just
+	// that one block.
+	c.seekBlock(lo)
+	if c.exhausted {
+		i.positioned = false
+		return false, nil
+	}
+	if err := c.loadBlock(); err != nil {
+		return false, err
+	}
+	i.positioned = true
+	i.cur = searchBlock(&c.buf.docs, lo)
+	return i.cur < c.nDocs, nil
+}
+
+// advanceOne steps to the next posting without skipping, which is what the
+// location path needs: the location blob is a per-document stream, so every
+// document has to be walked past even when it is not going to be returned.
+func (i *PostingsIterator) advanceOne() (bool, error) {
+	c := &i.cursor
+	if i.positioned {
+		i.cur++
+		if i.cur < c.nDocs {
+			return true, nil
 		}
-		i.ResetBytesRead(i.locReader.getBytesRead())
+		c.nextBlock()
+	}
+	if c.exhausted {
+		i.positioned = false
+		return false, nil
+	}
+	if err := c.loadBlock(); err != nil {
+		return false, err
+	}
+	i.positioned = true
+	i.cur = 0
+	return i.cur < c.nDocs, nil
+}
+
+// stepFast advances one posting inside the block that is already decoded. It
+// reports false whenever anything at all is unusual -- the block is spent, the
+// iterator is not a plain scan, nothing is decoded yet -- and the caller falls
+// back to the general path.
+func (i *PostingsIterator) stepFast() (uint32, bool) {
+	if !i.fastScan || !i.positioned {
+		return 0, false
+	}
+	k := i.cur + 1
+	if k >= i.cursor.nDocs {
+		return 0, false
+	}
+	i.cur = k
+	d := i.cursor.buf.docs[k]
+	i.nextAllowed = d + 1
+	return d, true
+}
+
+// nextDocNumAtOrAfter returns the next live doc number at or after atOrAfter.
+func (i *PostingsIterator) nextDocNumAtOrAfter(atOrAfter uint64) (uint64, bool, error) {
+	if i.err != nil {
+		return 0, false, i.err
 	}
 
-	i.currChunk = uint32(chunk)
+	if i.is1Hit {
+		if i.docNum1Hit == DocNum1HitFinished {
+			return 0, false, nil
+		}
+		docNum := i.docNum1Hit
+		i.docNum1Hit = DocNum1HitFinished // consume our 1-hit docNum
+		if docNum < atOrAfter {
+			return 0, false, nil
+		}
+		return docNum, true, nil
+	}
+
+	if i.docNum1Hit != DocNum1HitFinished {
+		docNum := i.docNum1Hit
+		i.docNum1Hit = DocNum1HitFinished // consume our 1-hit docNum
+		if docNum < atOrAfter {
+			return 0, false, nil
+		}
+		return docNum, true, nil
+	}
+
+	if i.postings == nil {
+		return 0, false, nil
+	}
+
+	lo := i.nextAllowed
+	if atOrAfter > uint64(docNumTerminated) {
+		return 0, false, nil
+	}
+	if uint32(atOrAfter) > lo {
+		lo = uint32(atOrAfter)
+	}
+
+	for {
+		var ok bool
+		var err error
+		if i.includeLocs {
+			ok, err = i.stepWithLocs(lo)
+		} else {
+			ok, err = i.positionAt(lo)
+		}
+		if err != nil || !ok {
+			return 0, false, err
+		}
+		docNum := i.cursor.buf.docs[i.cur]
+		if docNum == docNumTerminated {
+			return 0, false, nil
+		}
+		i.nextAllowed = docNum + 1
+		if !i.isDeleted(docNum) {
+			return uint64(docNum), true, nil
+		}
+		// A deleted document still occupies a slot in the location stream, so
+		// its group has to be discarded here. stepWithLocs only skips the
+		// documents it passes over on the way to lo; this one sits exactly at
+		// lo and was handed back before the deletion check rejected it.
+		if err := i.skipLocations(docNum); err != nil {
+			return 0, false, err
+		}
+		if docNum == math.MaxUint32 {
+			return 0, false, nil
+		}
+		lo = docNum + 1
+	}
+}
+
+// stepWithLocs advances to lo one document at a time, discarding the location
+// group of every document passed over so the location stream stays aligned.
+func (i *PostingsIterator) stepWithLocs(lo uint32) (bool, error) {
+	for {
+		ok, err := i.advanceOne()
+		if err != nil || !ok {
+			return false, err
+		}
+		docNum := i.cursor.buf.docs[i.cur]
+		if docNum >= lo {
+			return true, nil
+		}
+		if err := i.skipLocations(docNum); err != nil {
+			return false, err
+		}
+	}
+}
+
+// freqAt returns the frequency of the posting the cursor is sitting on.
+func (i *PostingsIterator) currFreq(docNum uint32) uint64 {
+	if !i.includeFreqNorm || !i.positioned {
+		return 1
+	}
+	if i.cur < i.cursor.nDocs && i.cursor.buf.docs[i.cur] == docNum {
+		return uint64(i.cursor.buf.freqs[i.cur])
+	}
+	return 1
+}
+
+// normIDOf reads a document's quantized norm ID directly, without the
+// 256-entry table lookup, for the Posting struct, which stores the id and
+// converts only if Norm() is called.
+func (i *PostingsIterator) normIDOf(docNum uint32) uint8 {
+	if i.normIsDense {
+		if int(docNum) < len(i.normDense) {
+			return i.normDense[docNum]
+		}
+		return 0
+	}
+	return i.postings.norms.constant
+}
+
+func (i *PostingsIterator) currNormID(docNum uint32) uint8 {
+	if i.postings == nil || i.postings.norms == nil {
+		return 0
+	}
+	return i.postings.norms.id(docNum)
+}
+
+// ------------------------------------------------------------------ locations
+
+func (i *PostingsIterator) loadLocChunk(docNum uint32) error {
+	if i.locReader == nil {
+		return nil
+	}
+	if i.postings.chunkSize == 0 {
+		return ErrChunkSizeZero
+	}
+	chunk := int(uint64(docNum) / i.postings.chunkSize)
+	if chunk == i.locChunk {
+		return nil
+	}
+	if err := i.locReader.loadChunk(chunk); err != nil {
+		return fmt.Errorf("error loading location chunk: %v", err)
+	}
+	i.locChunk = chunk
 	return nil
 }
 
-func (i *PostingsIterator) readFreqNormHasLocs() (uint64, uint64, bool, error) {
-	if i.normBits1Hit != 0 {
-		return 1, i.normBits1Hit, false, nil
+// skipLocations discards one document's location group. A term that records
+// locations writes a group for every posting -- possibly an empty one -- so
+// this is a fixed cost per document walked past and needs no per-document flag.
+func (i *PostingsIterator) skipLocations(docNum uint32) error {
+	if !i.hasLocs {
+		return nil
 	}
-
-	freqHasLocs, err := i.freqNormReader.readUvarint()
+	if err := i.loadLocChunk(docNum); err != nil {
+		return err
+	}
+	numLocsBytes, err := i.locReader.readUvarint()
 	if err != nil {
-		return 0, 0, false, fmt.Errorf("error reading frequency: %v", err)
+		return fmt.Errorf("error reading location numLocsBytes: %v", err)
 	}
-
-	freq, hasLocs := decodeFreqHasLocs(freqHasLocs)
-	if freq == 0 {
-		return freq, 0, hasLocs, nil
-	}
-
-	normBits, err := i.freqNormReader.readUvarint()
-	if err != nil {
-		return 0, 0, false, fmt.Errorf("error reading norm: %v", err)
-	}
-
-	return freq, normBits, hasLocs, nil
-}
-
-func (i *PostingsIterator) skipFreqNormReadHasLocs() (bool, error) {
-	if i.normBits1Hit != 0 {
-		return false, nil
-	}
-
-	freqHasLocs, err := i.freqNormReader.readUvarint()
-	if err != nil {
-		return false, fmt.Errorf("error reading freqHasLocs: %v", err)
-	}
-
-	freq, hasLocs := decodeFreqHasLocs(freqHasLocs)
-	if freq == 0 {
-		return hasLocs, nil
-	}
-
-	i.freqNormReader.SkipUvarint() // Skip normBits.
-
-	return hasLocs, nil // See decodeFreqHasLocs() / hasLocs.
-}
-
-func encodeFreqHasLocs(freq uint64, hasLocs bool) uint64 {
-	rv := freq << 1
-	if hasLocs {
-		rv = rv | 0x01 // 0'th LSB encodes whether there are locations
-	}
-	return rv
-}
-
-func decodeFreqHasLocs(freqHasLocs uint64) (uint64, bool) {
-	freq := freqHasLocs >> 1
-	hasLocs := freqHasLocs&0x01 != 0
-	return freq, hasLocs
+	i.locReader.SkipBytes(int(numLocsBytes))
+	return nil
 }
 
 // readLocation processes all the integers on the stream representing a single
@@ -497,6 +742,9 @@ func (i *PostingsIterator) readLocation(l *Location) error {
 		return fmt.Errorf("error reading location num array pos: %v", err)
 	}
 
+	if int(fieldID) >= len(i.postings.sb.fieldsInv) {
+		return fmt.Errorf("corrupt location: field id %d out of range", fieldID)
+	}
 	l.field = i.postings.sb.fieldsInv[fieldID]
 	l.pos = pos
 	l.start = start
@@ -521,6 +769,54 @@ func (i *PostingsIterator) readLocation(l *Location) error {
 	return nil
 }
 
+// readLocations fills rv with the location group of the doc the cursor is on.
+func (i *PostingsIterator) readLocations(rv *Posting, docNum uint32) error {
+	if err := i.loadLocChunk(docNum); err != nil {
+		return err
+	}
+
+	// The location count is bounded by the frequency, but only loosely: in a
+	// composite field some component fields may have term vectors switched off
+	// while others have them on, so the group can be shorter than the freq.
+	if rv.freq > 0 {
+		if cap(i.nextLocs) >= int(rv.freq) {
+			i.nextLocs = i.nextLocs[0:rv.freq]
+		} else {
+			i.nextLocs = make([]Location, rv.freq, rv.freq*2)
+		}
+		if cap(i.nextSegmentLocs) < int(rv.freq) {
+			i.nextSegmentLocs = make([]segment.Location, rv.freq, rv.freq*2)
+		}
+		rv.locs = i.nextSegmentLocs[:0]
+	}
+
+	numLocsBytes, err := i.locReader.readUvarint()
+	if err != nil {
+		return fmt.Errorf("error reading location numLocsBytes: %v", err)
+	}
+
+	j := 0
+	var nextLoc *Location
+	startBytesRemaining := i.locReader.Len() // # bytes remaining in the locReader
+	for startBytesRemaining-i.locReader.Len() < int(numLocsBytes) {
+		if len(i.nextLocs) > j {
+			nextLoc = &i.nextLocs[j]
+		} else {
+			nextLoc = &Location{}
+		}
+
+		if err := i.readLocation(nextLoc); err != nil {
+			return err
+		}
+
+		rv.locs = append(rv.locs, nextLoc)
+		j++
+	}
+	return nil
+}
+
+// --------------------------------------------------------------- the iterator
+
 // Next returns the next posting on the postings list, or nil at the end
 func (i *PostingsIterator) Next() (segment.Posting, error) {
 	return i.nextAtOrAfter(0)
@@ -532,8 +828,18 @@ func (i *PostingsIterator) Advance(docNum uint64) (segment.Posting, error) {
 	return i.nextAtOrAfter(docNum)
 }
 
-// Next returns the next posting on the postings list, or nil at the end
 func (i *PostingsIterator) nextAtOrAfter(atOrAfter uint64) (segment.Posting, error) {
+	if atOrAfter == 0 && i.includeFreqNorm {
+		if d, ok := i.stepFast(); ok {
+			rv := &i.next
+			rv.docNum = uint64(d)
+			rv.freq = uint64(i.cursor.buf.freqs[i.cur])
+			rv.normID = i.normIDOf(d)
+			rv.locs = nil
+			return rv, nil
+		}
+	}
+
 	docNum, exists, err := i.nextDocNumAtOrAfter(atOrAfter)
 	if err != nil || !exists {
 		return nil, err
@@ -547,307 +853,49 @@ func (i *PostingsIterator) nextAtOrAfter(atOrAfter uint64) (segment.Posting, err
 		return rv, nil
 	}
 
-	var normBits uint64
-	var hasLocs bool
+	rv.freq = i.currFreq(uint32(docNum))
+	rv.normID = i.currNormID(uint32(docNum))
 
-	rv.freq, normBits, hasLocs, err = i.readFreqNormHasLocs()
-	if err != nil {
-		return nil, err
-	}
-
-	rv.norm = math.Float32frombits(uint32(normBits))
-
-	if i.includeLocs && hasLocs {
-		// prepare locations into reused slices, where we assume
-		// rv.freq >= "number of locs", since in a composite field,
-		// some component fields might have their IncludeTermVector
-		// flags disabled while other component fields are enabled
-		if rv.freq > 0 {
-			if cap(i.nextLocs) >= int(rv.freq) {
-				i.nextLocs = i.nextLocs[0:rv.freq]
-			} else {
-				i.nextLocs = make([]Location, rv.freq, rv.freq*2)
-			}
-			if cap(i.nextSegmentLocs) < int(rv.freq) {
-				i.nextSegmentLocs = make([]segment.Location, rv.freq, rv.freq*2)
-			}
-			rv.locs = i.nextSegmentLocs[:0]
-		}
-
-		numLocsBytes, err := i.locReader.readUvarint()
-		if err != nil {
-			return nil, fmt.Errorf("error reading location numLocsBytes: %v", err)
-		}
-
-		j := 0
-		var nextLoc *Location
-		startBytesRemaining := i.locReader.Len() // # bytes remaining in the locReader
-		for startBytesRemaining-i.locReader.Len() < int(numLocsBytes) {
-			if len(i.nextLocs) > j {
-				nextLoc = &i.nextLocs[j]
-			} else {
-				nextLoc = &Location{}
-			}
-
-			err := i.readLocation(nextLoc)
-			if err != nil {
-				return nil, err
-			}
-
-			rv.locs = append(rv.locs, nextLoc)
-			j++
+	if i.hasLocs {
+		if err := i.readLocations(rv, uint32(docNum)); err != nil {
+			return nil, err
 		}
 	}
 
 	return rv, nil
 }
 
-// nextDocNum returns the next docNum on the postings list, and also
-// sets up the currChunk / loc related fields of the iterator.
-func (i *PostingsIterator) nextDocNumAtOrAfter(atOrAfter uint64) (uint64, bool, error) {
-	if i.normBits1Hit != 0 {
-		if i.docNum1Hit == DocNum1HitFinished {
-			return 0, false, nil
-		}
-		if i.docNum1Hit < atOrAfter {
-			// advanced past our 1-hit
-			i.docNum1Hit = DocNum1HitFinished // consume our 1-hit docNum
-			return 0, false, nil
-		}
-		docNum := i.docNum1Hit
-		i.docNum1Hit = DocNum1HitFinished // consume our 1-hit docNum
-		return docNum, true, nil
-	}
-
-	if i.Actual == nil || !i.Actual.HasNext() {
-		return 0, false, nil
-	}
-
-	if i.postings == nil || i.postings == emptyPostingsList {
-		// couldn't find anything
-		return 0, false, nil
-	}
-
-	if i.postings.postings == i.ActualBM {
-		return i.nextDocNumAtOrAfterClean(atOrAfter)
-	}
-
-	if i.postings.chunkSize == 0 {
-		return 0, false, ErrChunkSizeZero
-	}
-
-	i.Actual.AdvanceIfNeeded(uint32(atOrAfter))
-
-	if !i.Actual.HasNext() || !i.all.HasNext() {
-		// couldn't find anything
-		return 0, false, nil
-	}
-
-	n := i.Actual.Next()
-	allN := i.all.Next()
-	nChunk := n / uint32(i.postings.chunkSize)
-
-	// when allN becomes >= to here, then allN is in the same chunk as nChunk.
-	allNReachesNChunk := nChunk * uint32(i.postings.chunkSize)
-
-	// n is the next actual hit (excluding some postings), and
-	// allN is the next hit in the full postings, and
-	// if they don't match, move 'all' forwards until they do
-	for allN != n {
-		// we've reached same chunk, so move the freq/norm/loc decoders forward
-		if i.includeFreqNorm && allN >= allNReachesNChunk {
-			err := i.currChunkNext(nChunk)
-			if err != nil {
-				return 0, false, err
-			}
-		}
-
-		if !i.all.HasNext() {
-			return 0, false, nil
-		}
-
-		allN = i.all.Next()
-	}
-
-	if i.includeFreqNorm && (i.currChunk != nChunk || i.freqNormReader.isNil()) {
-		err := i.loadChunk(int(nChunk))
-		if err != nil {
-			return 0, false, fmt.Errorf("error loading chunk: %v", err)
-		}
-	}
-
-	return uint64(n), true, nil
-}
-
-var freqHasLocs1Hit = encodeFreqHasLocs(1, false)
-
-// nextBytes returns the docNum and the encoded freq & loc bytes for
-// the next posting
-func (i *PostingsIterator) nextBytes() (
-	docNumOut uint64, freq uint64, normBits uint64,
-	bytesFreqNorm []byte, bytesLoc []byte, err error) {
+// nextWithLocBytes returns the next posting along with the raw encoded bytes of
+// its location group, so a merge can move locations across without decoding and
+// re-encoding them.
+//
+// Unlike earlier zap versions there are no frequency or norm bytes to copy:
+// frequencies are bitpacked and have to be re-packed against the new doc
+// numbering, and norms are not in the postings at all.
+func (i *PostingsIterator) nextWithLocBytes() (
+	docNumOut uint64, freq uint64, bytesLoc []byte, exists bool, err error) {
 	docNum, exists, err := i.nextDocNumAtOrAfter(0)
 	if err != nil || !exists {
-		return 0, 0, 0, nil, nil, err
+		return 0, 0, nil, false, err
 	}
+	freq = i.currFreq(uint32(docNum))
 
-	if i.normBits1Hit != 0 {
-		if i.buf == nil {
-			i.buf = make([]byte, binary.MaxVarintLen64*2)
+	if i.hasLocs {
+		if err := i.loadLocChunk(uint32(docNum)); err != nil {
+			return 0, 0, nil, false, err
 		}
-		n := binary.PutUvarint(i.buf, freqHasLocs1Hit)
-		n += binary.PutUvarint(i.buf[n:], i.normBits1Hit)
-		return docNum, uint64(1), i.normBits1Hit, i.buf[:n], nil, nil
-	}
-
-	startFreqNorm := i.freqNormReader.remainingLen()
-
-	var hasLocs bool
-
-	freq, normBits, hasLocs, err = i.readFreqNormHasLocs()
-	if err != nil {
-		return 0, 0, 0, nil, nil, err
-	}
-
-	endFreqNorm := i.freqNormReader.remainingLen()
-	bytesFreqNorm = i.freqNormReader.readBytes(startFreqNorm, endFreqNorm)
-
-	if hasLocs {
 		startLoc := i.locReader.remainingLen()
-
 		numLocsBytes, err := i.locReader.readUvarint()
 		if err != nil {
-			return 0, 0, 0, nil, nil,
-				fmt.Errorf("error reading location nextBytes numLocs: %v", err)
+			return 0, 0, nil, false,
+				fmt.Errorf("error reading location numLocsBytes: %v", err)
 		}
-
-		// skip over all the location bytes
 		i.locReader.SkipBytes(int(numLocsBytes))
-
 		endLoc := i.locReader.remainingLen()
 		bytesLoc = i.locReader.readBytes(startLoc, endLoc)
 	}
 
-	return docNum, freq, normBits, bytesFreqNorm, bytesLoc, nil
-}
-
-// optimization when the postings list is "clean" (e.g., no updates &
-// no deletions) where the all bitmap is the same as the actual bitmap
-func (i *PostingsIterator) nextDocNumAtOrAfterClean(
-	atOrAfter uint64) (uint64, bool, error) {
-	if !i.includeFreqNorm {
-		i.Actual.AdvanceIfNeeded(uint32(atOrAfter))
-
-		if !i.Actual.HasNext() {
-			return 0, false, nil // couldn't find anything
-		}
-
-		return uint64(i.Actual.Next()), true, nil
-	}
-
-	if i.postings != nil && i.postings.chunkSize == 0 {
-		return 0, false, ErrChunkSizeZero
-	}
-
-	// freq-norm's needed, so maintain freq-norm chunk reader
-	sameChunkNexts := 0 // # of times we called Next() in the same chunk
-	n := i.Actual.Next()
-	nChunk := n / uint32(i.postings.chunkSize)
-
-	for uint64(n) < atOrAfter && i.Actual.HasNext() {
-		n = i.Actual.Next()
-
-		nChunkPrev := nChunk
-		nChunk = n / uint32(i.postings.chunkSize)
-
-		if nChunk != nChunkPrev {
-			sameChunkNexts = 0
-		} else {
-			sameChunkNexts += 1
-		}
-	}
-
-	if uint64(n) < atOrAfter {
-		// couldn't find anything
-		return 0, false, nil
-	}
-
-	for j := 0; j < sameChunkNexts; j++ {
-		err := i.currChunkNext(nChunk)
-		if err != nil {
-			return 0, false, fmt.Errorf("error optimized currChunkNext: %v", err)
-		}
-	}
-
-	if i.currChunk != nChunk || i.freqNormReader.isNil() {
-		err := i.loadChunk(int(nChunk))
-		if err != nil {
-			return 0, false, fmt.Errorf("error loading chunk: %v", err)
-		}
-	}
-
-	return uint64(n), true, nil
-}
-
-func (i *PostingsIterator) currChunkNext(nChunk uint32) error {
-	if i.currChunk != nChunk || i.freqNormReader.isNil() {
-		err := i.loadChunk(int(nChunk))
-		if err != nil {
-			return fmt.Errorf("error loading chunk: %v", err)
-		}
-	}
-
-	// read off freq/offsets even though we don't care about them
-	hasLocs, err := i.skipFreqNormReadHasLocs()
-	if err != nil {
-		return err
-	}
-
-	if i.includeLocs && hasLocs {
-		numLocsBytes, err := i.locReader.readUvarint()
-		if err != nil {
-			return fmt.Errorf("error reading location numLocsBytes: %v", err)
-		}
-
-		// skip over all the location bytes
-		i.locReader.SkipBytes(int(numLocsBytes))
-	}
-
-	return nil
-}
-
-// DocNum1Hit returns the docNum and true if this is "1-hit" optimized
-// and the docNum is available.
-func (p *PostingsIterator) DocNum1Hit() (uint64, bool) {
-	if p.normBits1Hit != 0 && p.docNum1Hit != DocNum1HitFinished {
-		return p.docNum1Hit, true
-	}
-	return 0, false
-}
-
-// ActualBitmap returns the underlying actual bitmap
-// which can be used up the stack for optimizations
-func (p *PostingsIterator) ActualBitmap() *roaring.Bitmap {
-	return p.ActualBM
-}
-
-// ReplaceActual replaces the ActualBM with the provided
-// bitmap
-func (p *PostingsIterator) ReplaceActual(abm *roaring.Bitmap) {
-	p.ActualBM = abm
-	p.Actual = abm.Iterator()
-}
-
-// PostingsIteratorFromBitmap constructs a PostingsIterator given an
-// "actual" bitmap.
-func PostingsIteratorFromBitmap(bm *roaring.Bitmap,
-	includeFreqNorm, includeLocs bool) (segment.PostingsIterator, error) {
-	return &PostingsIterator{
-		ActualBM:        bm,
-		Actual:          bm.Iterator(),
-		includeFreqNorm: includeFreqNorm,
-		includeLocs:     includeLocs,
-	}, nil
+	return docNum, freq, bytesLoc, true, nil
 }
 
 // PostingsIteratorFrom1Hit constructs a PostingsIterator given a
@@ -855,8 +903,8 @@ func PostingsIteratorFromBitmap(bm *roaring.Bitmap,
 func PostingsIteratorFrom1Hit(docNum1Hit uint64,
 	includeFreqNorm, includeLocs bool) (segment.PostingsIterator, error) {
 	return &PostingsIterator{
+		is1Hit:          true,
 		docNum1Hit:      docNum1Hit,
-		normBits1Hit:    NormBits1Hit,
 		includeFreqNorm: includeFreqNorm,
 		includeLocs:     includeLocs,
 	}, nil
@@ -866,7 +914,7 @@ func PostingsIteratorFrom1Hit(docNum1Hit uint64,
 type Posting struct {
 	docNum uint64
 	freq   uint64
-	norm   float32
+	normID uint8
 	locs   []segment.Location
 }
 
@@ -890,19 +938,21 @@ func (p *Posting) Frequency() uint64 {
 	return p.freq
 }
 
-// Norm returns the normalization factor for this posting
+// Norm returns the normalization factor for this posting: one lookup into the
+// 256-entry table built from the field-norm quantization, with no arithmetic on
+// the scan path at all.
 func (p *Posting) Norm() float64 {
-	return float64(float32(1.0 / math.Sqrt(float64(math.Float32bits(p.norm)))))
+	return normFactorFromID(p.normID)
+}
+
+// NormUint64 returns the field length this posting's norm stands for.
+func (p *Posting) NormUint64() uint64 {
+	return uint64(idToFieldNorm(p.normID))
 }
 
 // Locations returns the location information for each occurrence
 func (p *Posting) Locations() []segment.Location {
 	return p.locs
-}
-
-// NormUint64 returns the norm value as uint64
-func (p *Posting) NormUint64() uint64 {
-	return uint64(math.Float32bits(p.norm))
 }
 
 // Location represents the location of a single occurrence

--- a/postings_bench_test.go
+++ b/postings_bench_test.go
@@ -1,0 +1,222 @@
+//  Copyright (c) 2026 Couchbase, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// 		http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package zap
+
+import (
+	"fmt"
+	"os"
+	"strings"
+	"sync"
+	"testing"
+
+	"github.com/RoaringBitmap/roaring/v2"
+
+	index "github.com/blevesearch/bleve_index_api"
+)
+
+// Neither zapx nor bleve had a postings-scan benchmark before this format
+// change, which made "is the inner loop actually faster" unanswerable. These
+// measure the thing the block format exists to speed up: walking a term's
+// postings and reading the frequency and norm of each hit.
+
+const benchNumDocs = 50000
+
+// benchTermSpec names a term and how often it appears, spanning the range that
+// matters: one in every document (deltas of 1, so the doc block packs at zero
+// bits), a mid-frequency term, and a rare one.
+var benchTermSpecs = []struct {
+	term string
+	mod  int
+}{
+	{"bench_all", 1},
+	{"bench_10", 10},
+	{"bench_1000", 1000},
+}
+
+var (
+	benchSegOnce sync.Once
+	benchSeg     *SegmentBase
+)
+
+func benchSegment(tb testing.TB) *SegmentBase {
+	benchSegOnce.Do(func() {
+		results := make([]index.Document, 0, benchNumDocs)
+		for i := 0; i < benchNumDocs; i++ {
+			tokens := make([]string, 0, 8)
+			for _, spec := range benchTermSpecs {
+				if i%spec.mod == 0 {
+					tokens = append(tokens, spec.term)
+				}
+			}
+			tokens = append(tokens, fmt.Sprintf("u%d", i))
+			for p := 0; p < i%23; p++ {
+				tokens = append(tokens, "pad")
+			}
+			f := newStubFieldSplitString("body", nil, strings.Join(tokens, " "), false, false, false)
+			f.options = index.IndexField
+			for _, tf := range f.analyzedFreqs {
+				tf.Locations = nil
+			}
+			results = append(results, newStubDocument(fmt.Sprintf("d%d", i), []*stubField{
+				newStubFieldSplitString("_id", nil, fmt.Sprintf("d%d", i), true, false, false),
+				f,
+			}, "_all"))
+		}
+		seg, _, err := zapPlugin.newWithChunkMode(results, DefaultChunkMode, nil)
+		if err != nil {
+			panic(err)
+		}
+		benchSeg = seg.(*SegmentBase)
+	})
+	return benchSeg
+}
+
+func BenchmarkPostingsNext(b *testing.B) {
+	sb := benchSegment(b)
+	dict, err := sb.dictionary("body")
+	if err != nil {
+		b.Fatal(err)
+	}
+	for _, spec := range benchTermSpecs {
+		b.Run(spec.term, func(b *testing.B) {
+			var pl *PostingsList
+			var itr *PostingsIterator
+			var hits int
+			for b.Loop() {
+				pl, err = dict.postingsList([]byte(spec.term), nil, pl)
+				if err != nil {
+					b.Fatal(err)
+				}
+				it := pl.Iterator(true, true, false, itr)
+				itr = it.(*PostingsIterator)
+				for {
+					p, err := itr.Next()
+					if err != nil {
+						b.Fatal(err)
+					}
+					if p == nil {
+						break
+					}
+					sinkFloat += p.Norm() * float64(p.Frequency())
+					hits++
+				}
+			}
+			b.ReportMetric(float64(hits)/float64(b.N), "hits/op")
+		})
+	}
+}
+
+// BenchmarkPostingsAdvance is the conjunction-style access pattern: jump
+// forward by a stride rather than walking every posting. Large strides are what
+// the skip list is for.
+func BenchmarkPostingsAdvance(b *testing.B) {
+	sb := benchSegment(b)
+	dict, err := sb.dictionary("body")
+	if err != nil {
+		b.Fatal(err)
+	}
+	for _, stride := range []uint64{16, 256, 4096} {
+		b.Run(fmt.Sprintf("all/stride%d", stride), func(b *testing.B) {
+			var pl *PostingsList
+			var itr *PostingsIterator
+			for b.Loop() {
+				pl, err = dict.postingsList([]byte("bench_all"), nil, pl)
+				if err != nil {
+					b.Fatal(err)
+				}
+				it := pl.Iterator(true, true, false, itr)
+				itr = it.(*PostingsIterator)
+				var target uint64
+				for {
+					p, err := itr.Advance(target)
+					if err != nil {
+						b.Fatal(err)
+					}
+					if p == nil {
+						break
+					}
+					sinkFloat += p.Norm()
+					target = p.Number() + stride
+				}
+			}
+		})
+	}
+}
+
+var sinkFloat float64
+
+// BenchmarkSegmentBuild and BenchmarkSegmentMerge cover the write path: block
+// packing replaces the chunked varint encoders, and field norms move from one
+// varint per posting to one byte per document.
+func BenchmarkSegmentBuild(b *testing.B) {
+	results := benchDocuments(10000)
+	b.ResetTimer()
+	for b.Loop() {
+		_, _, err := zapPlugin.newWithChunkMode(results, DefaultChunkMode, nil)
+		if err != nil {
+			b.Fatal(err)
+		}
+	}
+}
+
+func BenchmarkSegmentMerge(b *testing.B) {
+	var sbs []*SegmentBase
+	for s := 0; s < 4; s++ {
+		seg, _, err := zapPlugin.newWithChunkMode(benchDocuments(5000), DefaultChunkMode, nil)
+		if err != nil {
+			b.Fatal(err)
+		}
+		sbs = append(sbs, seg.(*SegmentBase))
+	}
+	drops := make([]*roaring.Bitmap, len(sbs))
+	path := getTempPath("zap-bench-merge.zap")
+
+	b.ResetTimer()
+	for b.Loop() {
+		_ = os.RemoveAll(path)
+		_, _, err := mergeSegmentBases(sbs, drops, path, DefaultChunkMode, nil, nil, nil, nil)
+		if err != nil {
+			b.Fatal(err)
+		}
+	}
+	b.StopTimer()
+	_ = os.RemoveAll(path)
+}
+
+func benchDocuments(n int) []index.Document {
+	results := make([]index.Document, 0, n)
+	for i := 0; i < n; i++ {
+		tokens := make([]string, 0, 8)
+		for _, spec := range benchTermSpecs {
+			if i%spec.mod == 0 {
+				tokens = append(tokens, spec.term)
+			}
+		}
+		tokens = append(tokens, fmt.Sprintf("u%d", i))
+		for p := 0; p < i%23; p++ {
+			tokens = append(tokens, "pad")
+		}
+		f := newStubFieldSplitString("body", nil, strings.Join(tokens, " "), false, false, false)
+		f.options = index.IndexField
+		for _, tf := range f.analyzedFreqs {
+			tf.Locations = nil
+		}
+		results = append(results, newStubDocument(fmt.Sprintf("d%d", i), []*stubField{
+			newStubFieldSplitString("_id", nil, fmt.Sprintf("d%d", i), true, false, false),
+			f,
+		}, "_all"))
+	}
+	return results
+}

--- a/postings_block.go
+++ b/postings_block.go
@@ -1,0 +1,347 @@
+//  Copyright (c) 2026 Couchbase, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// 		http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package zap
+
+import (
+	"encoding/binary"
+	"fmt"
+
+	"github.com/blevesearch/freeway/bitpack"
+)
+
+// blockCursor walks one term's postings a block at a time.  It owns two roles
+// that tantivy splits between SkipReader and BlockSegmentPostings: stepping
+// through the skip list, which needs no payload at all, and decoding the block
+// the skip list landed on.
+//
+// Every loaded block presents exactly 128 slots in docs, non-decreasing, padded
+// out with docNumTerminated.  Callers can therefore index docs without a bounds
+// test, and the in-block search below can run without a branch.
+type blockCursor struct {
+	sb *SegmentBase
+
+	payloadStart uint64
+	payloadLen   uint64
+	skip         []byte // the decoded skip region; empty only when docFreq == 0
+
+	docFreq       uint32
+	numFullBlocks int
+	tailLen       int
+	entryLen      int
+	hasFreqs      bool
+	wantFreqs     bool
+
+	// tailLastDoc is the tail's own last, largest doc number, read once from
+	// the skip trailer. It gives seekBlock a real bound to compare the tail
+	// against instead of always having to decode it. Meaningless when
+	// tailLen == 0.
+	tailLastDoc uint32
+
+	// Position in the skip list.  blockIdx counts full blocks; reaching
+	// numFullBlocks means the uvarint tail, and going past it means the list is
+	// spent.
+	blockIdx  int
+	entry     skipEntry
+	inTail    bool
+	exhausted bool
+
+	// prevLastDoc is the last doc number of the preceding block, which is the
+	// anchor the current block's deltas are measured against.
+	prevLastDoc uint32
+
+	// buf holds the decoded block. It lives behind a pointer, and is only
+	// allocated once something actually has to be decoded, because a
+	// PostingsIterator embeds a blockCursor and a query over many small
+	// segments creates far more iterators than it decodes blocks -- inline
+	// arrays would mean a kilobyte allocated and zeroed per iterator.
+	buf *blockBuf
+
+	nDocs        int
+	blockLastDoc uint32
+	loaded       bool
+
+	bytesRead uint64
+}
+
+// blockBuf is one decoded block: 128 doc numbers and 128 frequencies.
+type blockBuf struct {
+	docs  [postingsBlockLen]uint32
+	freqs [postingsBlockLen]uint32
+}
+
+// allOnes seeds the frequency array for terms that do not record frequencies,
+// and for readers that asked not to decode them.  A missing frequency reads as
+// 1, which is what earlier zap versions returned.
+var allOnes = func() (a [postingsBlockLen]uint32) {
+	for i := range a {
+		a[i] = 1
+	}
+	return
+}()
+
+var allTerminated = func() (a [postingsBlockLen]uint32) {
+	for i := range a {
+		a[i] = docNumTerminated
+	}
+	return
+}()
+
+// init points the cursor at a term.  The footer has already been decoded, which
+// is where the three region offsets come from.
+func (c *blockCursor) init(sb *SegmentBase, h *termFooter,
+	payloadStart, skipStart uint64, wantFreqs bool) error {
+	c.sb = sb
+	c.payloadStart = payloadStart
+	c.payloadLen = h.payloadLen
+	c.docFreq = h.docFreq
+	c.hasFreqs = h.hasFreqs()
+	c.wantFreqs = wantFreqs && c.hasFreqs
+	c.numFullBlocks = int(h.docFreq) / postingsBlockLen
+	c.tailLen = int(h.docFreq) % postingsBlockLen
+	c.entryLen = skipEntryLen(c.hasFreqs)
+
+	c.skip = nil
+	c.tailLastDoc = docNumTerminated
+	if h.skipLen > 0 {
+		raw, err := sb.fileReader.process(sb.mem[skipStart : skipStart+h.skipLen])
+		if err != nil {
+			return fmt.Errorf("error processing skip data: %v", err)
+		}
+		want := skipDataLen(c.numFullBlocks, c.tailLen, c.hasFreqs)
+		if len(raw) != want {
+			return fmt.Errorf("corrupt skip data: %d bytes for %d blocks, want %d",
+				len(raw), c.numFullBlocks, want)
+		}
+		c.skip = raw
+		c.bytesRead += h.skipLen
+		if c.tailLen > 0 {
+			off := c.numFullBlocks * c.entryLen
+			if c.numFullBlocks > 0 {
+				off += skipTailOffsetLen
+			}
+			c.tailLastDoc = binary.LittleEndian.Uint32(c.skip[off:])
+		}
+	} else if c.numFullBlocks > 0 || c.tailLen > 0 {
+		return fmt.Errorf("corrupt term: %d full blocks, %d tail docs, but no skip data",
+			c.numFullBlocks, c.tailLen)
+	}
+
+	if c.buf == nil {
+		c.buf = &blockBuf{}
+	}
+	if !c.wantFreqs {
+		copy(c.buf.freqs[:], allOnes[:])
+	}
+	c.rewind()
+	return nil
+}
+
+// rewind returns the cursor to the first block without re-reading the footer.
+func (c *blockCursor) rewind() {
+	c.blockIdx = 0
+	c.prevLastDoc = 0
+	c.loaded = false
+	c.selectBlock()
+}
+
+// selectBlock reads the skip entry for blockIdx, or switches to the tail, or
+// marks the cursor spent.
+func (c *blockCursor) selectBlock() {
+	switch {
+	case c.blockIdx < c.numFullBlocks:
+		c.entry.decode(c.skip[c.blockIdx*c.entryLen:], c.hasFreqs)
+		c.inTail = false
+		c.exhausted = false
+	case c.blockIdx == c.numFullBlocks && c.tailLen > 0:
+		// tailLastDoc came from the skip trailer, so seekBlock's ordinary bound
+		// check applies to the tail exactly like a full block: a target past
+		// the tail's own range exhausts the cursor without decoding it.
+		c.entry = skipEntry{lastDoc: c.tailLastDoc}
+		c.inTail = true
+		c.exhausted = false
+	default:
+		c.inTail = false
+		c.exhausted = true
+	}
+}
+
+// nextBlock steps one block forward.
+func (c *blockCursor) nextBlock() {
+	if c.exhausted {
+		return
+	}
+	if !c.inTail {
+		c.prevLastDoc = c.entry.lastDoc
+	}
+	c.blockIdx++
+	c.loaded = false
+	c.selectBlock()
+}
+
+// seekBlock walks forward to the first block -- full or tail -- that could
+// contain target, or exhausts the cursor if none can.  It touches only the
+// skip list -- a linear scan over fixed-size records, one per 128 documents,
+// plus the tail's own lastDoc bound -- and never decodes a payload, which is
+// what makes a long forward skip cheap even when the answer turns out not to
+// exist at all.
+func (c *blockCursor) seekBlock(target uint32) {
+	for !c.exhausted && c.entry.lastDoc < target {
+		c.nextBlock()
+	}
+}
+
+// blockOffsetAt returns the payload-relative offset of block i.  Index
+// numFullBlocks is the tail, whose offset is the trailing value the writer
+// appended after the last entry; that also gives the last full block its length.
+func (c *blockCursor) blockOffsetAt(i int) uint32 {
+	if i >= c.numFullBlocks {
+		return binary.LittleEndian.Uint32(c.skip[c.numFullBlocks*c.entryLen:])
+	}
+	return binary.LittleEndian.Uint32(c.skip[i*c.entryLen+4:])
+}
+
+func (c *blockCursor) loadBlock() error {
+	if c.loaded {
+		return nil
+	}
+	c.loaded = true
+
+	if c.exhausted {
+		copy(c.buf.docs[:], allTerminated[:])
+		c.nDocs = 0
+		c.blockLastDoc = docNumTerminated
+		return nil
+	}
+	if c.inTail {
+		return c.loadTail()
+	}
+
+	start := c.payloadStart + uint64(c.entry.blockOffset)
+	end := c.payloadStart + uint64(c.blockOffsetAt(c.blockIdx+1))
+	if end < start || end > uint64(len(c.sb.mem)) {
+		return fmt.Errorf("corrupt postings block range [%d,%d)", start, end)
+	}
+	raw, err := c.sb.fileReader.process(c.sb.mem[start:end])
+	if err != nil {
+		return fmt.Errorf("error processing postings block: %v", err)
+	}
+	c.bytesRead += end - start
+
+	docBytes := bitpack.BlockBytes(c.entry.docNumBits)
+	if len(raw) < docBytes {
+		return fmt.Errorf("corrupt postings block: %d bytes, need %d", len(raw), docBytes)
+	}
+	bitpack.UnpackDelta1(raw, c.prevLastDoc, c.entry.docNumBits, &c.buf.docs)
+	if c.wantFreqs {
+		tfBytes := bitpack.BlockBytes(c.entry.tfNumBits)
+		if len(raw) < docBytes+tfBytes {
+			return fmt.Errorf("corrupt postings block: missing frequency bytes")
+		}
+		bitpack.UnpackPlus1(raw[docBytes:], c.entry.tfNumBits, &c.buf.freqs)
+	}
+	c.nDocs = postingsBlockLen
+	c.blockLastDoc = c.entry.lastDoc
+	return nil
+}
+
+// loadTail decodes the fewer-than-128 documents that could not fill a block.
+// They are plain uvarints: there is no bit width to save on a run this short,
+// and it keeps the reader on the existing uvarint decoder.
+func (c *blockCursor) loadTail() error {
+	var tailOffset uint64
+	if c.numFullBlocks > 0 {
+		// With no full blocks the tail starts at the payload itself; the skip
+		// trailer in that case holds only tailLastDoc, not a tail offset.
+		tailOffset = uint64(c.blockOffsetAt(c.numFullBlocks))
+	}
+	start := c.payloadStart + tailOffset
+	end := c.payloadStart + c.payloadLen
+	if end < start || end > uint64(len(c.sb.mem)) {
+		return fmt.Errorf("corrupt postings tail range [%d,%d)", start, end)
+	}
+	raw, err := c.sb.fileReader.process(c.sb.mem[start:end])
+	if err != nil {
+		return fmt.Errorf("error processing postings tail: %v", err)
+	}
+	c.bytesRead += end - start
+
+	r := memUvarintReader{S: raw}
+	prev := c.prevLastDoc
+	for i := 0; i < c.tailLen; i++ {
+		delta, err := r.ReadUvarint()
+		if err != nil {
+			return fmt.Errorf("error reading tail doc delta: %v", err)
+		}
+		prev += uint32(delta)
+		c.buf.docs[i] = prev
+	}
+	if c.hasFreqs {
+		if c.wantFreqs {
+			for i := 0; i < c.tailLen; i++ {
+				freq, err := r.ReadUvarint()
+				if err != nil {
+					return fmt.Errorf("error reading tail freq: %v", err)
+				}
+				c.buf.freqs[i] = uint32(freq)
+			}
+		}
+	}
+	copy(c.buf.docs[c.tailLen:], allTerminated[c.tailLen:])
+	c.nDocs = c.tailLen
+	c.blockLastDoc = prev
+	return nil
+}
+
+// b2i is the branchless comparison helper the in-block search is built from;
+// the compiler turns it into a set-on-condition.
+func b2i(b bool) int {
+	if b {
+		return 1
+	}
+	return 0
+}
+
+// searchBlock returns the index of the first entry in a decoded block that is
+// greater than or equal to target -- a lower bound.
+//
+// This is the 8-ary search of Schlegel, Gemulla and Lehner rather than a binary
+// search: 128 narrows to 16, then to 2, then a two-element scan, for sixteen
+// comparisons instead of seven.  All sixteen are branchless, and the seven
+// probes of each round are independent loads the processor can issue together,
+// so the extra comparisons cost less than the mispredictions they replace.
+//
+// It relies on the padding invariant: the block always holds 128 non-decreasing
+// entries ending in a value no legal target can exceed, so the result is always
+// in range.
+func searchBlock(arr *[postingsBlockLen]uint32, target uint32) int {
+	base, span := 0, postingsBlockLen
+	for {
+		step := span / 8
+		if step == 0 {
+			break
+		}
+		count := 0
+		for i := 1; i < 8; i++ {
+			count += b2i(arr[base+i*step-1] < target)
+		}
+		base += count * step
+		span = step
+	}
+	count := 0
+	for i := 0; i < span; i++ {
+		count += b2i(arr[base+i] < target)
+	}
+	return base + count
+}

--- a/postings_block_test.go
+++ b/postings_block_test.go
@@ -1,0 +1,705 @@
+//  Copyright (c) 2026 Couchbase, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// 		http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package zap
+
+import (
+	"fmt"
+	"math/rand"
+	"os"
+	"reflect"
+	"sort"
+	"strings"
+	"testing"
+
+	"github.com/RoaringBitmap/roaring/v2"
+	index "github.com/blevesearch/bleve_index_api"
+	segment "github.com/blevesearch/scorch_segment_api/v2"
+)
+
+// The tests in this file exist because the rest of the suite builds segments of
+// a handful of documents, which never fill the 128-document block the format is
+// built around. Everything interesting -- the skip list, the block boundary,
+// the uvarint tail, the in-block search -- only shows up past that size.
+
+// expPosting is the model these tests check the segment against.
+type expPosting struct {
+	docNum uint64
+	freq   uint64
+	normID uint8
+}
+
+// blockTestModel describes a synthetic corpus and what each term's postings
+// should look like once written and read back.
+type blockTestModel struct {
+	numDocs int
+	// term -> postings, in doc order
+	terms map[string][]expPosting
+}
+
+// buildBlockTestSegment makes a segment whose terms span every case that
+// matters: present in every document (packs at zero bits), present in a
+// scattered subset, present exactly once, and repeated within a document so the
+// frequency is not 1.
+func buildBlockTestSegment(t *testing.T, numDocs int, termVectors bool) (
+	*SegmentBase, *blockTestModel) {
+	t.Helper()
+
+	model := &blockTestModel{numDocs: numDocs, terms: map[string][]expPosting{}}
+	results := make([]index.Document, 0, numDocs)
+
+	for i := 0; i < numDocs; i++ {
+		var tokens []string
+		// "all" is in every document, so its deltas are all 1 and the doc block
+		// packs at zero bits.
+		tokens = append(tokens, "all")
+		// A term repeated within the document, to exercise frequencies.
+		reps := 1 + i%5
+		for r := 0; r < reps; r++ {
+			tokens = append(tokens, "rep")
+		}
+		for _, k := range []int{2, 3, 7, 50, 977} {
+			if i%k == 0 {
+				tokens = append(tokens, fmt.Sprintf("mod%d", k))
+			}
+		}
+		// A term unique to this document: the 1-hit case.
+		tokens = append(tokens, fmt.Sprintf("uniq%d", i))
+		// Pad so field lengths vary and the norm column is not constant.
+		for p := 0; p < i%37; p++ {
+			tokens = append(tokens, "pad")
+		}
+
+		value := strings.Join(tokens, " ")
+		f := newStubFieldSplitString("body", nil, value, false, false, termVectors)
+		if !termVectors {
+			f.options = index.IndexField
+			for _, tf := range f.analyzedFreqs {
+				tf.Locations = nil
+			}
+		}
+		doc := newStubDocument(fmt.Sprintf("d%d", i), []*stubField{
+			newStubFieldSplitString("_id", nil, fmt.Sprintf("d%d", i), true, false, false),
+			f,
+		}, "_all")
+		results = append(results, doc)
+
+		// The stub sets a field's analyzed length to its distinct token count,
+		// which is what the norm column will quantize.
+		normID := fieldNormToID(uint32(len(f.analyzedFreqs)))
+		for term, tf := range f.analyzedFreqs {
+			model.terms[term] = append(model.terms[term], expPosting{
+				docNum: uint64(i),
+				freq:   uint64(tf.Frequency()),
+				normID: normID,
+			})
+		}
+	}
+
+	seg, _, err := zapPlugin.newWithChunkMode(results, DefaultChunkMode, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return seg.(*SegmentBase), model
+}
+
+// collect walks a postings list and returns what it yielded.
+func collect(t *testing.T, sb *SegmentBase, field, term string,
+	except *roaring.Bitmap, includeLocs bool) []expPosting {
+	t.Helper()
+	dict, err := sb.dictionary(field)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if dict == nil {
+		return nil
+	}
+	pl, err := dict.postingsList([]byte(term), except, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	itr := pl.Iterator(true, true, includeLocs, nil)
+	var got []expPosting
+	for {
+		next, err := itr.Next()
+		if err != nil {
+			t.Fatal(err)
+		}
+		if next == nil {
+			break
+		}
+		p, ok := next.(*Posting)
+		if !ok {
+			t.Fatalf("unexpected posting type %T", next)
+		}
+		got = append(got, expPosting{p.Number(), p.Frequency(), p.normID})
+	}
+	return got
+}
+
+func sortedTerms(m map[string][]expPosting) []string {
+	rv := make([]string, 0, len(m))
+	for k := range m {
+		rv = append(rv, k)
+	}
+	sort.Strings(rv)
+	return rv
+}
+
+func TestBlockPostingsRoundTrip(t *testing.T) {
+	for _, numDocs := range []int{1, 2, 127, 128, 129, 255, 256, 257, 1000, 3000} {
+		t.Run(fmt.Sprintf("docs%d", numDocs), func(t *testing.T) {
+			sb, model := buildBlockTestSegment(t, numDocs, false)
+			for _, term := range sortedTerms(model.terms) {
+				want := model.terms[term]
+				got := collect(t, sb, "body", term, nil, false)
+				if !reflect.DeepEqual(got, want) {
+					if len(got) != len(want) {
+						t.Fatalf("term %q: got %d postings, want %d", term, len(got), len(want))
+					}
+					for i := range got {
+						if got[i] != want[i] {
+							t.Fatalf("term %q posting %d: got %+v want %+v",
+								term, i, got[i], want[i])
+						}
+					}
+				}
+			}
+		})
+	}
+}
+
+// TestBlockPostingsCount checks that a doc frequency read straight off the term
+// header agrees with what iteration produces.
+func TestBlockPostingsCount(t *testing.T) {
+	sb, model := buildBlockTestSegment(t, 1000, false)
+	dict, err := sb.dictionary("body")
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, term := range sortedTerms(model.terms) {
+		pl, err := dict.postingsList([]byte(term), nil, nil)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if got, want := pl.Count(), uint64(len(model.terms[term])); got != want {
+			t.Errorf("term %q: Count() = %d, want %d", term, got, want)
+		}
+	}
+}
+
+func TestBlockPostingsAdvance(t *testing.T) {
+	sb, model := buildBlockTestSegment(t, 3000, false)
+	dict, err := sb.dictionary("body")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	for _, stride := range []uint64{1, 2, 17, 128, 129, 511, 4096} {
+		for _, term := range []string{"all", "rep", "mod2", "mod7", "mod50", "mod977"} {
+			want := model.terms[term]
+			pl, err := dict.postingsList([]byte(term), nil, nil)
+			if err != nil {
+				t.Fatal(err)
+			}
+			itr := pl.Iterator(true, true, false, nil)
+
+			var got []expPosting
+			var target uint64
+			for {
+				next, err := itr.Advance(target)
+				if err != nil {
+					t.Fatal(err)
+				}
+				if next == nil {
+					break
+				}
+				p := next.(*Posting)
+				got = append(got, expPosting{p.Number(), p.Frequency(), p.normID})
+				target = p.Number() + stride
+			}
+
+			// The expected result is every posting whose doc number is the
+			// first at or after each successive target.
+			var exp []expPosting
+			t2 := uint64(0)
+			for _, w := range want {
+				if w.docNum >= t2 {
+					exp = append(exp, w)
+					t2 = w.docNum + stride
+				}
+			}
+			if !reflect.DeepEqual(got, exp) {
+				t.Fatalf("term %q stride %d: got %d postings, want %d\ngot:  %v\nwant: %v",
+					term, stride, len(got), len(exp), got, exp)
+			}
+		}
+	}
+}
+
+func TestBlockPostingsWithDeletions(t *testing.T) {
+	const numDocs = 2000
+	sb, model := buildBlockTestSegment(t, numDocs, false)
+
+	rng := rand.New(rand.NewSource(7))
+	except := roaring.New()
+	deleted := map[uint64]bool{}
+	for i := 0; i < numDocs/3; i++ {
+		d := uint64(rng.Intn(numDocs))
+		except.Add(uint32(d))
+		deleted[d] = true
+	}
+	// Also delete a whole contiguous block, which is the case that makes a
+	// reader skip an entire decoded block.
+	for d := uint64(256); d < 384; d++ {
+		except.Add(uint32(d))
+		deleted[d] = true
+	}
+
+	for _, term := range sortedTerms(model.terms) {
+		var want []expPosting
+		for _, p := range model.terms[term] {
+			if !deleted[p.docNum] {
+				want = append(want, p)
+			}
+		}
+		got := collect(t, sb, "body", term, except, false)
+		if !reflect.DeepEqual(got, want) {
+			t.Fatalf("term %q with deletions: got %d, want %d\ngot:  %v\nwant: %v",
+				term, len(got), len(want), got, want)
+		}
+
+		dict, _ := sb.dictionary("body")
+		pl, err := dict.postingsList([]byte(term), except, nil)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if got, want := pl.Count(), uint64(len(want)); got != want {
+			t.Errorf("term %q: Count() with deletions = %d, want %d", term, got, want)
+		}
+	}
+}
+
+func TestBlockPostingsLocations(t *testing.T) {
+	const numDocs = 700
+	sb, model := buildBlockTestSegment(t, numDocs, true)
+
+	dict, err := sb.dictionary("body")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	for _, term := range sortedTerms(model.terms) {
+		want := model.terms[term]
+		pl, err := dict.postingsList([]byte(term), nil, nil)
+		if err != nil {
+			t.Fatal(err)
+		}
+		itr := pl.Iterator(true, true, true, nil)
+
+		i := 0
+		for {
+			next, err := itr.Next()
+			if err != nil {
+				t.Fatalf("term %q: %v", term, err)
+			}
+			if next == nil {
+				break
+			}
+			if i >= len(want) {
+				t.Fatalf("term %q: more postings than expected", term)
+			}
+			if next.Number() != want[i].docNum || next.Frequency() != want[i].freq {
+				t.Fatalf("term %q posting %d: got doc %d freq %d, want doc %d freq %d",
+					term, i, next.Number(), next.Frequency(), want[i].docNum, want[i].freq)
+			}
+			locs := next.Locations()
+			if uint64(len(locs)) != want[i].freq {
+				t.Fatalf("term %q doc %d: got %d locations, want %d",
+					term, next.Number(), len(locs), want[i].freq)
+			}
+			for _, loc := range locs {
+				if loc.Field() != "body" {
+					t.Fatalf("term %q doc %d: location field %q, want body",
+						term, next.Number(), loc.Field())
+				}
+				if loc.Pos() == 0 {
+					t.Fatalf("term %q doc %d: location position 0", term, next.Number())
+				}
+			}
+			i++
+		}
+		if i != len(want) {
+			t.Fatalf("term %q: got %d postings, want %d", term, i, len(want))
+		}
+	}
+}
+
+// TestBlockPostingsLocationsWithAdvance exercises the location path under
+// skipping, where the reader has to walk past documents it will not return in
+// order to keep the location stream aligned.
+func TestBlockPostingsLocationsWithAdvance(t *testing.T) {
+	sb, model := buildBlockTestSegment(t, 900, true)
+	dict, err := sb.dictionary("body")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	for _, term := range []string{"all", "rep", "mod3"} {
+		pl, err := dict.postingsList([]byte(term), nil, nil)
+		if err != nil {
+			t.Fatal(err)
+		}
+		itr := pl.Iterator(true, true, true, nil)
+
+		want := model.terms[term]
+		var target uint64
+		wi := 0
+		for {
+			next, err := itr.Advance(target)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if next == nil {
+				break
+			}
+			for wi < len(want) && want[wi].docNum < target {
+				wi++
+			}
+			if wi >= len(want) || want[wi].docNum != next.Number() {
+				t.Fatalf("term %q: Advance(%d) gave doc %d, want %d",
+					term, target, next.Number(), want[wi].docNum)
+			}
+			if uint64(len(next.Locations())) != want[wi].freq {
+				t.Fatalf("term %q doc %d: got %d locations, want %d",
+					term, next.Number(), len(next.Locations()), want[wi].freq)
+			}
+			target = next.Number() + 101
+		}
+	}
+}
+
+func TestBlockPostingsNormsRoundTrip(t *testing.T) {
+	sb, model := buildBlockTestSegment(t, 800, false)
+	dict, err := sb.dictionary("body")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if dict.norms == nil || dict.norms.kind == normsKindAbsent {
+		t.Fatal("field has no norm column")
+	}
+	for _, term := range sortedTerms(model.terms) {
+		for _, want := range model.terms[term] {
+			if got := dict.norms.id(uint32(want.docNum)); got != want.normID {
+				t.Fatalf("doc %d: norm id %d, want %d", want.docNum, got, want.normID)
+			}
+		}
+	}
+	// A field whose documents all share a length collapses to the constant
+	// encoding rather than one byte per document.
+	if dict.norms.kind != normsKindDense {
+		t.Errorf("expected a dense norm column for varying lengths, got kind %d",
+			dict.norms.kind)
+	}
+}
+
+func TestNormsColumnConstantEncoding(t *testing.T) {
+	results := make([]index.Document, 0, 300)
+	for i := 0; i < 300; i++ {
+		results = append(results, newStubDocument(fmt.Sprintf("d%d", i), []*stubField{
+			newStubFieldSplitString("_id", nil, fmt.Sprintf("d%d", i), true, false, false),
+			newStubFieldSplitString("kw", nil, "constant value", false, false, false),
+		}, "_all"))
+	}
+	seg, _, err := zapPlugin.newWithChunkMode(results, DefaultChunkMode, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	sb := seg.(*SegmentBase)
+	dict, err := sb.dictionary("kw")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if dict.norms.kind != normsKindConstant {
+		t.Fatalf("expected a constant norm column, got kind %d", dict.norms.kind)
+	}
+}
+
+// TestBlockPostingsMerge covers the merge path at a size where the block
+// structure has to be rebuilt against renumbered documents.
+func TestBlockPostingsMerge(t *testing.T) {
+	for _, withDrops := range []bool{false, true} {
+		name := "clean"
+		if withDrops {
+			name = "withDrops"
+		}
+		t.Run(name, func(t *testing.T) {
+			const perSeg = 700
+			const numSegs = 3
+
+			var sbs []*SegmentBase
+			var models []*blockTestModel
+			for s := 0; s < numSegs; s++ {
+				sb, model := buildBlockTestSegment(t, perSeg, true)
+				sbs = append(sbs, sb)
+				models = append(models, model)
+			}
+
+			drops := make([]*roaring.Bitmap, numSegs)
+			dropped := make([]map[uint64]bool, numSegs)
+			for s := range drops {
+				dropped[s] = map[uint64]bool{}
+				if withDrops {
+					bm := roaring.New()
+					for d := 0; d < perSeg; d += 5 {
+						bm.Add(uint32(d))
+						dropped[s][uint64(d)] = true
+					}
+					drops[s] = bm
+				}
+			}
+
+			tmp := getTempPath(fmt.Sprintf("zap-merge-block-%s.zap", name))
+			_ = os.RemoveAll(tmp)
+			defer func() { _ = os.RemoveAll(tmp) }()
+
+			newDocNums, _, err := mergeSegmentBases(sbs, drops, tmp, DefaultChunkMode,
+				nil, nil, nil, nil)
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			merged, err := zapPlugin.Open(tmp)
+			if err != nil {
+				t.Fatal(err)
+			}
+			defer func() { _ = merged.Close() }()
+			msb := &merged.(*Segment).SegmentBase
+
+			// Rebuild the model in the merged doc numbering.
+			want := map[string][]expPosting{}
+			for s, model := range models {
+				for term, postings := range model.terms {
+					for _, p := range postings {
+						if dropped[s][p.docNum] {
+							continue
+						}
+						nd := newDocNums[s][p.docNum]
+						if nd == docDropped {
+							t.Fatalf("segment %d doc %d unexpectedly dropped", s, p.docNum)
+						}
+						want[term] = append(want[term], expPosting{nd, p.freq, p.normID})
+					}
+				}
+			}
+			for term := range want {
+				sort.Slice(want[term], func(a, b int) bool {
+					return want[term][a].docNum < want[term][b].docNum
+				})
+			}
+
+			for _, term := range sortedTerms(want) {
+				got := collect(t, msb, "body", term, nil, false)
+				if !reflect.DeepEqual(got, want[term]) {
+					if len(got) != len(want[term]) {
+						t.Fatalf("term %q: merged gave %d postings, want %d",
+							term, len(got), len(want[term]))
+					}
+					for i := range got {
+						if got[i] != want[term][i] {
+							t.Fatalf("term %q posting %d: got %+v want %+v",
+								term, i, got[i], want[term][i])
+						}
+					}
+				}
+			}
+
+			// Locations must survive the merge too.
+			mdict, err := msb.dictionary("body")
+			if err != nil {
+				t.Fatal(err)
+			}
+			pl, err := mdict.postingsList([]byte("rep"), nil, nil)
+			if err != nil {
+				t.Fatal(err)
+			}
+			itr := pl.Iterator(true, true, true, nil)
+			seen := 0
+			for {
+				next, err := itr.Next()
+				if err != nil {
+					t.Fatal(err)
+				}
+				if next == nil {
+					break
+				}
+				if uint64(len(next.Locations())) != next.Frequency() {
+					t.Fatalf("merged doc %d: %d locations for freq %d",
+						next.Number(), len(next.Locations()), next.Frequency())
+				}
+				seen++
+			}
+			if seen != len(want["rep"]) {
+				t.Fatalf("merged term rep: walked %d postings, want %d", seen, len(want["rep"]))
+			}
+		})
+	}
+}
+
+// TestTailSeekPastRangeSkipsDecode guards the fix for a real gap in the tail:
+// without a real bound on it, seeking past a term's entire range always had
+// to decode the tail's uvarint stream before it could report "not found" --
+// unlike a full block, whose skip entry already lets a seek past it skip the
+// payload entirely. This covers both a term that is nothing but a tail (no
+// full blocks at all, the common case for a real dictionary's long tail) and
+// a term with full blocks followed by a tail, and checks both that the
+// answer is still right and that the tail is never decoded when the target
+// is out of range.
+func TestTailSeekPastRangeSkipsDecode(t *testing.T) {
+	const numDocs = 300
+	sb, model := buildBlockTestSegment(t, numDocs, false)
+
+	cases := []struct {
+		name string
+		term string
+	}{
+		{"allTail", "mod50"},      // docFreq ~6: numFullBlocks == 0, nothing but a tail
+		{"blocksPlusTail", "all"}, // docFreq == numDocs: full blocks, then a tail
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			postings := model.terms[tc.term]
+			if len(postings) == 0 {
+				t.Fatalf("term %q has no postings in the model", tc.term)
+			}
+			lastDoc := postings[len(postings)-1].docNum
+
+			dict, err := sb.dictionary("body")
+			if err != nil {
+				t.Fatal(err)
+			}
+			pl, err := dict.postingsList([]byte(tc.term), nil, nil)
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			// A target beyond every posting must come back empty, and must not
+			// have decoded a block -- full or tail -- to find that out.
+			itr := pl.Iterator(true, true, false, nil).(*PostingsIterator)
+			farBeyond := lastDoc + uint64(numDocs) + 1000
+			next, err := itr.Advance(farBeyond)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if next != nil {
+				t.Fatalf("term %q: Advance(%d) returned a posting, want none", tc.term, farBeyond)
+			}
+			if !itr.cursor.exhausted {
+				t.Fatalf("term %q: Advance(%d) left the cursor un-exhausted", tc.term, farBeyond)
+			}
+			if itr.cursor.loaded {
+				t.Fatalf("term %q: Advance(%d) decoded a block it should have ruled out from skip metadata alone",
+					tc.term, farBeyond)
+			}
+
+			// The boundary itself must still be found: seeking to the term's
+			// real last doc must succeed.
+			itr2 := pl.Iterator(true, true, false, nil).(*PostingsIterator)
+			got, err := itr2.Advance(lastDoc)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if got == nil || got.Number() != lastDoc {
+				t.Fatalf("term %q: Advance(%d) (the term's own last doc) should have found it", tc.term, lastDoc)
+			}
+
+			// One past the boundary must not be found, and by the same
+			// no-decode path as the far-beyond case above.
+			itr3 := pl.Iterator(true, true, false, nil).(*PostingsIterator)
+			got3, err := itr3.Advance(lastDoc + 1)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if got3 != nil {
+				t.Fatalf("term %q: Advance(%d) returned a posting, want none", tc.term, lastDoc+1)
+			}
+		})
+	}
+}
+
+// TestSearchBlock checks the branchless in-block lower bound against a linear
+// scan, including the padded region past the end of a partial block.
+func TestSearchBlock(t *testing.T) {
+	rng := rand.New(rand.NewSource(11))
+	for trial := 0; trial < 500; trial++ {
+		var arr [postingsBlockLen]uint32
+		n := 1 + rng.Intn(postingsBlockLen)
+		v := uint32(rng.Intn(10))
+		for i := 0; i < n; i++ {
+			v += 1 + uint32(rng.Intn(50))
+			arr[i] = v
+		}
+		for i := n; i < postingsBlockLen; i++ {
+			arr[i] = docNumTerminated
+		}
+
+		for probe := 0; probe < 20; probe++ {
+			target := uint32(rng.Intn(int(v) + 10))
+			want := 0
+			for want < postingsBlockLen && arr[want] < target {
+				want++
+			}
+			if got := searchBlock(&arr, target); got != want {
+				t.Fatalf("searchBlock(target=%d) = %d, want %d", target, got, want)
+			}
+		}
+	}
+}
+
+// TestOneHitEncoding verifies that a singleton term takes the inline encoding,
+// which is the shape most of a real dictionary has.
+func TestOneHitEncoding(t *testing.T) {
+	sb, _ := buildBlockTestSegment(t, 500, false)
+	dict, err := sb.dictionary("body")
+	if err != nil {
+		t.Fatal(err)
+	}
+	val, exists, err := dict.fstReader.Get([]byte("uniq42"))
+	if err != nil || !exists {
+		t.Fatalf("term uniq42 missing: exists=%v err=%v", exists, err)
+	}
+	if val&FSTValEncodingMask != FSTValEncoding1Hit {
+		t.Fatalf("expected uniq42 to use the 1-hit encoding, got %x", val)
+	}
+	if got := FSTValDecode1Hit(val); got != 42 {
+		t.Fatalf("1-hit docNum = %d, want 42", got)
+	}
+
+	got := collect(t, sb, "body", "uniq42", nil, false)
+	if len(got) != 1 || got[0].docNum != 42 || got[0].freq != 1 {
+		t.Fatalf("uniq42 postings = %v", got)
+	}
+
+	// "all" is in every document, so it must not be 1-hit.
+	val, _, err = dict.fstReader.Get([]byte("all"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if val&FSTValEncodingMask == FSTValEncoding1Hit {
+		t.Fatal("term present in every document should not be 1-hit encoded")
+	}
+}
+
+var _ segment.PostingsIterator = (*PostingsIterator)(nil)

--- a/postings_format.go
+++ b/postings_format.go
@@ -1,0 +1,407 @@
+//  Copyright (c) 2026 Couchbase, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// 		http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package zap
+
+import (
+	"encoding/binary"
+	"fmt"
+	"math"
+
+	"github.com/blevesearch/freeway/bitpack"
+)
+
+// The on-disk shape of one term's postings.
+//
+// Doc numbers and term frequencies are bitpacked 128 at a time (see package
+// bitpack); whatever is left over at the end of the list, fewer than 128
+// documents, is written as plain uvarints.  A flat skip list carries one
+// fixed-size entry per full block, which is what lets a reader hop to the block
+// containing a target document without decoding anything.
+//
+// Field norms are not here at all.  They live in a dense column shared by every
+// term of the field -- see normsColumn -- because a term appearing in a million
+// documents would otherwise carry a million copies of the same few lengths.
+//
+// The regions are written in the order a writer can produce them, and the
+// footer comes last so nothing has to be buffered or back-patched:
+//
+//	[payload]    blocks, then the uvarint tail
+//	[locs]       chunkedIntCoder blob, unchanged from earlier zap versions
+//	[skip]       one entry per full block, then a trailing tail offset
+//	[footer]     <- the FST value points here
+//
+// The reader walks backwards from the footer: skip starts at footer-skipLen,
+// locs at skip-locsLen, payload at locs-payloadLen.
+
+const postingsBlockLen = bitpack.BlockLen
+
+// Term footer flags.
+const (
+	termHasFreqs = 1 << 0
+	termHasLocs  = 1 << 1
+)
+
+// docNumTerminated pads a decoded doc block out to a full 128 entries.  Keeping
+// every block the same length, non-decreasing, and ending in a value no target
+// can exceed is what makes the in-block search branchless.
+const docNumTerminated = uint32(math.MaxUint32)
+
+// Skip entry layout.  Each entry describes one full block:
+//
+//	u32 lastDocInBlock
+//	u32 blockByteOffset      (from the start of the payload)
+//	u8  docNumBits
+//	u8  tfNumBits            \
+//	u8  minNormID             > only when the term records frequencies
+//	u8  maxTF                /
+//
+// followed, after the last entry and only once there is at least one full
+// block, by a u32 giving the byte offset of the uvarint tail -- or, when
+// there is no tail, the end of the last full block's byte range.
+//
+// followed, whenever the term has a tail (fewer than 128 trailing documents
+// that didn't fill a block), by a u32 giving the tail's own last, largest doc
+// number. Without this, a seek past a term's entire range has no way to tell
+// "the tail might still hold the target" apart from "the tail's own range
+// ends before the target", and has to decode the tail's uvarint stream just
+// to find out which. With it, that seek is a skip-metadata comparison, the
+// same as seeking past a full block. This matters more than it might look:
+// most terms in a real dictionary never fill even one 128-document block, so
+// they are nothing but a tail, and this is the only bound they get.
+//
+// Storing the block's byte offset rather than deriving it from the bit widths
+// costs four bytes per 128 documents and buys two things: each block can be run
+// through the writer's process() hook independently, so encryption and
+// compression callbacks work without the reader having to decode a whole term
+// to reach one block; and advancing the skip cursor becomes a load instead of
+// an arithmetic reconstruction.
+const (
+	skipEntryLenNoFreqs   = 9
+	skipEntryLenWithFreqs = 12
+	skipTailOffsetLen     = 4
+	skipTailLastDocLen    = 4
+)
+
+func skipEntryLen(hasFreqs bool) int {
+	if hasFreqs {
+		return skipEntryLenWithFreqs
+	}
+	return skipEntryLenNoFreqs
+}
+
+// skipDataLen is the size of the whole skip region for a term, which is empty
+// only for a term with neither a full block nor a tail.
+func skipDataLen(numFullBlocks, tailLen int, hasFreqs bool) int {
+	n := numFullBlocks * skipEntryLen(hasFreqs)
+	if numFullBlocks > 0 {
+		n += skipTailOffsetLen
+	}
+	if tailLen > 0 {
+		n += skipTailLastDocLen
+	}
+	return n
+}
+
+type skipEntry struct {
+	lastDoc     uint32
+	blockOffset uint32
+	docNumBits  uint8
+	tfNumBits   uint8
+	minNormID   uint8
+	maxTF       uint8
+}
+
+func (e *skipEntry) encode(dst []byte, hasFreqs bool) int {
+	binary.LittleEndian.PutUint32(dst[0:4], e.lastDoc)
+	binary.LittleEndian.PutUint32(dst[4:8], e.blockOffset)
+	dst[8] = e.docNumBits
+	if !hasFreqs {
+		return skipEntryLenNoFreqs
+	}
+	dst[9] = e.tfNumBits
+	dst[10] = e.minNormID
+	dst[11] = e.maxTF
+	return skipEntryLenWithFreqs
+}
+
+func (e *skipEntry) decode(src []byte, hasFreqs bool) {
+	e.lastDoc = binary.LittleEndian.Uint32(src[0:4])
+	e.blockOffset = binary.LittleEndian.Uint32(src[4:8])
+	e.docNumBits = src[8]
+	if !hasFreqs {
+		e.tfNumBits, e.minNormID, e.maxTF = 0, 0, 0
+		return
+	}
+	e.tfNumBits = src[9]
+	e.minNormID = src[10]
+	e.maxTF = src[11]
+}
+
+// The block-max pair, minNormID and maxTF, bounds the BM25 contribution of
+// every document in the block: the score rises with term frequency and falls
+// with field length, so the shortest field paired with the highest frequency
+// dominates.  The two need not come from the same document, which makes the
+// bound looser than tantivy's joint argmax but keeps it a bound -- and a bound
+// is all a block-max pruner requires.  Nothing consumes these yet; they are
+// written now so that turning on block-max WAND later is not another format
+// break.
+//
+// encodeBlockMaxTF caps a term frequency into a byte.  A saturated value
+// decodes back as "unbounded", which over-estimates the block maximum, and an
+// over-estimate is still a valid upper bound.
+func encodeBlockMaxTF(tf uint32) uint8 {
+	if tf >= math.MaxUint8 {
+		return math.MaxUint8
+	}
+	return uint8(tf)
+}
+
+// ------------------------------------------------------------- term footer
+
+type termFooter struct {
+	docFreq    uint32
+	flags      uint8
+	payloadLen uint64
+	locsLen    uint64
+	skipLen    uint64
+
+	// locChunkSize is the chunking the location blob was written with, carried
+	// here rather than re-derived from the doc frequency the way earlier zap
+	// versions did.  A merge cannot know a term's post-deletion frequency until
+	// it has streamed the whole thing, but the location encoder needs its chunk
+	// size before the first write; recording what was actually used removes the
+	// coupling entirely.  Only present when the term records locations.
+	locChunkSize uint64
+}
+
+func (h *termFooter) hasFreqs() bool { return h.flags&termHasFreqs != 0 }
+func (h *termFooter) hasLocs() bool  { return h.flags&termHasLocs != 0 }
+
+// maxTermFooterLen bounds the encoded footer: five uvarints and a flag byte.
+const maxTermFooterLen = 5*binary.MaxVarintLen64 + 1
+
+func (h *termFooter) encode(dst []byte) int {
+	n := binary.PutUvarint(dst, uint64(h.docFreq))
+	dst[n] = h.flags
+	n++
+	n += binary.PutUvarint(dst[n:], h.payloadLen)
+	n += binary.PutUvarint(dst[n:], h.locsLen)
+	n += binary.PutUvarint(dst[n:], h.skipLen)
+	if h.hasLocs() {
+		n += binary.PutUvarint(dst[n:], h.locChunkSize)
+	}
+	return n
+}
+
+// decode reads a footer from mem at offset, and returns the absolute offsets of
+// the three regions that precede it.
+func (h *termFooter) decode(mem []byte, offset uint64) (
+	payloadStart, locsStart, skipStart uint64, err error) {
+	buf := memAt(mem, offset, maxTermFooterLen)
+
+	docFreq, n := binary.Uvarint(buf)
+	if n <= 0 {
+		return 0, 0, 0, fmt.Errorf("corrupt term footer: bad docFreq at offset %d", offset)
+	}
+	if docFreq > math.MaxUint32 {
+		return 0, 0, 0, fmt.Errorf("corrupt term footer: docFreq %d out of range", docFreq)
+	}
+	h.docFreq = uint32(docFreq)
+	if n >= len(buf) {
+		return 0, 0, 0, fmt.Errorf("corrupt term footer: truncated at offset %d", offset)
+	}
+	h.flags = buf[n]
+	n++
+
+	var read int
+	h.payloadLen, read = binary.Uvarint(buf[n:])
+	if read <= 0 {
+		return 0, 0, 0, fmt.Errorf("corrupt term footer: bad payloadLen at offset %d", offset)
+	}
+	n += read
+	h.locsLen, read = binary.Uvarint(buf[n:])
+	if read <= 0 {
+		return 0, 0, 0, fmt.Errorf("corrupt term footer: bad locsLen at offset %d", offset)
+	}
+	n += read
+	h.skipLen, read = binary.Uvarint(buf[n:])
+	if read <= 0 {
+		return 0, 0, 0, fmt.Errorf("corrupt term footer: bad skipLen at offset %d", offset)
+	}
+	n += read
+	h.locChunkSize = 0
+	if h.hasLocs() {
+		h.locChunkSize, read = binary.Uvarint(buf[n:])
+		if read <= 0 {
+			return 0, 0, 0, fmt.Errorf("corrupt term footer: bad locChunkSize at offset %d", offset)
+		}
+	}
+
+	total := h.payloadLen + h.locsLen + h.skipLen
+	if total > offset {
+		return 0, 0, 0, fmt.Errorf(
+			"corrupt term footer at offset %d: regions total %d bytes", offset, total)
+	}
+	skipStart = offset - h.skipLen
+	locsStart = skipStart - h.locsLen
+	payloadStart = locsStart - h.payloadLen
+	return payloadStart, locsStart, skipStart, nil
+}
+
+// memAt returns up to n bytes of mem starting at offset, clamped to the end of
+// the buffer.  Varint decoding wants a window it can over-read; clamping keeps
+// a footer near the end of the segment from slicing out of range.
+func memAt(mem []byte, offset uint64, n int) []byte {
+	if offset >= uint64(len(mem)) {
+		return nil
+	}
+	end := offset + uint64(n)
+	if end > uint64(len(mem)) {
+		end = uint64(len(mem))
+	}
+	return mem[offset:end]
+}
+
+// --------------------------------------------------------------- norms column
+
+// Field norms: one quantized byte per document, in a column shared by every
+// term of the field.  See fieldnorm.go for the quantization.
+const (
+	normsKindAbsent   = 0
+	normsKindConstant = 1
+	normsKindDense    = 2
+)
+
+type normsColumn struct {
+	kind     uint8
+	constant uint8
+	dense    []uint8
+}
+
+// normsAbsent is the column a field without norms gets; every lookup returns
+// id 0.
+var normsAbsent = &normsColumn{kind: normsKindAbsent}
+
+// id returns the quantized field length for a document.  A document that does
+// not contain the field reads as 0, matching what the writer back-fills.
+func (n *normsColumn) id(docNum uint32) uint8 {
+	switch n.kind {
+	case normsKindDense:
+		if int(docNum) < len(n.dense) {
+			return n.dense[docNum]
+		}
+	case normsKindConstant:
+		return n.constant
+	}
+	return 0
+}
+
+// encodeNormsColumn writes the column for one field.  ids has one entry per
+// document in the segment; a field that every document agrees on -- a keyword
+// field, say -- collapses to two bytes instead of one per document, which is
+// what keeps a wide schema from paying numFields*numDocs.
+func encodeNormsColumn(ids []uint8, dst []byte) []byte {
+	if len(ids) == 0 {
+		return append(dst, normsKindAbsent)
+	}
+	constant := true
+	for _, id := range ids[1:] {
+		if id != ids[0] {
+			constant = false
+			break
+		}
+	}
+	if constant {
+		return append(dst, normsKindConstant, ids[0])
+	}
+	dst = append(dst, normsKindDense)
+	return append(dst, ids...)
+}
+
+func decodeNormsColumn(buf []byte, numDocs uint64) (*normsColumn, error) {
+	if len(buf) == 0 {
+		return normsAbsent, nil
+	}
+	switch buf[0] {
+	case normsKindAbsent:
+		return normsAbsent, nil
+	case normsKindConstant:
+		if len(buf) < 2 {
+			return nil, fmt.Errorf("corrupt norms column: truncated constant")
+		}
+		return &normsColumn{kind: normsKindConstant, constant: buf[1]}, nil
+	case normsKindDense:
+		dense := buf[1:]
+		if uint64(len(dense)) != numDocs {
+			return nil, fmt.Errorf("corrupt norms column: %d entries for %d docs",
+				len(dense), numDocs)
+		}
+		return &normsColumn{kind: normsKindDense, dense: dense}, nil
+	}
+	return nil, fmt.Errorf("corrupt norms column: unknown kind %d", buf[0])
+}
+
+// ------------------------------------------------------------------- tooling
+
+// TermPostingsInfo describes one term's postings on disk. It exists for the zap
+// command-line tool, which lives outside this package and cannot reach the
+// footer codec directly.
+type TermPostingsInfo struct {
+	OneHit     bool
+	DocNum     uint64 // only meaningful when OneHit
+	DocFreq    uint32
+	HasFreqs   bool
+	HasLocs    bool
+	NumBlocks  int
+	TailLen    int
+	PayloadLen uint64
+	LocsLen    uint64
+	SkipLen    uint64
+
+	PayloadStart uint64
+	LocsStart    uint64
+	SkipStart    uint64
+	LocChunkSize uint64
+}
+
+// DescribeTermPostings decodes the term footer an FST value points at.
+func DescribeTermPostings(mem []byte, fstVal uint64) (*TermPostingsInfo, error) {
+	if fstVal&FSTValEncodingMask == FSTValEncoding1Hit {
+		return &TermPostingsInfo{
+			OneHit:  true,
+			DocNum:  FSTValDecode1Hit(fstVal),
+			DocFreq: 1,
+		}, nil
+	}
+	var h termFooter
+	payloadStart, locsStart, skipStart, err := h.decode(mem, fstVal)
+	if err != nil {
+		return nil, err
+	}
+	return &TermPostingsInfo{
+		DocFreq:      h.docFreq,
+		HasFreqs:     h.hasFreqs(),
+		HasLocs:      h.hasLocs(),
+		NumBlocks:    int(h.docFreq) / postingsBlockLen,
+		TailLen:      int(h.docFreq) % postingsBlockLen,
+		PayloadLen:   h.payloadLen,
+		LocsLen:      h.locsLen,
+		SkipLen:      h.skipLen,
+		PayloadStart: payloadStart,
+		LocsStart:    locsStart,
+		SkipStart:    skipStart,
+		LocChunkSize: h.locChunkSize,
+	}, nil
+}

--- a/postings_serializer.go
+++ b/postings_serializer.go
@@ -1,0 +1,300 @@
+//  Copyright (c) 2026 Couchbase, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// 		http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package zap
+
+import (
+	"encoding/binary"
+	"fmt"
+	"math"
+
+	"github.com/blevesearch/freeway/bitpack"
+)
+
+// postingsSerializer writes one term's postings in the block format described
+// in postings_format.go.  It is the only implementation of the write side:
+// building a fresh segment and merging existing ones both drive it, so there is
+// no way for the two to drift apart.
+//
+// The caller's protocol for one term is:
+//
+//	s.StartTerm(hasFreqs, hasLocs, normIDs)
+//	for each doc in increasing doc number: s.AddDoc(docNum, freq)
+//	if v, ok := s.OneHit(); ok {
+//	        // nothing was written; v is the FST value
+//	} else {
+//	        s.FinishPayload()
+//	        _, locBytes, _ := locEncoder.writeAt(w)
+//	        off, _ := s.Close(uint64(locBytes), locChunkSize)
+//	}
+//
+// Everything but the skip buffer streams straight to the writer, so a term with
+// a million documents costs a 128-slot staging block and about eight kilobytes
+// of skip data, not a copy of its whole postings list.
+type postingsSerializer struct {
+	// w is the segment writer every term's postings land in. It is set once,
+	// for the life of the serializer -- a single build or merge writes to one
+	// FileWriter throughout -- rather than threaded through every method call.
+	w *FileWriter
+
+	docs  [postingsBlockLen]uint32
+	freqs [postingsBlockLen]uint32
+	n     int // documents staged in docs/freqs
+
+	docFreq  uint32
+	lastDoc  uint32 // last doc of the last flushed block: the delta anchor
+	hasFreqs bool
+	hasLocs  bool
+
+	// normIDs is the field's quantized norm column, indexed by doc number.  It
+	// is only read to compute the per-block score bound, and may be nil.
+	normIDs []uint8
+
+	payloadStart uint64
+	payloadEnd   uint64
+
+	skipBuf []byte
+	packBuf []byte
+	tailBuf []byte
+	footerBuf  []byte
+}
+
+func (s *postingsSerializer) StartTerm(hasFreqs, hasLocs bool, normIDs []uint8) {
+	s.n = 0
+	s.docFreq = 0
+	s.lastDoc = 0
+	s.hasFreqs = hasFreqs
+	s.hasLocs = hasLocs
+	s.normIDs = normIDs
+	s.payloadStart = uint64(s.w.Count())
+	s.payloadEnd = s.payloadStart
+	s.skipBuf = s.skipBuf[:0]
+}
+
+// AddDoc stages one posting.  Doc numbers must arrive strictly increasing.
+func (s *postingsSerializer) AddDoc(docNum, freq uint32) error {
+	s.docs[s.n] = docNum
+	s.freqs[s.n] = freq
+	s.n++
+	s.docFreq++
+	if s.n == postingsBlockLen {
+		return s.flushBlock()
+	}
+	return nil
+}
+
+// blockBound returns the pair that bounds the BM25 contribution of every
+// document in the staged block: the shortest field length and the highest term
+// frequency.  See the note in postings_format.go on why the two need not come
+// from the same document.
+func (s *postingsSerializer) blockBound() (minNormID, maxTF uint8) {
+	minNormID = 0xFF
+	var mtf uint32
+	for i := 0; i < postingsBlockLen; i++ {
+		var id uint8
+		if int(s.docs[i]) < len(s.normIDs) {
+			id = s.normIDs[s.docs[i]]
+		}
+		if id < minNormID {
+			minNormID = id
+		}
+		if s.freqs[i] > mtf {
+			mtf = s.freqs[i]
+		}
+	}
+	return minNormID, encodeBlockMaxTF(mtf)
+}
+
+func (s *postingsSerializer) flushBlock() error {
+	blockOffset := uint64(s.w.Count()) - s.payloadStart
+	if blockOffset > math.MaxUint32 {
+		return fmt.Errorf("postings payload for a single term exceeds 4GiB")
+	}
+
+	docNumBits := bitpack.MaxBitsDelta1(&s.docs, s.lastDoc)
+	size := bitpack.BlockBytes(docNumBits)
+	var tfNumBits uint8
+	if s.hasFreqs {
+		tfNumBits = bitpack.MaxBitsMinus1(&s.freqs)
+		size += bitpack.BlockBytes(tfNumBits)
+	}
+
+	if cap(s.packBuf) < size {
+		s.packBuf = make([]byte, size)
+	}
+	buf := s.packBuf[:size]
+	bitpack.PackDelta1(&s.docs, s.lastDoc, docNumBits, buf)
+	if s.hasFreqs {
+		bitpack.PackMinus1(&s.freqs, tfNumBits, buf[bitpack.BlockBytes(docNumBits):])
+	}
+
+	// Each block goes through the writer's hook on its own.  That is what lets
+	// a reader with an encryption or compression callback decode a single
+	// block rather than a whole term, and it is why the skip entry records the
+	// block's byte offset instead of deriving it from the bit widths.
+	processed := s.w.process(buf)
+	if _, err := s.w.Write(processed); err != nil {
+		return err
+	}
+
+	e := skipEntry{
+		lastDoc:     s.docs[postingsBlockLen-1],
+		blockOffset: uint32(blockOffset),
+		docNumBits:  docNumBits,
+		tfNumBits:   tfNumBits,
+	}
+	if s.hasFreqs {
+		e.minNormID, e.maxTF = s.blockBound()
+	}
+	var entry [skipEntryLenWithFreqs]byte
+	s.skipBuf = append(s.skipBuf, entry[:e.encode(entry[:], s.hasFreqs)]...)
+
+	s.lastDoc = s.docs[postingsBlockLen-1]
+	s.n = 0
+	return nil
+}
+
+// OneHit reports the FST value for a term that can skip the general encoding
+// entirely: a single document, a frequency of one, no locations, and a doc
+// number that fits the 31 bits available.  Nothing has been written to w at
+// that point, because a term this small never filled a block.
+//
+// The long tail of a real dictionary is terms like this, so avoiding an
+// indirection for them is worth the special case.  Unlike earlier zap versions
+// the norm does not have to be carried in the FST value -- it is in the field's
+// norm column -- which leaves the encoding to just the doc number.
+func (s *postingsSerializer) OneHit() (uint64, bool) {
+	if s.docFreq != 1 || s.hasLocs || s.n != 1 {
+		return 0, false
+	}
+	if s.hasFreqs && s.freqs[0] != 1 {
+		return 0, false
+	}
+	docNum := uint64(s.docs[0])
+	if !under32Bits(docNum) {
+		return 0, false
+	}
+	return FSTValEncode1Hit(docNum), true
+}
+
+// FinishPayload flushes the leftover documents as a uvarint tail and closes out
+// the payload region.  Fewer than 128 documents cannot be bitpacked, and the
+// tail is short by construction, so uvarints cost nothing worth optimising.
+func (s *postingsSerializer) FinishPayload() error {
+	tailOffset := uint64(s.w.Count()) - s.payloadStart
+
+	var tailLastDoc uint32
+	if s.n > 0 {
+		buf := s.tailBuf[:0]
+		// Plain deltas here, not delta-minus-one: the tail is decoded by the
+		// uvarint reader, which has no bit width to save.
+		prev := s.lastDoc
+		for i := 0; i < s.n; i++ {
+			buf = binary.AppendUvarint(buf, uint64(s.docs[i]-prev))
+			prev = s.docs[i]
+		}
+		if s.hasFreqs {
+			for i := 0; i < s.n; i++ {
+				buf = binary.AppendUvarint(buf, uint64(s.freqs[i]))
+			}
+		}
+		s.tailBuf = buf
+		tailLastDoc = prev
+
+		processed := s.w.process(buf)
+		if _, err := s.w.Write(processed); err != nil {
+			return err
+		}
+	}
+
+	// The skip list records where the tail begins, which also gives the last
+	// full block its length. Only meaningful once there is at least one full
+	// block -- with none, the tail starts at the payload itself.
+	if len(s.skipBuf) > 0 {
+		if tailOffset > math.MaxUint32 {
+			return fmt.Errorf("postings payload for a single term exceeds 4GiB")
+		}
+		var off [skipTailOffsetLen]byte
+		binary.LittleEndian.PutUint32(off[:], uint32(tailOffset))
+		s.skipBuf = append(s.skipBuf, off[:]...)
+	}
+
+	// The tail's own last doc number lets a seek past a term's entire range --
+	// full blocks and tail alike -- conclude "not present" from skip metadata,
+	// the same way it already can for a target past a full block. Without
+	// this, that seek would have to decode the tail's uvarint stream just to
+	// discover it doesn't contain the target. This is the common case: most
+	// terms in a real dictionary never fill even one 128-document block, so
+	// they are nothing but a tail, and this is the only bound they get.
+	if s.n > 0 {
+		var last [skipTailLastDocLen]byte
+		binary.LittleEndian.PutUint32(last[:], tailLastDoc)
+		s.skipBuf = append(s.skipBuf, last[:]...)
+	}
+
+	s.payloadEnd = uint64(s.w.Count())
+	s.n = 0
+	return nil
+}
+
+// Close writes the skip region and the term footer, and returns the footer's
+// offset, which is what goes into the FST.
+func (s *postingsSerializer) Close(locsLen, locChunkSize uint64) (uint64, error) {
+	var skipLen uint64
+	if len(s.skipBuf) > 0 {
+		processed := s.w.process(s.skipBuf)
+		if _, err := s.w.Write(processed); err != nil {
+			return 0, err
+		}
+		skipLen = uint64(len(processed))
+	}
+
+	footerOffset := uint64(s.w.Count())
+	h := termFooter{
+		docFreq:    s.docFreq,
+		payloadLen: s.payloadEnd - s.payloadStart,
+		locsLen:    locsLen,
+		skipLen:    skipLen,
+	}
+	if s.hasFreqs {
+		h.flags |= termHasFreqs
+	}
+	if s.hasLocs && locsLen > 0 {
+		h.flags |= termHasLocs
+		h.locChunkSize = locChunkSize
+	}
+
+	if cap(s.footerBuf) < maxTermFooterLen {
+		s.footerBuf = make([]byte, maxTermFooterLen)
+	}
+	buf := s.footerBuf[:maxTermFooterLen]
+	if _, err := s.w.Write(buf[:h.encode(buf)]); err != nil {
+		return 0, err
+	}
+
+	// A footer at offset zero would be indistinguishable from "this term has no
+	// postings", which is how the writer signals an empty term to the FST
+	// builder.  The field's data never starts at zero -- the segment begins
+	// with stored fields -- so this cannot happen in practice.
+	if footerOffset == 0 {
+		return 0, fmt.Errorf("postings footer landed at offset 0")
+	}
+	return footerOffset, nil
+}
+
+// BytesWritten reports the payload plus skip bytes this term contributed, for
+// the segment's write statistics.
+func (s *postingsSerializer) BytesWritten() uint64 {
+	return (s.payloadEnd - s.payloadStart) + uint64(len(s.skipBuf))
+}

--- a/section_inverted_text_index.go
+++ b/section_inverted_text_index.go
@@ -78,18 +78,88 @@ func (i *invertedTextIndexSection) AddrForField(opaque map[int]resetable, fieldI
 	return io.fieldAddrs[fieldID]
 }
 
+// mergeNormsColumn builds the merged field-norm column for one field by
+// remapping each source segment's column through the merge's doc renumbering.
+//
+// This is where moving norms out of the postings pays off twice over: what used
+// to be a re-encode of one varint per posting is now a single pass over the
+// documents, and with no deletions it degenerates to a copy.
+func mergeNormsColumn(dicts []*Dictionary, newDocNums [][]uint64,
+	dropped []bool, numDocs uint64, buf []uint8) []uint8 {
+	if cap(buf) < int(numDocs) {
+		buf = make([]uint8, numDocs)
+	} else {
+		buf = buf[:numDocs]
+		clear(buf)
+	}
+
+	for i, d := range dicts {
+		if d == nil || d.norms == nil || d.norms.kind == normsKindAbsent {
+			continue
+		}
+		nd := newDocNums[i]
+		if len(nd) == 0 {
+			continue
+		}
+		switch d.norms.kind {
+		case normsKindConstant:
+			for _, nw := range nd {
+				if nw != docDropped {
+					buf[nw] = d.norms.constant
+				}
+			}
+		case normsKindDense:
+			dense := d.norms.dense
+			if len(dense) > len(nd) {
+				dense = dense[:len(nd)]
+			}
+			if !dropped[i] {
+				// No deletions means the renumbering is a constant shift, so
+				// the whole column moves in one copy.
+				copy(buf[nd[0]:], dense)
+				continue
+			}
+			for old, id := range dense {
+				if nw := nd[old]; nw != docDropped {
+					buf[nw] = id
+				}
+			}
+		}
+	}
+	return buf
+}
+
+// writeNormsColumn emits a field's norm column and reports where it landed.
+// It runs before the field's postings because the per-block score bounds are
+// computed from it, the same ordering constraint tantivy has between its
+// fieldnorm and postings files.
+func writeNormsColumn(w *FileWriter, ids []uint8, buf []byte) (
+	offset, length uint64, bufOut []byte, err error) {
+	buf = encodeNormsColumn(ids, buf[:0])
+	processed := w.process(buf)
+	offset = uint64(w.Count())
+	if _, err := w.Write(processed); err != nil {
+		return 0, 0, buf, err
+	}
+	return offset, uint64(len(processed)), buf, nil
+}
+
 func mergeAndPersistInvertedSection(segments []*SegmentBase, dropsIn []*roaring.Bitmap,
 	fieldsInv []string, fieldsMap map[string]uint16, fieldsOptions map[string]index.FieldIndexingOptions,
 	fieldsSame bool, newDocNumsIn [][]uint64, newSegDocCount uint64, chunkMode uint32, w *FileWriter,
 	closeCh chan struct{}) (map[int]int, error) {
 	var bufMaxVarintLen64 []byte = make([]byte, binary.MaxVarintLen64)
 	var bufLoc []uint64
+	var normsBuf []byte
+	var normIDs []uint8
 
 	var postings *PostingsList
 	var postItr *PostingsIterator
 
 	fieldAddrs := make(map[int]int)
 	dictOffsets := make([]uint64, len(fieldsInv))
+	normsOffsets := make([]uint64, len(fieldsInv))
+	normsLens := make([]uint64, len(fieldsInv))
 	fieldDvLocsStart := make([]uint64, len(fieldsInv))
 	fieldDvLocsEnd := make([]uint64, len(fieldsInv))
 
@@ -107,11 +177,11 @@ func mergeAndPersistInvertedSection(segments []*SegmentBase, dropsIn []*roaring.
 		copyFlag = false
 	}
 
-	// these int coders are initialized with chunk size 1024
-	// however this will be reset to the correct chunk size
-	// while processing each individual field-term section
-	tfEncoder := newChunkedIntCoder(1024, newSegDocCount-1)
+	// The location encoder is initialised with a placeholder chunk size; the
+	// real one is set per term, from the same number that goes into the term
+	// footer.
 	locEncoder := newChunkedIntCoder(1024, newSegDocCount-1)
+	ser := &postingsSerializer{w: w}
 
 	var vellumBuf bytes.Buffer
 	newVellum, err := vellum.New(&vellumBuf, nil)
@@ -119,9 +189,8 @@ func mergeAndPersistInvertedSection(segments []*SegmentBase, dropsIn []*roaring.
 		return nil, err
 	}
 
-	newRoaring := roaring.NewBitmap()
 	newDocNums := make([][]uint64, 0, len(segments))
-	drops := make([]*roaring.Bitmap, 0, len(segments))
+	dropped := make([]bool, 0, len(segments))
 	dicts := make([]*Dictionary, 0, len(segments))
 	itrs := make([]vellum.Iterator, 0, len(segments))
 	segmentsInFocus := make([]*SegmentBase, 0, len(segments))
@@ -129,7 +198,7 @@ func mergeAndPersistInvertedSection(segments []*SegmentBase, dropsIn []*roaring.
 	for fieldID, fieldName := range fieldsInv {
 		// collect FST iterators from all active segments for this field
 		newDocNums = newDocNums[:0]
-		drops = drops[:0]
+		dropped = dropped[:0]
 		dicts = dicts[:0]
 		itrs = itrs[:0]
 		segmentsInFocus = segmentsInFocus[:0]
@@ -154,11 +223,8 @@ func mergeAndPersistInvertedSection(segments []*SegmentBase, dropsIn []*roaring.
 				}
 				if itr != nil {
 					newDocNums = append(newDocNums, newDocNumsIn[segmentI])
-					if dropsIn[segmentI] != nil && !dropsIn[segmentI].IsEmpty() {
-						drops = append(drops, dropsIn[segmentI])
-					} else {
-						drops = append(drops, nil)
-					}
+					dropped = append(dropped,
+						dropsIn[segmentI] != nil && !dropsIn[segmentI].IsEmpty())
 					dicts = append(dicts, dict)
 					itrs = append(itrs, itr)
 					segmentsInFocus = append(segmentsInFocus, segment)
@@ -166,132 +232,110 @@ func mergeAndPersistInvertedSection(segments []*SegmentBase, dropsIn []*roaring.
 			}
 		}
 
-		var prevTerm []byte
+		hasFreqs := !fieldsOptions[fieldName].SkipFreqNorm()
 
-		newRoaring.Clear()
-
-		var lastDocNum, lastFreq, lastNorm uint64
-
-		// determines whether to use "1-hit" encoding optimization
-		// when a term appears in only 1 doc, with no loc info,
-		// has freq of 1, and the docNum fits into 31-bits
-		use1HitEncoding := func(termCardinality uint64) (bool, uint64, uint64) {
-			if termCardinality == uint64(1) && locEncoder.FinalSize() <= 0 {
-				docNum := uint64(newRoaring.Minimum())
-				if under32Bits(docNum) && docNum == lastDocNum && lastFreq == 1 {
-					return true, docNum, lastNorm
-				}
-			}
-			return false, 0, 0
-		}
-
-		finishTerm := func(term []byte) error {
-			tfEncoder.Close()
-			locEncoder.Close()
-
-			postingsOffset, err := writePostings(newRoaring,
-				tfEncoder, locEncoder, use1HitEncoding, w, bufMaxVarintLen64)
+		// The norm column comes first: the block bounds written with each term
+		// are computed from it.
+		normsOffsets[fieldID] = 0
+		normsLens[fieldID] = 0
+		if hasFreqs && len(dicts) > 0 {
+			normIDs = mergeNormsColumn(dicts, newDocNums, dropped, newSegDocCount, normIDs)
+			normsOffsets[fieldID], normsLens[fieldID], normsBuf, err =
+				writeNormsColumn(w, normIDs, normsBuf)
 			if err != nil {
-				return err
+				return nil, err
 			}
-
-			if postingsOffset > 0 {
-				err = newVellum.Insert(term, postingsOffset)
-				if err != nil {
-					return err
-				}
-			}
-
-			newRoaring.Clear()
-
-			tfEncoder.Reset()
-			locEncoder.Reset()
-
-			lastDocNum = 0
-			lastFreq = 0
-			lastNorm = 0
-
-			return nil
+		} else {
+			normIDs = normIDs[:0]
 		}
 
 		enumerator, err := newEnumerator(itrs)
 
 		for err == nil {
-			term, itrI, postingsOffset := enumerator.Current()
+			// check for the closure in meantime
+			if isClosed(closeCh) {
+				return nil, seg.ErrClosed
+			}
 
-			if !bytes.Equal(prevTerm, term) {
-				// check for the closure in meantime
-				if isClosed(closeCh) {
-					return nil, seg.ErrClosed
+			term, _, _ := enumerator.Current()
+			lowIdxs, lowVals := enumerator.GetLowIdxsAndValues()
+
+			// Look at every contributing segment's term footer before writing
+			// anything. Two things are needed up front: whether the merged term
+			// records locations, because a term that does must carry a location
+			// group for every posting, and an upper bound on its doc frequency
+			// to size the location chunks. The bound is an upper one because
+			// deletions are only discovered while streaming -- which is exactly
+			// why the chunk size is recorded in the footer rather than being
+			// re-derived by the reader.
+			var upperDocFreq uint64
+			termHasLocs := false
+			for i, idx := range lowIdxs {
+				postings, err = dicts[idx].postingsListFromOffset(lowVals[i], nil, postings)
+				if err != nil {
+					return nil, err
+				}
+				upperDocFreq += postings.rawDocFreq()
+				if postings.footer.hasLocs() {
+					termHasLocs = true
+				}
+			}
+
+			locChunkSize, err2 := getChunkSize(chunkMode, upperDocFreq, newSegDocCount)
+			if err2 != nil {
+				return nil, err2
+			}
+			locEncoder.SetChunkSize(locChunkSize, newSegDocCount-1)
+
+			ser.StartTerm(hasFreqs, termHasLocs, normIDs)
+
+			for i, idx := range lowIdxs {
+				var except *roaring.Bitmap
+				if dropped[idx] {
+					except = dropsForDict(dropsIn, segments, segmentsInFocus, idx)
+				}
+				postings, err = dicts[idx].postingsListFromOffset(lowVals[i], except, postings)
+				if err != nil {
+					return nil, err
 				}
 
-				// if the term changed, write out the info collected
-				// for the previous term
-				err = finishTerm(prevTerm)
+				postItr, err = postings.iterator(true, true, termHasLocs, postItr)
+				if err != nil {
+					return nil, err
+				}
+
+				// can only safely copy location bytes if all segments have the
+				// same fields and all have an empty writer id (i.e. no callbacks)
+				if fieldsSame && copyFlag {
+					err = mergeTermPostingsByCopying(postItr, newDocNums[idx],
+						termHasLocs, ser, locEncoder)
+				} else {
+					bufLoc, err = mergeTermPostings(fieldsMap, postItr, newDocNums[idx],
+						termHasLocs, ser, locEncoder, bufLoc)
+				}
 				if err != nil {
 					return nil, err
 				}
 			}
-			if !bytes.Equal(prevTerm, term) || prevTerm == nil {
-				// compute cardinality of field-term in new seg
-				var newCard uint64
-				lowItrIdxs, lowItrVals := enumerator.GetLowIdxsAndValues()
-				for i, idx := range lowItrIdxs {
-					pl, err := dicts[idx].postingsListFromOffset(lowItrVals[i], drops[idx], nil)
-					if err != nil {
-						return nil, err
-					}
-					newCard += pl.Count()
-				}
-				// compute correct chunk size with this
-				chunkSize, err := getChunkSize(chunkMode, newCard, newSegDocCount)
+
+			if err = finishMergedTerm(w, ser, locEncoder, newVellum, term,
+				locChunkSize); err != nil {
+				return nil, err
+			}
+
+			// step the enumerator past every entry for this term
+			for range lowIdxs {
+				err = enumerator.Next()
 				if err != nil {
-					return nil, err
+					break
 				}
-				// update encoders chunk
-				tfEncoder.SetChunkSize(chunkSize, newSegDocCount-1)
-				locEncoder.SetChunkSize(chunkSize, newSegDocCount-1)
 			}
-
-			postings, err = dicts[itrI].postingsListFromOffset(
-				postingsOffset, drops[itrI], postings)
-			if err != nil {
-				return nil, err
-			}
-
-			postItr = postings.iterator(true, true, true, postItr)
-
-			// can only safely copy data if all segments have same fields and all have an empty
-			// writer id (i.e. no callbacks)
-			if fieldsSame && copyFlag {
-				// can optimize by copying freq/norm/loc bytes directly
-				lastDocNum, lastFreq, lastNorm, err = mergeTermFreqNormLocsByCopying(
-					term, postItr, newDocNums[itrI], newRoaring,
-					tfEncoder, locEncoder)
-			} else {
-				lastDocNum, lastFreq, lastNorm, bufLoc, err = mergeTermFreqNormLocs(
-					fieldsMap, term, postItr, newDocNums[itrI], newRoaring,
-					tfEncoder, locEncoder, bufLoc)
-			}
-			if err != nil {
-				return nil, err
-			}
-
-			prevTerm = prevTerm[:0] // copy to prevTerm in case Next() reuses term mem
-			prevTerm = append(prevTerm, term...)
-
-			err = enumerator.Next()
 		}
 		if err != vellum.ErrIteratorDone {
 			return nil, err
 		}
 		// close the enumerator to free the underlying iterators
 		err = enumerator.Close()
-		if err != nil {
-			return nil, err
-		}
-
-		err = finishTerm(prevTerm)
 		if err != nil {
 			return nil, err
 		}
@@ -386,20 +430,9 @@ func mergeAndPersistInvertedSection(segments []*SegmentBase, dropsIn []*roaring.
 
 		fieldStart := w.Count()
 
-		n = binary.PutUvarint(bufMaxVarintLen64, fieldDvLocsStart[fieldID])
-		_, err = w.Write(bufMaxVarintLen64[:n])
-		if err != nil {
-			return nil, err
-		}
-
-		n = binary.PutUvarint(bufMaxVarintLen64, fieldDvLocsEnd[fieldID])
-		_, err = w.Write(bufMaxVarintLen64[:n])
-		if err != nil {
-			return nil, err
-		}
-
-		n = binary.PutUvarint(bufMaxVarintLen64, dictOffsets[fieldID])
-		_, err = w.Write(bufMaxVarintLen64[:n])
+		err = writeFieldFooter(w, bufMaxVarintLen64, fieldDvLocsStart[fieldID],
+			fieldDvLocsEnd[fieldID], dictOffsets[fieldID],
+			normsOffsets[fieldID], normsLens[fieldID])
 		if err != nil {
 			return nil, err
 		}
@@ -414,6 +447,66 @@ func mergeAndPersistInvertedSection(segments []*SegmentBase, dropsIn []*roaring.
 		}
 	}
 	return fieldAddrs, nil
+}
+
+// dropsForDict maps an index into the per-field dicts slice back to the
+// deletion bitmap of the segment it came from.
+func dropsForDict(dropsIn []*roaring.Bitmap, segments []*SegmentBase,
+	segmentsInFocus []*SegmentBase, idx int) *roaring.Bitmap {
+	target := segmentsInFocus[idx]
+	for i, s := range segments {
+		if s == target {
+			return dropsIn[i]
+		}
+	}
+	return nil
+}
+
+// finishMergedTerm closes out one term: the uvarint tail, the location blob,
+// the skip list and the footer, then the FST entry.
+func finishMergedTerm(w *FileWriter, ser *postingsSerializer, locEncoder *chunkedIntCoder,
+	builder *vellum.Builder, term []byte, locChunkSize uint64) error {
+	if ser.docFreq == 0 {
+		locEncoder.Reset()
+		return nil
+	}
+
+	if fstVal, ok := ser.OneHit(); ok {
+		locEncoder.Reset()
+		return builder.Insert(term, fstVal)
+	}
+
+	if err := ser.FinishPayload(); err != nil {
+		return err
+	}
+
+	locEncoder.Close()
+	_, locBytes, err := locEncoder.writeAt(w)
+	if err != nil {
+		return err
+	}
+	locEncoder.Reset()
+
+	offset, err := ser.Close(uint64(locBytes), locChunkSize)
+	if err != nil {
+		return err
+	}
+	return builder.Insert(term, offset)
+}
+
+// writeFieldFooter records where each of a field's regions ended up. The first
+// three entries are unchanged from earlier zap versions -- other sections read
+// the doc-value pair from the same place -- and the norm column's location is
+// appended after them.
+func writeFieldFooter(w *FileWriter, buf []byte,
+	dvStart, dvEnd, dictOffset, normsOffset, normsLen uint64) error {
+	for _, v := range []uint64{dvStart, dvEnd, dictOffset, normsOffset, normsLen} {
+		n := binary.PutUvarint(buf, v)
+		if _, err := w.Write(buf[:n]); err != nil {
+			return err
+		}
+	}
+	return nil
 }
 
 func (i *invertedTextIndexSection) Merge(opaque map[int]resetable, segments []*SegmentBase,
@@ -458,7 +551,11 @@ func (io *invertedIndexOpaque) writeDicts(w *FileWriter) error {
 		return nil
 	}
 
+	numDocs := uint64(len(io.results))
+
 	dictOffsets := make([]uint64, len(io.FieldsInv))
+	normsOffsets := make([]uint64, len(io.FieldsInv))
+	normsLens := make([]uint64, len(io.FieldsInv))
 	var err error
 
 	fdvOffsetsStart := make([]uint64, len(io.FieldsInv))
@@ -466,13 +563,13 @@ func (io *invertedIndexOpaque) writeDicts(w *FileWriter) error {
 
 	buf := io.grabBuf(binary.MaxVarintLen64)
 
-	// these int coders are initialized with chunk size 1024
-	// however this will be reset to the correct chunk size
-	// while processing each individual field-term section
-	tfEncoder := newChunkedIntCoder(1024, uint64(len(io.results)-1))
-	locEncoder := newChunkedIntCoder(1024, uint64(len(io.results)-1))
+	// The location encoder is initialised with a placeholder chunk size; the
+	// real one is set per term and recorded in that term's footer.
+	locEncoder := newChunkedIntCoder(1024, numDocs-1)
+	ser := &postingsSerializer{w: w}
 
 	var docTermMap [][]byte
+	var normsBuf []byte
 
 	if io.builder == nil {
 		io.builder, err = vellum.New(&io.builderBuf, nil)
@@ -492,104 +589,90 @@ func (io *invertedIndexOpaque) writeDicts(w *FileWriter) error {
 		}
 
 		dict := io.Dicts[fieldID]
+		hasFreqs := !io.FieldsOptions[io.FieldsInv[fieldID]].SkipFreqNorm()
+
+		// The field's norm column is written before its postings, because the
+		// per-block score bounds are computed from it.
+		normIDs := io.NormIDs[fieldID]
+		if !hasFreqs {
+			normIDs = nil
+		}
+		if len(normIDs) > 0 {
+			normsOffsets[fieldID], normsLens[fieldID], normsBuf, err =
+				writeNormsColumn(w, normIDs, normsBuf)
+			if err != nil {
+				return err
+			}
+			io.incrementBytesWritten(normsLens[fieldID])
+		}
 
 		for _, term := range terms { // terms are already sorted
 			pid := dict[term] - 1
 
-			postingsBS := io.Postings[pid]
-
-			freqNorms := io.FreqNorms[pid]
-			freqNormOffset := 0
-
-			locs := io.Locs[pid]
-			locOffset := 0
-
-			var cardinality uint64
-			if postingsBS != nil {
-				cardinality = postingsBS.GetCardinality()
+			docNums := io.Postings[pid]
+			if len(docNums) == 0 {
+				continue
 			}
-			chunkSize, err := getChunkSize(io.chunkMode, cardinality, uint64(len(io.results)))
+			freqs := io.Freqs[pid]
+			locs := io.Locs[pid]
+
+			// A term that records locations carries a location group for every
+			// one of its postings, empty ones included, so a reader walking the
+			// location stream stays aligned without a per-document flag.
+			termHasLocs := io.numLocsPerPostingsList[pid] > 0
+
+			locChunkSize, err := getChunkSize(io.chunkMode, uint64(len(docNums)), numDocs)
 			if err != nil {
 				return err
 			}
-			tfEncoder.SetChunkSize(chunkSize, uint64(len(io.results)-1))
-			locEncoder.SetChunkSize(chunkSize, uint64(len(io.results)-1))
+			locEncoder.SetChunkSize(locChunkSize, numDocs-1)
 
-			postingsItr := postingsBS.Iterator()
-			for postingsItr.HasNext() {
-				docNum := uint64(postingsItr.Next())
+			ser.StartTerm(hasFreqs, termHasLocs, normIDs)
 
-				freqNorm := freqNorms[freqNormOffset]
+			for i, docNum := range docNums {
+				freq := freqs[i]
 
-				// check if freq/norm is enabled
-				if freqNorm.freq > 0 {
-					err = tfEncoder.Add(docNum,
-						encodeFreqHasLocs(freqNorm.freq, freqNorm.numLocs > 0),
-						uint64(math.Float32bits(freqNorm.norm)))
-				} else {
-					// if disabled, then skip the norm part
-					err = tfEncoder.Add(docNum,
-						encodeFreqHasLocs(freqNorm.freq, freqNorm.numLocs > 0))
-				}
-				if err != nil {
+				if err = ser.AddDoc(docNum, freq); err != nil {
 					return err
 				}
 
-				if freqNorm.numLocs > 0 {
+				if termHasLocs {
+					docLocs := locs[i]
+
 					numBytesLocs := 0
-					for _, loc := range locs[locOffset : locOffset+freqNorm.numLocs] {
+					for _, loc := range docLocs {
 						numBytesLocs += totalUvarintBytes(
 							uint64(loc.fieldID), loc.pos, loc.start, loc.end,
 							uint64(len(loc.arrayposs)), loc.arrayposs)
 					}
 
-					err = locEncoder.Add(docNum, uint64(numBytesLocs))
-					if err != nil {
+					if err = locEncoder.Add(uint64(docNum), uint64(numBytesLocs)); err != nil {
 						return err
 					}
-					for _, loc := range locs[locOffset : locOffset+freqNorm.numLocs] {
-						err = locEncoder.Add(docNum,
+					for _, loc := range docLocs {
+						err = locEncoder.Add(uint64(docNum),
 							uint64(loc.fieldID), loc.pos, loc.start, loc.end,
 							uint64(len(loc.arrayposs)))
 						if err != nil {
 							return err
 						}
-
-						err = locEncoder.Add(docNum, loc.arrayposs...)
-						if err != nil {
+						if err = locEncoder.Add(uint64(docNum), loc.arrayposs...); err != nil {
 							return err
 						}
 					}
-					locOffset += freqNorm.numLocs
 				}
-
-				freqNormOffset++
 
 				docTermMap[docNum] = append(
 					append(docTermMap[docNum], term...),
 					index.DocValueTermSeparator)
 			}
 
-			tfEncoder.Close()
-			locEncoder.Close()
-			io.incrementBytesWritten(locEncoder.getBytesWritten())
-			io.incrementBytesWritten(tfEncoder.getBytesWritten())
-
-			postingsOffset, err :=
-				writePostings(postingsBS, tfEncoder, locEncoder, nil, w, buf)
-			if err != nil {
+			if err = finishMergedTerm(w, ser, locEncoder, io.builder,
+				[]byte(term), locChunkSize); err != nil {
 				return err
 			}
-
-			if postingsOffset > uint64(0) {
-				err = io.builder.Insert([]byte(term), postingsOffset)
-				if err != nil {
-					return err
-				}
-			}
-
-			tfEncoder.Reset()
-			locEncoder.Reset()
+			io.incrementBytesWritten(ser.BytesWritten())
+			io.incrementBytesWritten(locEncoder.getBytesWritten())
 		}
 
 		err = io.builder.Close()
@@ -634,7 +717,7 @@ func (io *invertedIndexOpaque) writeDicts(w *FileWriter) error {
 		if io.FieldsOptions[io.FieldsInv[fieldID]].SkipDVChunking() {
 			chunkSize = 1
 		}
-		fdvEncoder := newChunkedContentCoder(chunkSize, uint64(len(io.results)-1), w, false, io.FieldsOptions[io.FieldsInv[fieldID]].SkipDVCompression())
+		fdvEncoder := newChunkedContentCoder(chunkSize, numDocs-1, w, false, io.FieldsOptions[io.FieldsInv[fieldID]].SkipDVCompression())
 		if io.IncludeDocValues[fieldID] {
 			for docNum, docTerms := range docTermMap {
 				if fieldTermMap, ok := io.extraDocValues[docNum]; ok {
@@ -674,20 +757,8 @@ func (io *invertedIndexOpaque) writeDicts(w *FileWriter) error {
 
 		fieldStart := w.Count()
 
-		n = binary.PutUvarint(buf, fdvOffsetsStart[fieldID])
-		_, err = w.Write(buf[:n])
-		if err != nil {
-			return err
-		}
-
-		n = binary.PutUvarint(buf, fdvOffsetsEnd[fieldID])
-		_, err = w.Write(buf[:n])
-		if err != nil {
-			return err
-		}
-
-		n = binary.PutUvarint(buf, dictOffsets[fieldID])
-		_, err = w.Write(buf[:n])
+		err = writeFieldFooter(w, buf, fdvOffsetsStart[fieldID], fdvOffsetsEnd[fieldID],
+			dictOffsets[fieldID], normsOffsets[fieldID], normsLens[fieldID])
 		if err != nil {
 			return err
 		}
@@ -708,44 +779,44 @@ func (io *invertedIndexOpaque) process(field index.Field, fieldID uint16, docNum
 	// finished invoking the process() for every field on that doc.
 	if fieldID == math.MaxUint16 {
 		for fid, tfs := range io.reusableFieldTFs {
+			if tfs == nil {
+				continue
+			}
 			dict := io.Dicts[fid]
-			norm := math.Float32frombits(uint32(io.reusableFieldLens[fid]))
+
+			// The field's length is quantized once per document into the
+			// field's norm column, rather than being copied alongside every
+			// posting of every term the document contains.
+			if len(io.NormIDs[fid]) > 0 {
+				io.NormIDs[fid][docNum] = fieldNormToID(uint32(io.reusableFieldLens[fid]))
+			}
 
 			for term, tf := range tfs {
 				pid := dict[term] - 1
-				bs := io.Postings[pid]
-				bs.Add(uint32(docNum))
+				io.Postings[pid] = append(io.Postings[pid], docNum)
+				io.Freqs[pid] = append(io.Freqs[pid], uint32(tf.Frequency()))
 
-				io.FreqNorms[pid] = append(io.FreqNorms[pid],
-					interimFreqNorm{
-						freq:    uint64(tf.Frequency()),
-						norm:    norm,
-						numLocs: len(tf.Locations),
-					})
-
-				if len(tf.Locations) > 0 {
-					locs := io.Locs[pid]
-
-					for _, loc := range tf.Locations {
-						var locf = uint16(fid)
-						if loc.Field != "" {
-							locf = uint16(io.getOrDefineField(loc.Field))
-						}
-						var arrayposs []uint64
-						if len(loc.ArrayPositions) > 0 {
-							arrayposs = loc.ArrayPositions
-						}
-						locs = append(locs, interimLoc{
-							fieldID:   locf,
-							pos:       uint64(loc.Position),
-							start:     uint64(loc.Start),
-							end:       uint64(loc.End),
-							arrayposs: arrayposs,
-						})
+				n := len(tf.Locations)
+				docLocs := io.locsRemaining[pid][:n:n]
+				for i, loc := range tf.Locations {
+					var locf = uint16(fid)
+					if loc.Field != "" {
+						locf = uint16(io.getOrDefineField(loc.Field))
 					}
-
-					io.Locs[pid] = locs
+					var arrayposs []uint64
+					if len(loc.ArrayPositions) > 0 {
+						arrayposs = loc.ArrayPositions
+					}
+					docLocs[i] = interimLoc{
+						fieldID:   locf,
+						pos:       uint64(loc.Position),
+						start:     uint64(loc.Start),
+						end:       uint64(loc.End),
+						arrayposs: arrayposs,
+					}
 				}
+				io.locsRemaining[pid] = io.locsRemaining[pid][n:]
+				io.Locs[pid] = append(io.Locs[pid], docLocs)
 			}
 		}
 		for i := 0; i < len(io.FieldsInv); i++ { // clear these for reuse
@@ -874,41 +945,64 @@ func (i *invertedIndexOpaque) realloc() {
 
 	numPostingsLists := pidNext
 
+	// Doc numbers accumulate into plain slices carved out of one backing array.
+	// They arrive already sorted -- process() is called per document in order --
+	// so there is nothing a bitmap would add here beyond its own overhead.
 	if cap(i.Postings) >= numPostingsLists {
 		i.Postings = i.Postings[:numPostingsLists]
 	} else {
-		postings := make([]*roaring.Bitmap, numPostingsLists)
-		copy(postings, i.Postings[:cap(i.Postings)])
-		for i := 0; i < numPostingsLists; i++ {
-			if postings[i] == nil {
-				postings[i] = roaring.New()
-			}
-		}
-		i.Postings = postings
+		i.Postings = make([][]uint32, numPostingsLists)
 	}
 
-	if cap(i.FreqNorms) >= numPostingsLists {
-		i.FreqNorms = i.FreqNorms[:numPostingsLists]
+	if cap(i.postingsBacking) >= totTFs {
+		i.postingsBacking = i.postingsBacking[:totTFs]
 	} else {
-		i.FreqNorms = make([][]interimFreqNorm, numPostingsLists)
+		i.postingsBacking = make([]uint32, totTFs)
 	}
 
-	if cap(i.freqNormsBacking) >= totTFs {
-		i.freqNormsBacking = i.freqNormsBacking[:totTFs]
-	} else {
-		i.freqNormsBacking = make([]interimFreqNorm, totTFs)
-	}
-
-	freqNormsBacking := i.freqNormsBacking
+	postingsBacking := i.postingsBacking
 	for pid, numTerms := range i.numTermsPerPostingsList {
-		i.FreqNorms[pid] = freqNormsBacking[0:0]
-		freqNormsBacking = freqNormsBacking[numTerms:]
+		i.Postings[pid] = postingsBacking[0:0]
+		postingsBacking = postingsBacking[numTerms:]
 	}
 
+	if cap(i.Freqs) >= numPostingsLists {
+		i.Freqs = i.Freqs[:numPostingsLists]
+	} else {
+		i.Freqs = make([][]uint32, numPostingsLists)
+	}
+
+	if cap(i.freqsBacking) >= totTFs {
+		i.freqsBacking = i.freqsBacking[:totTFs]
+	} else {
+		i.freqsBacking = make([]uint32, totTFs)
+	}
+
+	freqsBacking := i.freqsBacking
+	for pid, numTerms := range i.numTermsPerPostingsList {
+		i.Freqs[pid] = freqsBacking[0:0]
+		freqsBacking = freqsBacking[numTerms:]
+	}
+
+	// Locs mirrors Freqs one level deeper: one []interimLoc per doc-occurrence,
+	// carved from locsPerDocBacking, each in turn carved from locsBacking as
+	// process() fills them in via locsRemaining.
 	if cap(i.Locs) >= numPostingsLists {
 		i.Locs = i.Locs[:numPostingsLists]
 	} else {
-		i.Locs = make([][]interimLoc, numPostingsLists)
+		i.Locs = make([][][]interimLoc, numPostingsLists)
+	}
+
+	if cap(i.locsPerDocBacking) >= totTFs {
+		i.locsPerDocBacking = i.locsPerDocBacking[:totTFs]
+	} else {
+		i.locsPerDocBacking = make([][]interimLoc, totTFs)
+	}
+
+	locsPerDocBacking := i.locsPerDocBacking
+	for pid, numTerms := range i.numTermsPerPostingsList {
+		i.Locs[pid] = locsPerDocBacking[0:0]
+		locsPerDocBacking = locsPerDocBacking[numTerms:]
 	}
 
 	if cap(i.locsBacking) >= totLocs {
@@ -917,14 +1011,39 @@ func (i *invertedIndexOpaque) realloc() {
 		i.locsBacking = make([]interimLoc, totLocs)
 	}
 
+	if cap(i.locsRemaining) >= numPostingsLists {
+		i.locsRemaining = i.locsRemaining[:numPostingsLists]
+	} else {
+		i.locsRemaining = make([][]interimLoc, numPostingsLists)
+	}
+
 	locsBacking := i.locsBacking
 	for pid, numLocs := range i.numLocsPerPostingsList {
-		i.Locs[pid] = locsBacking[0:0]
+		i.locsRemaining[pid] = locsBacking[:numLocs]
 		locsBacking = locsBacking[numLocs:]
 	}
 
 	for _, dict := range i.DictKeys {
 		sort.Strings(dict)
+	}
+
+	// One norm column per field, indexed by doc number. Documents that do not
+	// contain the field keep the zero the allocation leaves behind, which is
+	// exactly what the reader expects.
+	numFields := len(i.FieldsInv)
+	numDocsInBatch := len(i.results)
+	if cap(i.NormIDs) >= numFields {
+		i.NormIDs = i.NormIDs[:numFields]
+	} else {
+		i.NormIDs = make([][]uint8, numFields)
+	}
+	for fid := 0; fid < numFields; fid++ {
+		if cap(i.NormIDs[fid]) >= numDocsInBatch {
+			i.NormIDs[fid] = i.NormIDs[fid][:numDocsInBatch]
+			clear(i.NormIDs[fid])
+		} else {
+			i.NormIDs[fid] = make([]uint8, numDocsInBatch)
+		}
 	}
 
 	if cap(i.reusableFieldTFs) >= len(i.FieldsInv) {
@@ -1013,16 +1132,28 @@ type invertedIndexOpaque struct {
 	//  field id -> bool
 	IncludeDocValues []bool
 
-	// postings id -> bitmap of docNums
-	Postings []*roaring.Bitmap
+	// postings id -> ascending docNums
+	Postings        [][]uint32
+	postingsBacking []uint32
 
-	// postings id -> freq/norm's, one for each docNum in postings
-	FreqNorms        [][]interimFreqNorm
-	freqNormsBacking []interimFreqNorm
+	// field id -> docNum -> quantized field length
+	NormIDs [][]uint8
 
-	// postings id -> locs, one for each freq
-	Locs        [][]interimLoc
-	locsBacking []interimLoc
+	// postings id -> freqs, one for each docNum in postings
+	Freqs        [][]uint32
+	freqsBacking []uint32
+
+	// postings id -> doc index (same index as Postings/Freqs) -> that doc's
+	// locs. A doc with no locations for the term still gets an (empty) entry,
+	// so len(Locs[pid][i]) is the location count for Postings[pid][i] -- there
+	// is no separate count to keep in sync.
+	Locs              [][][]interimLoc
+	locsPerDocBacking [][]interimLoc
+	locsBacking       []interimLoc
+
+	// locsRemaining is the per-pid unconsumed tail of locsBacking, used only
+	// while process() is carving each doc's slice out of it.
+	locsRemaining [][]interimLoc
 
 	numTermsPerPostingsList []int // key is postings list id
 	numLocsPerPostingsList  []int // key is postings list id
@@ -1067,20 +1198,36 @@ func (io *invertedIndexOpaque) Reset() (err error) {
 		io.IncludeDocValues[i] = false
 	}
 	io.IncludeDocValues = io.IncludeDocValues[:0]
-	for _, idn := range io.Postings {
-		idn.Clear()
+	for i := range io.Postings {
+		io.Postings[i] = nil
 	}
 	io.Postings = io.Postings[:0]
-	io.FreqNorms = io.FreqNorms[:0]
-	for i := range io.freqNormsBacking {
-		io.freqNormsBacking[i] = interimFreqNorm{}
+	io.postingsBacking = io.postingsBacking[:0]
+	for i := range io.NormIDs {
+		io.NormIDs[i] = io.NormIDs[i][:0]
 	}
-	io.freqNormsBacking = io.freqNormsBacking[:0]
+	io.NormIDs = io.NormIDs[:0]
+	for i := range io.Freqs {
+		io.Freqs[i] = nil
+	}
+	io.Freqs = io.Freqs[:0]
+	io.freqsBacking = io.freqsBacking[:0]
+	for i := range io.Locs {
+		io.Locs[i] = nil
+	}
 	io.Locs = io.Locs[:0]
+	for i := range io.locsPerDocBacking {
+		io.locsPerDocBacking[i] = nil
+	}
+	io.locsPerDocBacking = io.locsPerDocBacking[:0]
 	for i := range io.locsBacking {
 		io.locsBacking[i] = interimLoc{}
 	}
 	io.locsBacking = io.locsBacking[:0]
+	for i := range io.locsRemaining {
+		io.locsRemaining[i] = nil
+	}
+	io.locsRemaining = io.locsRemaining[:0]
 	io.numTermsPerPostingsList = io.numTermsPerPostingsList[:0]
 	io.numLocsPerPostingsList = io.numLocsPerPostingsList[:0]
 	io.builderBuf.Reset()

--- a/segment.go
+++ b/segment.go
@@ -465,16 +465,25 @@ func (sb *SegmentBase) dictionary(field string) (rv *Dictionary, err error) {
 		}
 		// skip the doc value offsets to get to the dictionary portion
 		for i := 0; i < 2; i++ {
-			_, n := binary.Uvarint(sb.mem[pos : pos+binary.MaxVarintLen64])
+			_, n := binary.Uvarint(memAt(sb.mem, pos, binary.MaxVarintLen64))
 			pos += uint64(n)
 		}
-		dictLoc, n := binary.Uvarint(sb.mem[pos : pos+binary.MaxVarintLen64])
+		var loc dictLocation
+		loc.numDocs = sb.numDocs
+		var n int
+		loc.dictOffset, n = binary.Uvarint(memAt(sb.mem, pos, binary.MaxVarintLen64))
 		pos += uint64(n)
-		fst, bytesRead, err := sb.invIndexCache.loadOrCreate(rv.fieldID, sb.mem[dictLoc:], sb.fileReader)
+		loc.normsOffset, n = binary.Uvarint(memAt(sb.mem, pos, binary.MaxVarintLen64))
+		pos += uint64(n)
+		loc.normsLen, _ = binary.Uvarint(memAt(sb.mem, pos, binary.MaxVarintLen64))
+
+		fst, norms, bytesRead, err := sb.invIndexCache.loadOrCreate(
+			rv.fieldID, sb.mem, loc, sb.fileReader)
 		if err != nil {
 			return nil, fmt.Errorf("dictionary for field %s err: %v", field, err)
 		}
 		rv.fst = fst
+		rv.norms = norms
 		rv.fstReader, err = rv.fst.Reader()
 		if err != nil {
 			return nil, fmt.Errorf("dictionary for field %s, vellum reader err: %v", field, err)

--- a/zap.md
+++ b/zap.md
@@ -124,35 +124,62 @@ Sections Index is a set of NF uint64 addresses (0 through F# - 1) each of which 
 
 Each field has its own types of indexes in separate sections as indicated above. This can be a vector index or inverted text index.
 
-In case of inverted text index, the dictionary is encoded in [Vellum](https://github.com/couchbase/vellum) format. Dictionary consists of pairs `(term, offset)`, where `offset` indicates the position of postings (list of documents) for this particular term.
+In case of inverted text index, the dictionary is encoded in [Vellum](https://github.com/couchbase/vellum) format. Dictionary consists of pairs `(term, offset)`, where `offset` indicates the position of the term header (described below) for this particular term.
+
+Doc numbers and term frequencies are bitpacked 128 at a time. Doc numbers within a
+postings list are strictly increasing, so `delta - 1` is stored, and a term present in
+every document therefore packs at zero bits per document; term frequencies are at
+least 1, so `tf - 1` is stored and a block of all-ones frequencies also costs nothing.
+A flat skip list carries one fixed-size entry per full block, which lets a reader hop
+to the block containing a target document without decoding any payload. Whatever is
+left over at the end of a list -- fewer than 128 documents -- is written as plain
+uvarints.
+
+Field norms are **not** stored in the postings. They live in a dense column, one
+quantized byte per document, shared by every term of the field: a term appearing in a
+million documents would otherwise carry a million copies of the same handful of field
+lengths. The quantization is the scheme Lucene and tantivy use -- exact for lengths
+0..40, then a 3-bit mantissa with a 5-bit exponent -- so reading a norm is one byte
+load plus one lookup in a 256-entry table.
 
         +================================================================+- Inverted Text
         |                                                                |  Index Section
         |                                                                |
-        |    Freq/Norm (chunked)                                         |
-        |    [~~~~~~+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~]                      |
-        | +->[ Freq | Norm (float32 under varint) ]                      |
-        | |  [~~~~~~+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~]                      |
+        |    Field Norms                                                 |
+        |    [~~~~~~+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~]              |
+        | +->[ Kind | absent | constant u8 | u8[numDocs] ]               |
+        | |  [~~~~~~+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~]              |
         | |                                                              |
-        | +------------------------------------------------------------+ |
-        |    Location Details (chunked)                                | |
-        |    [~~~~~~+~~~~~+~~~~~~~+~~~~~+~~~~~~+~~~~~~~~+~~~~~]        | |
-        | +->[ Size | Pos | Start | End | Arr# | ArrPos | ... ]        | |
-        | |  [~~~~~~+~~~~~+~~~~~~~+~~~~~+~~~~~~+~~~~~~~~+~~~~~]        | |
-        | |                                                            | |
-        | +----------------------+                                     | |
-        |          Postings List |                                     | |
-        |         +~~~~~~~~+~~~~~+~~+~~~~~~~~+----------+...+-+        | |
-        |      +->+    F/N |     LD | Length | ROARING BITMAP |        | |
-        |      |  +~~~~~+~~|~~~~~~~~|~~~~~~~~+----------+...+-+        | |
-        |      |        +----------------------------------------------+ |
-        |      +-------------------------------------------------+       |
-        |                                                        |       |
-        |                     Dictionary                         |       |
-        | +~~~~~~~~~~+~~~~~~~+~~~~~~~~+--------------------------+-...-+ |
-    +-----> DV Start | DV End| Length | VELLUM DATA : (TERM -> OFFSET) | |
-    |   | +~~~~~~~~~~+~~~~~~~+~~~~~~~~+----------------------------...-+ |
-    |   |                                                                |
+        | |  Per term, in term order:                                    |
+        | |                                                              |
+        | |  Payload                                                     |
+        | |  [~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~+~~~~~~~~~~~~~~~~~~~~~~]  |
+        | |  [ 128 docNum deltas @docNumBits   | 128 tfs @tfNumBits  ]*  |
+        | |  [~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~+~~~~~~~~~~~~~~~~~~~~~~]  |
+        | |  [ uvarint doc deltas | uvarint tfs ]  (tail, < 128 docs)    |
+        | |                                                              |
+        | |  Location Details (chunked)                                  |
+        | |  [~~~~~~+~~~~~+~~~~~~~+~~~~~+~~~~~~+~~~~~~~~+~~~~~]          |
+        | |  [ Size | Pos | Start | End | Arr# | ArrPos | ... ]          |
+        | |  [~~~~~~+~~~~~+~~~~~~~+~~~~~+~~~~~~+~~~~~~~~+~~~~~]          |
+        | |                                                              |
+        | |  Skip List (one entry per full block, then a tail offset)    |
+        | |  [~~~~~~~~~+~~~~~~~~~~~~+~~~~~~~~~+~~~~~~~~+~~~~~~~+~~~~~~]  |
+        | |  [ LastDoc | BlockOffset | DocBits | TfBits | MinNorm| MaxTf] |
+        | |  [~~~~~~~~~+~~~~~~~~~~~~~+~~~~~~~~+~~~~~~~~+~~~~~~~~+~~~~~~] |
+        | |                                                              |
+        | |  Term Header                          <- the FST value       |
+        | |  +~~~~~~~~~+~~~~~~~+~~~~~~~~~~~+~~~~~~~~~+~~~~~~~~~+~~~~~~+  |
+        | +->| DocFreq | Flags | PayloadLen | LocsLen | SkipLen | LocCS| |
+        | |  +~~~~~~~~~+~~~~~~~+~~~~~~~~~~~+~~~~~~~~~+~~~~~~~~~+~~~~~~+  |
+        | |                                                              |
+        | +----------------------------------------------+               |
+        |                                                |               |
+        |                     Dictionary                 |               |
+        | +~~~~~~~~~~+~~~~~~~+~~~~~~~~+-------------------+-...-+~~~~~~~+ |
+    +-----> DV Start | DV End| Length | VELLUM (TERM->OFFSET) | Norms  | |
+    |   | +~~~~~~~~~~+~~~~~~~+~~~~~~~~+-------------------+-...-+~~~~~~~+ |
+    |   |                                            Offset & Length      |
     |   |                                                                |
     |   |================================================================+- Vector Index Section
     |   |                                                                |
@@ -166,6 +193,24 @@ In case of inverted text index, the dictionary is encoded in [Vellum](https://gi
         |     +-------+-----+------------+~~~~~~~~+~~~~~~~~+--+...+--+   |
         +================================================================+
 
+
+The regions of a term are written in the order the writer can produce them and the
+header comes last, so nothing needs buffering or back-patching. A reader walks
+backwards from the header: skip data starts at `header - skipLen`, locations at
+`skip - locsLen`, payload at `locs - payloadLen`.
+
+Each block is passed through the writer's `process()` hook independently, which is why
+the skip entry records the block's byte offset rather than deriving it from the bit
+widths: an encrypting or compressing callback changes a block's length, and a reader
+must still be able to reach one block without decoding the whole term.
+
+`MinNorm` and `MaxTf` bound the BM25 contribution of every document in a block --
+score rises with frequency and falls with field length. Nothing consumes them yet;
+they are written so that enabling block-max WAND later is not another format change.
+
+A term with a single document, a frequency of one and no locations skips all of this:
+its doc number is packed directly into the FST value ("1-hit" encoding). That is most
+of the dictionary in a real corpus.
 
          ITI - Inverted Text Index
 


### PR DESCRIPTION
- Replaces the varint style postings list with bitpacked blocks that are encoded and decoded using SIMD instructions from https://github.com/blevesearch/freeway. Terms with fewer than 128 trailing docs fall back to a plain uvarint tail.
- Contains additional metadata to enable block-max WAND/MAXSCORE in the postings list
- Norms is moved out of the postings list and is represented in it's own separate column that is per-field. Additionally, each norm is represented in a quantized form in 8 bits rather than using 32 bits, which will reduce the number
- The locs stream still uses the old varint coded methods.
- The `PostingsList.Count()` now returns the full count and does not take into account the exclude bitmap. Count is used for calculating the idf, so will require an extra postings list iteration just for calculating the exact count. So we can expect some score drift and inaccuracy, but other search engines pay this price as well.